### PR TITLE
Fix conditional fields not showing after form error

### DIFF
--- a/members/forms_applications.py
+++ b/members/forms_applications.py
@@ -406,40 +406,44 @@ class MembershipApplicationForm(forms.ModelForm):
 
         # Validate agreement checkboxes
         if not cleaned_data.get("agrees_to_terms"):
-            raise ValidationError("You must agree to the club terms and conditions.")
+            self.add_error(
+                "agrees_to_terms", "You must agree to the club terms and conditions."
+            )
         if not cleaned_data.get("agrees_to_safety_rules"):
-            raise ValidationError("You must agree to follow club safety rules.")
+            self.add_error(
+                "agrees_to_safety_rules", "You must agree to follow club safety rules."
+            )
         if not cleaned_data.get("agrees_to_financial_obligations"):
-            raise ValidationError("You must agree to meet financial obligations.")
+            self.add_error(
+                "agrees_to_financial_obligations",
+                "You must agree to meet financial obligations.",
+            )
 
         # If insurance rejection is checked, details are required
         if cleaned_data.get("insurance_rejection_history") and not cleaned_data.get(
             "insurance_rejection_details"
         ):
-            raise ValidationError(
-                {
-                    "insurance_rejection_details": "Please explain the insurance rejection circumstances."
-                }
+            self.add_error(
+                "insurance_rejection_details",
+                "Please explain the insurance rejection circumstances.",
             )
 
         # If club rejection is checked, details are required
         if cleaned_data.get("club_rejection_history") and not cleaned_data.get(
             "club_rejection_details"
         ):
-            raise ValidationError(
-                {
-                    "club_rejection_details": "Please explain the club rejection circumstances."
-                }
+            self.add_error(
+                "club_rejection_details",
+                "Please explain the club rejection circumstances.",
             )
 
         # If aviation incidents is checked, details are required
         if cleaned_data.get("aviation_incidents") and not cleaned_data.get(
             "aviation_incident_details"
         ):
-            raise ValidationError(
-                {
-                    "aviation_incident_details": "Please provide details about the aviation incidents."
-                }
+            self.add_error(
+                "aviation_incident_details",
+                "Please provide details about the aviation incidents.",
             )
 
         # Validate address fields based on country

--- a/members/templates/members/membership_application.html
+++ b/members/templates/members/membership_application.html
@@ -554,7 +554,7 @@
 </div>
 {% endblock %}
 
-{% block extra_js %}
+{% block extra_scripts %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Handle insurance rejection history


### PR DESCRIPTION
## Summary

Fixes #303

Two issues were causing problems with the membership application form when validation errors occurred:

## Issues Fixed

### 1. JavaScript Not Running (Conditional Fields Not Showing)

The template used `{% block extra_js %}` but `base.html` defines `{% block extra_scripts %}`. This meant all JavaScript that toggles conditional field visibility was **silently ignored**.

**Root cause:** Undefined template blocks are silently discarded by Django's template engine.

**Fix:** Changed block name from `extra_js` to `extra_scripts` to match the base template.

### 2. Validation Errors Appearing One at a Time

The form's `clean()` method used `raise ValidationError()` which stops validation immediately after the first error. Users had to fix and resubmit multiple times.

**Fix:** Changed all `raise ValidationError()` calls to `self.add_error()` so all validation errors appear together on the first submission.

## Changes

- **`members/templates/members/membership_application.html`**: Fixed template block name
- **`members/forms_applications.py`**: Replaced `raise ValidationError()` with `self.add_error()` for all custom validations
- **`members/tests/test_membership_applications.py`**: Added regression tests:
  - `test_multiple_validation_errors_shown_together` - verifies agreement checkbox errors appear together
  - `test_conditional_field_errors_shown_together` - verifies conditional field errors appear together

## Testing

All 14 membership application tests pass.