### PR TITLE
Fix issue #462: Protect member names from Google OAuth overwrites

### DIFF
--- a/manage2soar/settings.py
+++ b/manage2soar/settings.py
@@ -206,6 +206,12 @@ SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.user.user_details",  # Update user fields
 )
 
+# Issue #462: Protect member names from being overwritten by Google OAuth data.
+# The user_details pipeline step would otherwise update first_name/last_name
+# from the Google account on every login. These fields should remain independent
+# and editable only by the member or admin.
+SOCIAL_AUTH_PROTECTED_USER_FIELDS = ["first_name", "last_name"]
+
 
 MESSAGE_TAGS = {
     messages.ERROR: "danger",  # maps Django "error" to Bootstrap "danger"


### PR DESCRIPTION
## Summary
Fixes #462 - Prevents Google OAuth from overwriting member first_name and last_name on every login.

## Problem
When members log in with Google credentials, the social-auth pipeline's `user_details` step was overwriting their profile name (first_name, last_name) with their Google account name. This was undesirable because:
- Members may have nicknames or preferred names in M2S that differ from their legal name in Google
- Admins who set member names would have those changes reverted on the next login
- The member profile should be independent of external OAuth provider data

## Root Cause
The `social_core.pipeline.user.user_details` function at the end of the authentication pipeline updates user model fields from OAuth response data. By default, this includes first_name and last_name.

## Solution
Added `SOCIAL_AUTH_PROTECTED_USER_FIELDS` setting to protect `first_name` and `last_name` from being updated by the pipeline. This is the recommended approach per python-social-auth documentation.

```python
SOCIAL_AUTH_PROTECTED_USER_FIELDS = ["first_name", "last_name"]
```

## Changes
- Added 6 lines to `manage2soar/settings.py`
- Added comment explaining the purpose (Issue #462 reference)

## Testing
- ✅ Django check passed (no errors)
- ✅ Code formatted with isort
- ✅ Pre-commit hooks passed (bandit, black, etc.)

## Documentation
From python-social-auth docs:
> `SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['email',]` - Any value in [details] will be checked as an attribute in the user instance. Usually there are attributes that cannot be updated (like username, id, email, etc.), those fields need to be protected. Set any field name that requires protection in this setting, and it won't be updated.

## Related Issues
Closes #462