### PR TITLE
Fix Issue #377: Ground Instruction Form Submit Button and Field Conflicts

### DIFF
--- a/docs/resolved-issues/issue-377-ground-instruction-submit-fix.md
+++ b/docs/resolved-issues/issue-377-ground-instruction-submit-fix.md
@@ -11,6 +11,12 @@ The "Save Complete Session" button on the ground instruction form (`/instructors
 ### Problem 2: Incorrect Qualification Validation Error (Follow-up Discovery)
 After fixing Problem 1, when submitting a ground instruction session WITHOUT any qualifications, the form showed a pink error message: "Please correct the qualification form errors." This error should only appear when explicitly submitting the qualification form via the "Add Qualification Only" button, not when submitting a ground instruction session without qualifications.
 
+### Problem 3: JavaScript Syntax Error Breaking Page Functionality
+After implementing Fix 2, the "Set first click to" dropdown feature stopped working. A JavaScript syntax error (`{e)` instead of `{`) in the `submitInstructionSession()` function caused all subsequent JavaScript on the page to fail silently, breaking multiple features including the lesson score quick-fill functionality.
+
+### Problem 4: Ground Instruction Notes Not Saving (Duplicate Field Names)
+When submitting a ground instruction session with essay notes, the notes content was not saved to the database. All other fields (date, location, duration, lesson scores) saved correctly, but the instructor's essay/notes field was empty in the database. This was discovered during testing after all previous fixes were implemented.
+
 ## Symptoms
 
 ### Problem 1 Symptoms:
@@ -330,10 +336,37 @@ function submitQualificationOnly() {
 6. **Main form submits with NO qualification data and NO `form_type` field**
 7. Server processes as ground instruction submission (correct!)
 8. Form submits successfully! ✅
-5. **If valid**: Processes qualification data
-6. Function calls `mainForm.submit()` to explicitly submit
-7. Function returns `false` to prevent any default button behavior
-8. Form submits successfully! ✅
+
+### Problem 3 - Before Fix:
+1. JavaScript syntax error `if (qualFields && qualFields.querySelector(...).value) {e) {` present in code
+2. Browser JavaScript parser encounters syntax error
+3. **All JavaScript after error stops executing**
+4. "Set first click to" functionality doesn't work
+5. Form submission still works (fixed in previous commits) but other features broken
+
+### Problem 3 - After Fix:
+1. Fixed syntax error to `if (qualFields && qualFields.querySelector(...).value) {`
+2. JavaScript parses and executes correctly
+3. All page functionality restored including "Set first click to" dropdown
+4. ✅ All features work correctly!
+
+### Problem 4 - Before Fix:
+1. Ground instruction form has `notes` field (TinyMCE HTMLField)
+2. Qualification section (inside main form) ALSO has `notes` field (regular textarea)
+3. Both fields have `name="notes"` in same form
+4. User enters essay in ground instruction notes field
+5. **Browser submits both fields with same name - last value (empty qualification notes) overwrites**
+6. Server receives only the qualification notes value (empty)
+7. Ground instruction notes lost!
+
+### Problem 4 - After Fix:
+1. Moved entire qualification section OUTSIDE main form
+2. Ground instruction `notes` field remains inside main form
+3. Qualification `notes` field now outside main form in separate div
+4. **No field name conflicts - each form has unique field names**
+5. User enters essay in ground instruction notes field
+6. Form submits only ground instruction notes
+7. ✅ Notes save correctly to database!
 
 ## Testing Verification
 

--- a/instructors/templates/instructors/log_ground_instruction.html
+++ b/instructors/templates/instructors/log_ground_instruction.html
@@ -473,13 +473,19 @@ function submitQualificationOnly() {
     const expirationDate = qualFields.querySelector('input[name="expiration_date"]');
     const notes = qualFields.querySelector('textarea[name="notes"]');
 
+    // Null checks for all required fields
+    if (!qualificationSelect || !isQualifiedCheck || !dateAwarded || !expirationDate || !notes) {
+      console.error('Missing qualification form fields');
+      return false;
+    }
+
     // Remove any existing fields
     qualForm.querySelectorAll('input:not([name="form_type"]), select, textarea').forEach(field => field.remove());
 
     // Create and append copies
     const fieldsToClone = [
       {name: 'qualification', value: qualificationSelect.value},
-      {name: 'is_qualified', value: isQualifiedCheck.checked ? 'on' : '', type: 'checkbox'},
+      {name: 'is_qualified', value: isQualifiedCheck.checked ? 'on' : ''},
       {name: 'date_awarded', value: dateAwarded.value},
       {name: 'expiration_date', value: expirationDate.value},
       {name: 'notes', value: notes.value}
@@ -517,6 +523,12 @@ function submitInstructionSession() {
     const dateAwarded = qualFields.querySelector('input[name="date_awarded"]');
     const expirationDate = qualFields.querySelector('input[name="expiration_date"]');
     const notes = qualFields.querySelector('textarea[name="notes"]');
+
+    // Null checks for all qualification fields
+    if (!qualificationSelect || !isQualifiedCheck || !dateAwarded || !expirationDate || !notes) {
+      console.error('Missing qualification form fields');
+      return false;
+    }
 
     // Remove any existing qualification fields
     mainForm.querySelectorAll('input[name^="qual_"]').forEach(field => field.remove());


### PR DESCRIPTION
## Overview
Fixes #377 - Ground instruction form had multiple critical bugs discovered during testing.

## Issues Fixed

### 1. Submit Button Not Working (Initial Discovery)
- **Problem**: "Save Complete Session" button did nothing when clicked
- **Root Cause**: Bootstrap 5 validation pattern misunderstanding - function returned `true` without calling `form.submit()`
- **Solution**: Added explicit form validation check and `form.submit()` call

### 2. Incorrect Qualification Validation Error
- **Problem**: Submitting ground instruction without qualifications showed "Please correct the qualification form errors"
- **Root Cause**: Nested forms (invalid HTML) - qualification form was inside main form, causing `form_type` field pollution
- **Solution**: Converted qualification section to div container, created separate standalone form for qualification-only submissions

### 3. JavaScript Syntax Error
- **Problem**: "Set first click to" dropdown feature stopped working
- **Root Cause**: Typo `{e)` instead of `{` broke all JavaScript execution
- **Solution**: Fixed syntax error

### 4. Ground Instruction Notes Not Saving
- **Problem**: Essay/notes content was lost on submission
- **Root Cause**: Duplicate field names - both ground instruction and qualification forms had `name="notes"`, browser sent qualification notes (empty) last, overwriting essay
- **Solution**: Moved qualification section entirely outside main form to prevent field name conflicts

## Changes Made

### Template Changes
- `instructors/templates/instructors/log_ground_instruction.html`:
  - Fixed `submitInstructionSession()` function with validation and explicit submit
  - Removed nested form structure (qualification form)
  - Moved qualification UI fields to div container (`qualificationFormFields`)
  - Relocated entire Student Qualifications section outside main form
  - Added standalone hidden form for qualification-only submissions
  - Updated JavaScript to work with new structure

### Documentation
- Created `docs/resolved-issues/issue-377-ground-instruction-submit-fix.md` with comprehensive documentation of all four issues, root causes, solutions, and prevention guidelines

## Testing Verification

All test cases pass:
- ✅ Invalid form shows Bootstrap validation UI
- ✅ Valid form without qualifications submits successfully
- ✅ Valid form with qualifications submits both ground instruction and qualification
- ✅ Ground instruction notes/essay saves correctly
- ✅ "Set first click to" functionality works
- ✅ "Add Qualification Only" button works independently

## Impact
- Ground instruction logging is now fully functional
- No data loss for instructor notes/essays
- Optional qualifications work correctly
- Form validation provides proper user feedback

## Deployment Notes
- No database migrations required
- Pure template and JavaScript changes
- Takes effect immediately upon deployment