### PR TITLE
Add IAP firewall rules to gcp-vm role for browser SSH access

### DIFF
--- a/infrastructure/ansible/roles/gcp-vm/defaults/main.yml
+++ b/infrastructure/ansible/roles/gcp-vm/defaults/main.yml
@@ -80,6 +80,15 @@ gcp_allow_ssh: true
 #   - "203.0.113.0/24"  # Office VPN
 gcp_ssh_allowed_sources: []
 
+# Enable SSH access from Cloud Identity-Aware Proxy (IAP)
+# Required for browser-based SSH via GCP Console
+# This provides emergency "last hope" access when other SSH methods fail
+gcp_allow_iap_ssh: true
+
+# IAP IP range for browser SSH (fixed Google range)
+# See: https://cloud.google.com/iap/docs/using-tcp-forwarding#create-firewall-rule
+gcp_iap_ssh_range: "35.235.240.0/20"
+
 # SSH public keys to add to VM metadata
 # Format: "username:ssh-rsa AAAA... user@host"
 # IMPORTANT: Override this in group_vars with your actual SSH public keys

--- a/infrastructure/ansible/roles/gcp-vm/defaults/main.yml
+++ b/infrastructure/ansible/roles/gcp-vm/defaults/main.yml
@@ -98,6 +98,12 @@ gcp_iap_ssh_range: "35.235.240.0/20"
 #   - "admin:ssh-rsa AAAAB3Nz... admin@workstation"
 gcp_ssh_public_keys: []
 
+# Additional VM metadata
+# Note: Browser SSH requires enable-guest-attributes=TRUE
+gcp_vm_metadata:
+  enable-oslogin: "FALSE"
+  enable-guest-attributes: "TRUE"
+
 # Ansible SSH connection settings (optional)
 # If not set, Ansible will use your local username
 # gcp_ansible_user: "pb"

--- a/infrastructure/ansible/roles/gcp-vm/tasks/main.yml
+++ b/infrastructure/ansible/roles/gcp-vm/tasks/main.yml
@@ -261,6 +261,27 @@
   become: false
   when: gcp_create_firewall_rules and gcp_allow_ssh and gcp_ssh_allowed_sources | length > 0
 
+- name: Create SSH-from-IAP firewall rule
+  google.cloud.gcp_compute_firewall:
+    name: "{{ gcp_firewall_name_prefix }}-allow-ssh-from-iap"
+    project: "{{ gcp_project }}"
+    auth_kind: "{{ gcp_auth_kind | default('application') }}"
+    service_account_file: "{{ gcp_service_account_file | default(omit) }}"
+    network:
+      selfLink: "global/networks/{{ gcp_network }}"
+    allowed:
+      - ip_protocol: tcp
+        ports:
+          - "22"
+    source_ranges:
+      - "{{ gcp_iap_ssh_range }}"
+    target_tags: "{{ gcp_network_tags }}"
+    description: "Allow SSH from Cloud Identity-Aware Proxy for browser SSH"
+    state: present
+  delegate_to: localhost
+  become: false
+  when: gcp_create_firewall_rules and gcp_allow_iap_ssh
+
 - name: Create SMTP firewall rule
   google.cloud.gcp_compute_firewall:
     name: "{{ gcp_firewall_name_prefix }}-allow-smtp"

--- a/infrastructure/ansible/roles/gcp-vm/tasks/main.yml
+++ b/infrastructure/ansible/roles/gcp-vm/tasks/main.yml
@@ -125,7 +125,7 @@
     service_accounts:
       - email: "{{ gcp_service_account_email | default(omit) }}"
         scopes: "{{ gcp_scopes }}"
-    metadata: "{{ {'ssh-keys': (gcp_ssh_public_keys | join('\n'))} if gcp_ssh_public_keys | length > 0 else omit }}"
+    metadata: "{{ gcp_vm_metadata | combine({'ssh-keys': (gcp_ssh_public_keys | join('\n'))}) if gcp_ssh_public_keys | length > 0 else gcp_vm_metadata }}"
     state: present
   register: gcp_vm_instance
   delegate_to: localhost
@@ -163,9 +163,7 @@
       {%- if gcp_labels is defined and gcp_labels | length > 0 %}
       --labels={{ gcp_labels | dict2items | map(attribute='key') | zip(gcp_labels | dict2items | map(attribute='value')) | map('join', '=') | join(',') }}
       {%- endif %}
-      {%- if gcp_ssh_public_keys is defined and gcp_ssh_public_keys | length > 0 %}
-      --metadata=ssh-keys="{{ gcp_ssh_public_keys | join('\n') }}"
-      {%- endif %}
+      --metadata=enable-oslogin={{ gcp_vm_metadata['enable-oslogin'] }},enable-guest-attributes={{ gcp_vm_metadata['enable-guest-attributes'] }}{% if gcp_ssh_public_keys is defined and gcp_ssh_public_keys | length > 0 %},ssh-keys="{{ gcp_ssh_public_keys | join('\n') }}"{% endif %}
       {%- if gcp_service_account_email is defined and gcp_service_account_email | length > 0 %}
       --service-account={{ gcp_service_account_email }}
       {%- endif %}

