### PR TITLE
Fix TypeError in DutyPreferenceForm when percentage values are None

### DIFF
--- a/duty_roster/forms.py
+++ b/duty_roster/forms.py
@@ -140,10 +140,10 @@ class DutyPreferenceForm(forms.ModelForm):
             )
 
         total = (
-            cleaned_data.get("instructor_percent", 0)
-            + cleaned_data.get("duty_officer_percent", 0)
-            + cleaned_data.get("ado_percent", 0)
-            + cleaned_data.get("towpilot_percent", 0)
+            (cleaned_data.get("instructor_percent") or 0)
+            + (cleaned_data.get("duty_officer_percent") or 0)
+            + (cleaned_data.get("ado_percent") or 0)
+            + (cleaned_data.get("towpilot_percent") or 0)
         )
         if total not in (0, 100):
             raise forms.ValidationError(


### PR DESCRIPTION
## Summary
Fixes #424 - Resolves 500 error on `/duty_roster/blackout/` page when submitting duty preferences.

## Problem
The blackout management page was crashing with a `TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'` when members submitted their duty preferences. This occurred when calculating the total percentage of duty assignments.

## Root Cause
The form validation code used `.get('field', 0)` to safely retrieve percentage values with a default of `0`. However, this pattern only provides the default when the **key is missing**, not when the value is `None`. 

When optional fields (like `instructor_percent` for non-instructors) weren't filled in, `cleaned_data` contained the key with a `None` value, causing the addition operation to fail.

## Solution
Changed the pattern from:
```python
cleaned_data.get("instructor_percent", 0)
```
to:
```python
(cleaned_data.get("instructor_percent") or 0)
```

This properly converts `None` to `0` before performing addition, using Python's truthiness evaluation where `None or 0` returns `0`.

## Changes
- **duty_roster/forms.py**: Updated `DutyPreferenceForm.clean()` to handle `None` percentage values
- **duty_roster/tests.py**: Added comprehensive test suite with 3 test cases

## Tests Added
- `test_form_handles_none_percent_values`: Tests the exact bug scenario where percentage fields are `None`
- `test_form_validates_total_percent_equals_100`: Ensures normal validation still works
- `test_form_allows_all_zeros`: Verifies that 0% totals are accepted (members can opt out of all duties)

## Testing
```bash
$ pytest duty_roster/tests.py::DutyPreferenceFormTests -v
=================== 3 passed in 46.60s ===================
```

All tests pass successfully.

## Closes
- Closes #424