### PR TITLE
Fix navbar Resources link to point to CMS index

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -87,7 +87,7 @@
               <li><a class="dropdown-item" href="{% url 'members:badge_board' %}">Badge Board</a></li>
               <li><a class="dropdown-item" href="{% url 'instructors:member_logbook' %}">🗒️ My Logbook</a></li>
               <li><hr class="dropdown-divider"></li>
-              <li><a class="dropdown-item" href="{% url 'home' %}">Resources</a></li>
+              <li><a class="dropdown-item" href="{% url 'cms:home' %}">Resources</a></li>
 
             </ul>
           </li>


### PR DESCRIPTION
- Change Resources link from {% url 'home' %} to {% url 'cms:home' %}
- Now correctly navigates to /cms/ instead of homepage
- Fixes navigation issue in Members dropdown menu