### PR TITLE
Add IaC scripts for GCS bucket and SSL certificate provisioning

### DIFF
--- a/infrastructure/ansible/playbooks/gcp-storage.yml
+++ b/infrastructure/ansible/playbooks/gcp-storage.yml
@@ -86,24 +86,27 @@
         auth_kind: application
       register: iam_result
 
-    - name: Display IAM binding information
+    - name: Display IAM member information
       tags: [permissions]
       ansible.builtin.debug:
         msg:
           - "Role: {{ iam_result.role }}"
-          - "Members: {{ iam_result.members }}"
+          - "Member: {{ iam_result.member }}"
           - "Bucket: {{ iam_result.bucket }}"
 
     - name: Verify bucket is accessible
       tags: [verify]
-      ansible.builtin.command:
-        cmd: "gcloud storage buckets describe gs://{{ gcs_bucket_name }} --project={{ gcs_project }}"
+      google.cloud.gcp_storage_bucket_info:
+        name: "{{ gcs_bucket_name }}"
+        project: "{{ gcs_project }}"
+        auth_kind: application
       register: verify_result
-      changed_when: false
 
     - name: Display verification result
       tags: [verify]
       ansible.builtin.debug:
         msg:
           - "Bucket verification successful"
-          - "{{ verify_result.stdout_lines }}"
+          - "Bucket name: {{ verify_result.resources[0].name }}"
+          - "Location: {{ verify_result.resources[0].location }}"
+          - "Uniform bucket-level access: {{ verify_result.resources[0].iamConfiguration.uniformBucketLevelAccess.enabled }}"

--- a/infrastructure/ansible/setup-gcs-bucket.sh
+++ b/infrastructure/ansible/setup-gcs-bucket.sh
@@ -25,7 +25,12 @@
 #     GCS_SERVICE_ACCOUNT=django@my-project.iam.gserviceaccount.com ./setup-gcs-bucket.sh
 #
 # Usage:
+#   # Option 1: make the script executable once, then run directly:
+#   chmod +x setup-gcs-bucket.sh
 #   ./setup-gcs-bucket.sh
+#
+#   # Option 2: run via bash without changing file permissions:
+#   bash setup-gcs-bucket.sh
 #
 # This is an IaC script - commit changes and version control this file.
 


### PR DESCRIPTION
## Overview
Adds Infrastructure as Code (IaC) scripts for Google Cloud Storage bucket and SSL certificate provisioning, following the IaC-first philosophy established in PR #460.

## Changes

### New Scripts
1. **`setup-gcs-bucket.sh`** - GCS bucket provisioning
   - Creates `gs://manage2soar` bucket with uniform bucket-level access
   - Grants `roles/storage.objectAdmin` to Django service account
   - Required for Django media storage (avatars, profile photos)
   - Idempotent with IAM binding existence check

2. **`setup-ssl-cert.sh`** - SSL certificate provisioning
   - Creates Google-managed SSL certificates for `ssc.manage2soar.com` and `masa.manage2soar.com`
   - Updates Gateway to use new certificate (`manage2soar-ssl-cert-v2`)
   - Validates Gateway exists before patching
   - Documents hardcoded listener index assumption
   - Replaces old certificate for deprecated domains
   - Includes status monitoring guidance

3. **`playbooks/gcp-storage.yml`** - Ansible playbook alternative
   - Declarative approach using `google.cloud` collection
   - Bucket creation with IAM policy bindings
   - Requires Ansible installation (alternative to shell scripts)

## Testing
- ✅ `setup-gcs-bucket.sh` executed successfully in production
- ✅ `setup-ssl-cert.sh` executed successfully in production
- ✅ GCS bucket permissions verified (MASA superuser creation succeeded)
- ⏳ SSL certificates currently PROVISIONING (expected 10-15 minutes)

## Context
These scripts were created during post-deployment configuration of the GKE cluster after PR #458 (Gateway API) and PR #460 (post-deployment fixes) were merged. They solve:
- MASA tenant superuser creation failure (403 GCS permissions)
- SSL certificate migration from old domains to manage2soar.com
- Missing IaC for infrastructure components

## Related Issues/PRs
- Related to PR #460 (post-deployment fixes)
- Follows IaC-first philosophy from `.github/copilot-instructions.md`

## Deployment Notes
- Scripts are idempotent and safe to re-run
- Both scripts have been executed in production environment
- Old SSL certificate (`manage2soar-ssl-cert`) should be deleted after verification

## Review Updates
Addressed all 4 GitHub Copilot review comments:
- ✅ Added idempotency check for IAM binding
- ✅ Added Gateway existence validation before patching
- ✅ Documented hardcoded listener index assumption
- ✅ Made Gateway IP documentation dynamic