### PR TITLE
Issue #415, #418: Duty roster agenda empty state + Outlook email button fix

### DIFF
--- a/duty_roster/templates/duty_roster/_calendar_agenda.html
+++ b/duty_roster/templates/duty_roster/_calendar_agenda.html
@@ -12,7 +12,7 @@
 {% endif %}
 
 <div class="container-fluid my-4">
-  {% if assignments_by_date %}
+  {% if assignments_by_date and has_upcoming_assignments %}
     {% for day, assignment in assignments_by_date.items %}
       {% if day.month == month and day >= today %}
         <div class="duty-agenda-item mb-4">
@@ -203,8 +203,9 @@
       <div class="mb-4">
         <i class="fas fa-calendar-times fa-4x text-muted"></i>
       </div>
-      <h4 class="text-muted">No Duty Assignments</h4>
-      <p class="text-muted">There are no duty assignments scheduled for {{ formatted_date }}.</p>
+      <h4 class="text-muted">No Upcoming Flight Operations</h4>
+      <p class="text-muted">There are no scheduled operations for the remainder of {{ formatted_date }}.</p>
+      <p class="text-muted small">Use the calendar view to see past operations, or check back later for new scheduling.</p>
       {% if user.rostermeister %}
         <a href="{% url 'duty_roster:propose_roster' %}?year={{ year }}&month={{ month }}"
            class="btn btn-primary">

--- a/duty_roster/templates/duty_roster/emails/ad_hoc_confirmed.html
+++ b/duty_roster/templates/duty_roster/emails/ad_hoc_confirmed.html
@@ -88,7 +88,7 @@
                                         </v:roundrect>
                                         <![endif]-->
                                         <!--[if !mso]>-->
-                                        <a href="{{ roster_url }}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
+                                        <a href="{{ roster_url }}" style="display: inline-block; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
                                         <!--<![endif]-->
                                     </td>
                                 </tr>

--- a/duty_roster/templates/duty_roster/emails/ad_hoc_expiration.html
+++ b/duty_roster/templates/duty_roster/emails/ad_hoc_expiration.html
@@ -99,7 +99,7 @@
                                         </v:roundrect>
                                         <![endif]-->
                                         <!--[if !mso]>-->
-                                        <a href="{{ roster_url }}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
+                                        <a href="{{ roster_url }}" style="display: inline-block; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
                                         <!--<![endif]-->
                                     </td>
                                 </tr>

--- a/duty_roster/templates/duty_roster/emails/ad_hoc_proposed.html
+++ b/duty_roster/templates/duty_roster/emails/ad_hoc_proposed.html
@@ -88,7 +88,7 @@
                                         </v:roundrect>
                                         <![endif]-->
                                         <!--[if !mso]>-->
-                                        <a href="{{ roster_url }}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">Confirm Availability</a>
+                                        <a href="{{ roster_url }}" style="display: inline-block; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">Confirm Availability</a>
                                         <!--<![endif]-->
                                     </td>
                                 </tr>

--- a/duty_roster/templates/duty_roster/emails/duty_delinquency_report.html
+++ b/duty_roster/templates/duty_roster/emails/duty_delinquency_report.html
@@ -111,7 +111,7 @@
                                     <td style="padding: 10px;">
                                         <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 auto; border-collapse: collapse;">
                                             <tr>
-                                                <td style="border-radius: 5px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); text-align: center;">
+                                                <td style="border-radius: 5px; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); text-align: center;">
                                                     <a href="{{ detail_report_url }}" style="display: inline-block; padding: 15px 30px; color: #ffffff; text-decoration: none; font-size: 16px; font-weight: bold;">
                                                         📊 View Detailed Report
                                                     </a>

--- a/duty_roster/templates/duty_roster/emails/instruction_cancellation.html
+++ b/duty_roster/templates/duty_roster/emails/instruction_cancellation.html
@@ -74,7 +74,7 @@
                                         </v:roundrect>
                                         <![endif]-->
                                         <!--[if !mso]>-->
-                                        <a href="{{ roster_url }}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
+                                        <a href="{{ roster_url }}" style="display: inline-block; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
                                         <!--<![endif]-->
                                     </td>
                                 </tr>

--- a/duty_roster/templates/duty_roster/emails/maintenance_digest.html
+++ b/duty_roster/templates/duty_roster/emails/maintenance_digest.html
@@ -70,7 +70,7 @@
                             <!-- CTA Button -->
                             <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 30px auto; border-collapse: collapse;">
                                 <tr>
-                                    <td style="border-radius: 5px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); text-align: center;">
+                                    <td style="border-radius: 5px; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); text-align: center;">
                                         <a href="{{ maintenance_dashboard_url }}" style="display: inline-block; padding: 15px 30px; color: #ffffff; text-decoration: none; font-size: 16px; font-weight: bold;">
                                             View Maintenance Dashboard
                                         </a>