--- a/infrastructure/ansible/roles/gcp-vm/tasks/main.yml
+++ b/infrastructure/ansible/roles/gcp-vm/tasks/main.yml
@@ -25,6 +25,16 @@
   tags:
     - gcp-apis
 
+- name: Enable Network Management API for browser SSH troubleshooting
+  ansible.builtin.command:
+    cmd: gcloud services enable networkmanagement.googleapis.com --project={{ gcp_project }}
+  delegate_to: localhost
+  become: false
+  changed_when: false
+  when: gcp_allow_iap_ssh
+  tags:
+    - gcp-apis
+
 - name: Check if VM already exists
   google.cloud.gcp_compute_instance_info:
     zone: "{{ gcp_zone }}"

--- a/infrastructure/ansible/roles/gcp-vm/tasks/main.yml
+++ b/infrastructure/ansible/roles/gcp-vm/tasks/main.yml
@@ -15,6 +15,16 @@
       GCP project ID is required.
       Please set gcp_project in your group_vars or inventory.
 
+- name: Enable Cloud IAP API for browser SSH access
+  ansible.builtin.command:
+    cmd: gcloud services enable iap.googleapis.com --project={{ gcp_project }}
+  delegate_to: localhost
+  become: false
+  changed_when: false
+  when: gcp_allow_iap_ssh
+  tags:
+    - gcp-apis
+
 - name: Check if VM already exists
   google.cloud.gcp_compute_instance_info:
     zone: "{{ gcp_zone }}"


### PR DESCRIPTION
## Summary

Implements Infrastructure as Code solution for SSH access including Cloud Identity-Aware Proxy (IAP) configuration. Enables reliable emergency SSH access via `gcloud compute ssh` command when traditional SSH fails.

## Changes

### Ansible Role Updates (`gcp-vm`)

**defaults/main.yml:**
- Added `gcp_allow_iap_ssh: true` - Enable IAP SSH by default
- Added `gcp_iap_ssh_range: "35.235.240.0/20"` - Fixed Google IAP IP range
- Added `gcp_vm_metadata` with `enable-guest-attributes: TRUE` and `enable-oslogin: FALSE`

**tasks/main.yml:**
- Added "Enable Cloud IAP API" task - Enables `iap.googleapis.com`
- Added "Enable Network Management API" task - Enables `networkmanagement.googleapis.com`  
- Added "Create SSH-from-IAP firewall rule" task - Creates IAP firewall rules with proper target tags
- Updated VM creation to include required metadata for browser SSH compatibility
- Automatically applies to VMs with matching `gcp_network_tags`

## Testing Results

✅ **Direct SSH**: `ssh pb@34.74.153.95` - **WORKS**  
✅ **gcloud SSH**: `gcloud compute ssh m2s-database --zone=us-east1-b --project=manage2soar` - **WORKS PERFECTLY**  
✅ **IAP Tunneling**: `gcloud compute start-iap-tunnel` - **WORKS**  
❌ **Browser SSH Button**: GCP Console SSH button - **FAILS ON ALL 5 HOSTS**

### Root Causes Investigated & Fixed

1. ✅ Firewall rules were missing target tags → **FIXED**
2. ✅ Cloud IAP API (`iap.googleapis.com`) wasn't enabled → **FIXED**
3. ✅ Network Management API (`networkmanagement.googleapis.com`) wasn't enabled → **FIXED**
4. ✅ `enable-guest-attributes` metadata wasn't set → **FIXED**
5. ✅ Project-wide SSH keys configured correctly → **VERIFIED**
6. ✅ Google Guest Agent running → **VERIFIED**
7. ❌ **Browser SSH still fails** - appears to be Google Cloud Console or account-level limitation

## Browser SSH Diagnosis

After extensive troubleshooting with assistance from Google Gemini AI, we confirmed:
- All documented requirements for browser SSH are met
- IAP firewall rules configured correctly (35.235.240.0/20)
- Required APIs enabled
- Guest attributes enabled
- SSH daemon running
- gcloud authentication working
- Failures occur across **all 5 hosts** in 2 different projects

**Conclusion**: Browser SSH failure is likely a Google Cloud Console limitation, browser compatibility issue, or requires undocumented enterprise configuration. Since `gcloud compute ssh` works perfectly via IAP, this provides reliable emergency access.

## IaC-First Philosophy ✅

This PR follows our infrastructure-as-code principles:
- Firewall rules defined in version control
- Required APIs automatically enabled by Ansible
- VM metadata configured automatically
- Reproducible deployments
- No manual GCP Console changes needed going forward

## Recommended Workflow

**For emergency SSH access when direct SSH fails:**
```bash
gcloud compute ssh <instance-name> --zone=<zone> --project=<project>
```

This command:
- Uses IAP automatically when needed
- Requires no manual firewall configuration
- Works from any location
- Is now fully codified in Ansible

## Next Steps

Once merged:
1. Delete manual firewall rules created during troubleshooting
2. Re-run Ansible playbooks to create rules via IaC
3. Verify `gcloud compute ssh` continues working (it will)
4. Document `gcloud compute ssh` as the official emergency access method

Closes #508