### PR TITLE
Fix equipment_logbook.css: use Django static tag for GCS URL

### DIFF
--- a/logsheet/templates/logsheet/equipment_logbook.html
+++ b/logsheet/templates/logsheet/equipment_logbook.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 {% load humanize %}
+{% load static %}
+
+{% block head_extra %}
+<link rel="stylesheet" href="{% static 'css/equipment_logbook.css' %}">
+{% endblock %}
 
 {% block content %}
 
@@ -25,7 +30,6 @@
     </div>
     {% endif %}
 
-    <link rel="stylesheet" href="/static/css/equipment_logbook.css">
     <div class="table-responsive">
         <table class="table table-sm align-middle sort" id="equipmentLogbookTable">
             <thead class="table-light">


### PR DESCRIPTION
The CSS link was hardcoded as '/static/css/equipment_logbook.css' which pointed to the Django app server instead of Google Cloud Storage.

Changed to use {% static %} tag which generates the correct GCS URL: https://storage.googleapis.com/skyline-soaring-storage/ssc/static/css/...

Also moved the CSS link to the head_extra block where it belongs.