### PR TITLE
Configure SSL certificate for skylinesoaring.org production domains

### DIFF
--- a/infrastructure/ansible/inventory/gcp_app.yml.example
+++ b/infrastructure/ansible/inventory/gcp_app.yml.example
@@ -72,19 +72,20 @@ all:
     gke_tenants:
       - prefix: "ssc"
         name: "Skyline Soaring Club"
-        # Single domain (simple)
-        domain: "ssc.manage2soar.com"
-        # OR multiple domains (for migrations):
-        # domains:
-        #   - "ssc.manage2soar.com"      # Primary domain
-        #   - "www.skylinesoaring.org"   # Alias (added during migration)
+        # Multi-domain example (production domains for skylinesoaring.org)
+        domains:
+          - "ssc.manage2soar.com"          # Testing/staging domain
+          - "skylinesoaring.org"            # Production apex domain
+          - "www.skylinesoaring.org"        # Production www subdomain
 
       - prefix: "masa"
         name: "Mid-Atlantic Soaring Association"
-        # Multi-domain example (primary + alias during migration)
-        domains:
-          - "masa.manage2soar.com"          # Primary domain
-          - "www.midatlanticsoaring.org"    # Alias (added during migration)
+        # Single domain (simple)
+        domain: "masa.manage2soar.com"
+        # OR multiple domains (for migrations):
+        # domains:
+        #   - "masa.manage2soar.com"          # Primary domain
+        #   - "www.midatlanticsoaring.org"    # Alias (added during migration)
 
     # ============================================================
     # INGRESS (External Access)

--- a/manage2soar/settings.py
+++ b/manage2soar/settings.py
@@ -344,11 +344,11 @@ AUTHENTICATION_BACKENDS = (
 )
 
 
-# Or your real domain in production
-# ALLOWED_HOSTS = ['10.76.0.0', '127.0.0.1',
-# 'localhost', 'm2s.skylinesoaring.org', '.skylinesoaring.org']
-
-ALLOWED_HOSTS = ["*"]
+# ALLOWED_HOSTS configuration
+# Multi-tenant system: Populated via DJANGO_ALLOWED_HOSTS environment variable
+# The IaC deployment (Ansible) dynamically builds this from tenant domain configurations
+# Never hardcode specific club domains here - breaks multi-tenant model
+ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
 
 # Trust X-Forwarded-Proto header for HTTPS detection (required for OAuth2 redirect URI to use https)
 # Only enable in production behind a reverse proxy (causes issues in development)


### PR DESCRIPTION
## Issue
Fixes #501

## Changes
- **inventory/gcp_app.yml.example**: Update SSC tenant configuration to use  array with production hostnames
  -  (testing/staging domain)
  -  (production apex domain)
  -  (production www subdomain)
- **manage2soar/settings.py**: Use  environment variable instead of hardcoded list
  - Maintains multi-tenant flexibility
  - IaC deployment dynamically builds ALLOWED_HOSTS from tenant domains

## How It Works
The existing Ansible deployment already handles multi-domain SSL certificates:

1. **SSL Certificate Creation**: The `k8s-secrets.yml.j2` template extracts all domains from tenant configuration and creates a Google-managed SSL certificate with all hostnames
2. **ALLOWED_HOSTS Population**: The deployment automatically populates `DJANGO_ALLOWED_HOSTS` with:
   - All tenant domains (from `domains` array or `domain` string)
   - `localhost` and `127.0.0.1` for health checks
   - Gateway IP (if defined) for troubleshooting
3. **Gateway HTTPRoute**: The Gateway API automatically configures routing for all specified hostnames

## Deployment Steps
After merging:

1. Update local `infrastructure/ansible/inventory/gcp_app.yml` (gitignored) with production domains:
   ```yaml
   gke_tenants:
     - prefix: "ssc"
       name: "Skyline Soaring Club"
       domains:
         - "ssc.manage2soar.com"
         - "skylinesoaring.org"
         - "www.skylinesoaring.org"
   ```

2. Deploy configuration:
   ```bash
   cd infrastructure/ansible
   ansible-playbook -i inventory/gcp_app.yml \
     --vault-password-file ~/.ansible_vault_pass \
     playbooks/gcp-app-deploy.yml
   ```

3. Get Gateway IP:
   ```bash
   kubectl get gateway manage2soar-gateway -n default -o jsonpath='{.status.addresses[0].value}'
   ```

4. Configure DNS A records at domain registrar:
   - `skylinesoaring.org` → Gateway IP
   - `www.skylinesoaring.org` → Gateway IP

5. Wait for SSL certificate provisioning (10-60 minutes):
   ```bash
   gcloud compute ssl-certificates describe manage2soar-ssl-cert \
     --global --project=skyline-soaring-storage \
     --format="value(managed.status,managed.domainStatus)"
   ```

6. Verify HTTPS access:
   ```bash
   curl -I https://skylinesoaring.org
   curl -I https://www.skylinesoaring.org
   curl -I https://ssc.manage2soar.com
   ```

## Testing
- ✅ Pre-commit hooks passed (bandit, isort, black)
- ✅ Multi-tenant model preserved (no hardcoded domains in settings.py)
- ✅ Existing deployment logic handles domains array correctly

## Related Issues
- #499 - Pre-Go-Live Checklist (SSL certificate is a blocker)