### PR TITLE
Security: Upgrade Django 5.2.8 → 5.2.9 (CVE-2025-13372, CVE-2025-64460)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ cyclonedx-python-lib==9.1.0
 defusedxml==0.7.1
 diff-match-patch==20241021
 distlib==0.4.0
-Django==5.2.8
+Django==5.2.9
 django-crispy-forms==2.4
 django-extensions==4.1
 django-htmx==1.23.2


### PR DESCRIPTION
## Security Update

Upgrades Django from 5.2.8 to 5.2.9 to fix two moderate security vulnerabilities discovered by Dependabot.

### Vulnerabilities Fixed

1. **CVE-2025-13372** (Moderate - 4.3/10): SQL injection in `FilteredRelation` column aliases
   - Affects: `QuerySet.annotate()` and `QuerySet.alias()` on PostgreSQL when using dictionary expansion
   - GHSA: https://github.com/advisories/GHSA-rqw2-ghq9-44m7

2. **CVE-2025-64460** (Moderate - 6.3/10): DoS via XML serializer text extraction
   - Affects: `django.core.serializers.xml_serializer.getInnerText()`
   - Can cause CPU/memory exhaustion with specially crafted XML input
   - GHSA: https://github.com/advisories/GHSA-vrcr-9hj9-jcg6

### Reference
https://www.djangoproject.com/weblog/2025/dec/02/security-releases/

### Testing
- ✅ `pip-audit` confirms no known vulnerabilities
- ✅ 696 tests pass (4 unrelated pre-existing failures due to EMAIL_DEV_MODE)