### PR TITLE
fix: Sort duty calendar agenda view by date

### DIFF
--- a/duty_roster/models.py
+++ b/duty_roster/models.py
@@ -164,6 +164,9 @@ class DutyAssignment(models.Model):
     is_confirmed = models.BooleanField(default=True)
     notes = models.TextField(blank=True)
 
+    class Meta:
+        ordering = ["date"]
+
     def __str__(self):
         return f"{self.date} @ {self.location.identifier if self.location else 'Unknown Field'}"
 

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -268,7 +268,7 @@ def duty_calendar_view(request, year=None, month=None):
     last_visible_day = weeks[-1][-1]
     assignments = DutyAssignment.objects.filter(
         date__range=(first_visible_day, last_visible_day)
-    )
+    ).order_by("date")
 
     assignments_by_date = {a.date: a for a in assignments}
 


### PR DESCRIPTION
## Summary
Fixes the duty calendar agenda view displaying duty assignments in an unpredictable order.

## Problem
The agenda view was showing dates like:
- November 29th
- November 22nd
- November 23rd  
- November 30th

This happened because the `DutyAssignment` model lacked a default ordering and the queryset in `duty_calendar_view` didn't explicitly order by date. Since Python dicts maintain insertion order, the unordered queryset results appeared in database insertion order rather than chronological order.

## Solution
1. Added `.order_by("date")` to the assignments queryset in `duty_calendar_view()`
2. Added `Meta.ordering = ["date"]` to the `DutyAssignment` model for consistent ordering throughout the application

## Testing
- All existing duty_roster tests pass (19/19)
- Manual verification shows agenda items now appear in chronological order

Fixes #282