--- a/duty_roster/templates/duty_roster/emails/operations_cancelled.html
+++ b/duty_roster/templates/duty_roster/emails/operations_cancelled.html
@@ -96,7 +96,7 @@
                                         </v:roundrect>
                                         <![endif]-->
                                         <!--[if !mso]>-->
-                                        <a href="{{ roster_url }}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
+                                        <a href="{{ roster_url }}" style="display: inline-block; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
                                         <!--<![endif]-->
                                     </td>
                                 </tr>

--- a/duty_roster/templates/duty_roster/emails/ops_intent_notification.html
+++ b/duty_roster/templates/duty_roster/emails/ops_intent_notification.html
@@ -77,7 +77,7 @@
                                         </v:roundrect>
                                         <![endif]-->
                                         <!--[if !mso]>-->
-                                        <a href="{{ roster_url }}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
+                                        <a href="{{ roster_url }}" style="display: inline-block; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
                                         <!--<![endif]-->
                                     </td>
                                 </tr>

--- a/duty_roster/templates/duty_roster/emails/surge_instructor_alert.html
+++ b/duty_roster/templates/duty_roster/emails/surge_instructor_alert.html
@@ -74,7 +74,7 @@
                                         </v:roundrect>
                                         <![endif]-->
                                         <!--[if !mso]>
-                                        <a href="{{ roster_url }}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">Confirm Availability</a>
+                                        <a href="{{ roster_url }}" style="display: inline-block; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">Confirm Availability</a>
                                         <![endif]-->
                                     </td>
                                 </tr>

--- a/duty_roster/templates/duty_roster/emails/surge_towpilot_alert.html
+++ b/duty_roster/templates/duty_roster/emails/surge_towpilot_alert.html
@@ -74,7 +74,7 @@
                                         </v:roundrect>
                                         <![endif]-->
                                         <!--[if !mso]>-->
-                                        <a href="{{ roster_url }}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">Confirm Availability</a>
+                                        <a href="{{ roster_url }}" style="display: inline-block; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">Confirm Availability</a>
                                         <!--<![endif]-->
                                     </td>
                                 </tr>

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -340,6 +340,11 @@ def duty_calendar_view(request, year=None, month=None):
     prev_month_name = calendar.month_name[prev_month]
     next_month_name = calendar.month_name[next_month]
 
+    # Check if there are any upcoming assignments for the agenda view
+    has_upcoming_assignments = any(
+        day.month == month and day >= today for day in assignments_by_date.keys()
+    )
+
     context = {
         "year": year,
         "month": month,
@@ -349,6 +354,7 @@ def duty_calendar_view(request, year=None, month=None):
         "next_month_name": next_month_name,
         "weeks": weeks,
         "assignments_by_date": assignments_by_date,
+        "has_upcoming_assignments": has_upcoming_assignments,
         "prev_year": prev_year,
         "prev_month": prev_month,
         "next_year": next_year,


### PR DESCRIPTION
## Summary
Fixes two UI issues in the duty roster and email templates.

## Issue #415: Duty Roster Agenda View Empty State
When there are no upcoming flight operations in the duty roster, the agenda view was empty and looked broken.

### Changes
- Added `has_upcoming_assignments` context variable to the calendar view
- Updated `_calendar_agenda.html` template to show a proper empty state message
- Message now says "No Upcoming Flight Operations" with helpful guidance

### Before
Empty agenda view with no indication of why there's no content.

### After
Shows: "No Upcoming Flight Operations - There are no scheduled operations for the remainder of [month]. Use the calendar view to see past operations."

---

## Issue #418: Outlook Email Button Visibility
The "Confirm Availability" button in ad-hoc operations emails was white-on-white (invisible) in Outlook.

### Root Cause
Outlook doesn't support CSS `linear-gradient()` backgrounds. Without a fallback `background-color`, the button background was transparent, making white text invisible.

### Fix
Added `background-color: #667eea;` as a fallback before the `background: linear-gradient(...)` on all email button links. This follows the pattern already documented in `docs/email-style-guide.md`.

### Templates Fixed
1. `ad_hoc_confirmed.html`
2. `ad_hoc_expiration.html`
3. `ad_hoc_proposed.html`
4. `duty_delinquency_report.html`
5. `instruction_cancellation.html`
6. `maintenance_digest.html`
7. `operations_cancelled.html`
8. `ops_intent_notification.html`
9. `surge_instructor_alert.html`
10. `surge_towpilot_alert.html`

## Testing
- Verified context processors tests pass
- Email templates follow documented pattern in `docs/email-style-guide.md`

Closes #415
Closes #418