### PR TITLE
Add scroll anchors to analytics date range forms

### DIFF
--- a/analytics/templates/analytics/dashboard.html
+++ b/analytics/templates/analytics/dashboard.html
@@ -7,7 +7,7 @@
     <h2 class="mb-0">Operations Analytics</h2>
   </div>
 
-  <form class="row g-2 mb-4">
+  <form class="row g-2 mb-4" id="annual-range" action="#annual-range">
     <div class="col-auto">
       <label class="form-label">Start</label>
       <input class="form-control" type="number" name="start" value="{{ start }}">
@@ -93,9 +93,9 @@
 
 {# ===== Date-range section banner ===== #}
 
-<div class="alert alert-info py-2 small">
+<div class="alert alert-info py-2 small" id="date-range">
   The charts below show data for the selected date range:<br>
-  <form class="row g-2 align-items-end d-inline-flex" method="get" style="margin-bottom:0;">
+  <form class="row g-2 align-items-end d-inline-flex" method="get" action="#date-range" style="margin-bottom:0;">
     <div class="col-auto">
       <label class="form-label small mb-1">From</label>
       <input class="form-control form-control-sm" type="date" name="util_start" value="{{ util_start }}">


### PR DESCRIPTION
## Summary
Fixes #465 - After submitting date range forms on the analytics dashboard, the page now scrolls back to the form location instead of jumping to the top.

## Changes
Added anchor IDs to both date range forms in the analytics dashboard:

1. **Annual range form** (year selector at top): Added `id="annual-range"` and `action="#annual-range"`
2. **Date range form** (date selector in middle): Added `id="date-range"` to the container div and `action="#date-range"` to the form

## How It Works
When the user submits either form, the URL will include the anchor fragment (e.g., `?start=2020&end=2026#date-range`), causing the browser to scroll to that element after the page reloads.

## Testing
- Submit the annual year range form → page scrolls to the form after reload
- Submit the date range form → page scrolls to the date range section after reload