### PR TITLE
fix: ChargeableItem price_display format_html error

### DIFF
--- a/siteconfig/admin.py
+++ b/siteconfig/admin.py
@@ -464,9 +464,12 @@ class ChargeableItemAdmin(AdminHelperMixin, admin.ModelAdmin):
     @admin.display(description="Price")
     def price_display(self, obj):
         """Display price with unit."""
+        # Format the price first, then pass to format_html
+        # (format_html doesn't support format specifiers like {:.2f})
+        formatted_price = f"{obj.price:.2f}"
         if obj.unit == ChargeableItem.UnitType.HOUR:
-            return format_html("${:.2f}/hour", obj.price)
-        return format_html("${:.2f}", obj.price)
+            return format_html("${}/hour", formatted_price)
+        return format_html("${}", formatted_price)
 
     def _has_webmaster_permission(self, request):
         """Check if user has webmaster-level permission."""


### PR DESCRIPTION
## Summary
Fixes a `ValueError` when viewing the ChargeableItem list in Django admin.

## Problem
The `price_display` method in `ChargeableItemAdmin` was using:
```python
format_html("${:.2f}/hour", obj.price)
```

This doesn't work because `format_html()` escapes its arguments to `SafeString` before applying format specifiers. Python's format specifier `{:.2f}` cannot be applied to a `SafeString`, causing:
```
ValueError: Unknown format code 'f' for object of type 'SafeString'
```

## Solution
Format the price as a string first using an f-string, then pass the pre-formatted value to `format_html()`:
```python
formatted_price = f"{obj.price:.2f}"
format_html("${}/hour", formatted_price)
```

This maintains proper HTML escaping while allowing numeric formatting.

## Testing
- Verified the admin ChargeableItem list page loads without errors
- Price displays correctly with 2 decimal places (e.g., "$25.00/hour")