### PR TITLE
Fix towplane closeout form validation error

### DIFF
--- a/logsheet/templates/logsheet/edit_closeout_form.html
+++ b/logsheet/templates/logsheet/edit_closeout_form.html
@@ -291,13 +291,15 @@
                 {% for hidden in towform.hidden_fields %}
                   {{ hidden }}
                 {% endfor %}
+                <!-- Towplane field as hidden input - towplane name shown in header -->
+                {{ towform.towplane.as_hidden }}
                 <h5 class="mb-0"><i class="bi bi-airplane-engines me-2"></i>{{ towform.instance.towplane }}</h5>
               </div>
 
               <div class="card-body">
                 <div class="row">
                   <div class="col-md-6">
-                    <!-- Towplane field hidden - already rendered in card header -->
+                    <!-- Towplane field hidden above - already rendered in card header -->
 
                     <div class="mb-3">
                       {{ towform.start_tach.label_tag }}


### PR DESCRIPTION
## Problem
When closing out a logsheet with towplane operations, users encountered a validation error:
> **"Towplane: this field is required"**

Despite the towplane being clearly identified in the form's card header, there was no visible field to select a towplane, causing form submission to fail.

## Root Cause
The `TowplaneCloseoutForm` includes a `towplane` field in its model definition, but the template (`edit_closeout_form.html`) was not rendering this field as a hidden input. The form validation expected the towplane field value to be submitted, but it wasn't being included in the form data.

## Solution
Added the missing hidden input field to the template:

```html
<!-- Towplane field as hidden input - towplane name shown in header -->
{{ towform.towplane.as_hidden }}
```

## Changes Made
- **File:** `logsheet/templates/logsheet/edit_closeout_form.html`
- **Change:** Added `{{ towform.towplane.as_hidden }}` in the card header section
- **UI Impact:** None - towplane name still displays in card header as before
- **Functionality:** Form now properly submits towplane field value

## Testing
- ✅ All 9 closeout-related tests pass
- ✅ Form validation now works correctly
- ✅ Hidden field renders with correct towplane ID value
- ✅ No visual changes to the interface
- ✅ Towplane closeout can be successfully submitted

## Verification Steps
1. Navigate to a logsheet with towplane operations
2. Click "Edit Closeout"
3. Fill in towplane tach readings and fuel data
4. Submit the form
5. ✅ Form submits successfully (previously failed with validation error)

This fix ensures the towplane closeout process works as expected while maintaining the clean UI design where the towplane is identified in the card header rather than requiring redundant dropdown selection.