### PR TITLE
Fix mobile training grid lesson title wrapping

### DIFF
--- a/static/css/mobile-fixes.css
+++ b/static/css/mobile-fixes.css
@@ -223,6 +223,36 @@
     }
 }
 
+/* Mobile responsive lesson column for training progress grid */
+@media (max-width: 768px) {
+    /* Lesson title column (sticky-col) - limit width and enable word wrapping */
+    .training-grid th.sticky-col, 
+    .training-grid td.sticky-col {
+        max-width: 25vw !important;
+        width: 25vw !important;
+        word-wrap: break-word !important;
+        word-break: break-word !important;
+        white-space: normal !important;
+        overflow-wrap: break-word !important;
+        hyphens: auto !important;
+        padding: 0.25rem 0.5rem !important;
+        font-size: 0.85rem !important;
+        line-height: 1.2 !important;
+    }
+    
+    /* Ensure links in lesson titles also wrap properly */
+    .training-grid th.sticky-col a, 
+    .training-grid td.sticky-col a {
+        word-wrap: break-word !important;
+        word-break: break-word !important;
+        white-space: normal !important;
+        overflow-wrap: break-word !important;
+        hyphens: auto !important;
+        display: inline-block !important;
+        line-height: 1.2 !important;
+    }
+}
+
 /* Issue #219: Syllabus view layout improvements */
 @media (max-width: 768px) {
 


### PR DESCRIPTION
- Add responsive CSS for lesson titles in training progress grid
- Limit lesson column width to 25% of viewport on mobile (≤768px)
- Enable word wrapping, break-word, and hyphenation for long lesson titles
- Maintain font size at 0.85rem for better readability
- Ensure links within lesson titles also wrap properly
- Move responsive styles to mobile-fixes.css for consistency
- Remove duplicate inline styles from template

Resolves issue where lesson titles were being squished on mobile devices.