### PR TITLE
Add database connection pooling via IaC (CONN_MAX_AGE=300)

### DIFF
--- a/infrastructure/ansible/inventory/gcp_app.yml.example
+++ b/infrastructure/ansible/inventory/gcp_app.yml.example
@@ -54,6 +54,12 @@ all:
     # Get from: gcloud compute instances describe m2s-database --zone=us-east1-b --format='get(networkInterfaces[0].networkIP)'
     postgresql_host: "192.0.2.1"
 
+    # Optional: Connection pooling for persistent database connections
+    # Default: 300 seconds (5 minutes) - reuse connections to reduce overhead
+    # 0 = new connection per request (no pooling)
+    # 600 = 10 minutes (aggressive pooling for high-traffic sites)
+    # postgresql_conn_max_age: 300
+
     # ============================================================
     # MULTI-TENANT
     # ============================================================

--- a/infrastructure/ansible/roles/gke-deploy/defaults/main.yml
+++ b/infrastructure/ansible/roles/gke-deploy/defaults/main.yml
@@ -98,6 +98,14 @@ gke_db_user: "{{ postgresql_user | default('m2s') }}"
 # Database SSL mode
 gke_db_sslmode: "{{ 'require' if (postgresql_ssl_enabled | default(false)) else 'prefer' }}"
 
+# Database connection max age (seconds)
+# Enables Django's persistent connections to reduce connection overhead.
+# 0 = new connection per request (default Django behavior)
+# 300 = reuse connections for 5 minutes (recommended for production)
+# 600 = reuse connections for 10 minutes (aggressive pooling)
+# None = infinite lifetime (use with caution, can lead to stale connections)
+gke_db_conn_max_age: "{{ postgresql_conn_max_age | default(300) }}"
+
 # ============================================================
 # GOOGLE CLOUD STORAGE
 # ============================================================

--- a/infrastructure/ansible/roles/gke-deploy/templates/k8s-secrets.yml.j2
+++ b/infrastructure/ansible/roles/gke-deploy/templates/k8s-secrets.yml.j2
@@ -115,6 +115,7 @@ stringData:
   DB_HOST: "{{ gke_db_host }}"
   DB_PORT: "{{ gke_db_port | string }}"
   DB_SSLMODE: "{{ gke_db_sslmode }}"
+  DB_CONN_MAX_AGE: "{{ gke_db_conn_max_age | string }}"
 
   # ============================================================
   # GOOGLE CLOUD STORAGE

--- a/manage2soar/settings.py
+++ b/manage2soar/settings.py
@@ -154,6 +154,7 @@ DATABASES = {
         "PASSWORD": os.getenv("DB_PASSWORD"),
         "HOST": os.getenv("DB_HOST", "localhost"),
         "PORT": os.getenv("DB_PORT", "5432"),
+        "CONN_MAX_AGE": int(os.getenv("DB_CONN_MAX_AGE", "300")),
         "OPTIONS": {
             "sslmode": os.getenv("DB_SSLMODE", "require"),
         },


### PR DESCRIPTION
## Issue
Addresses #499 (Pre-Go-Live Checklist - Connection pooling item)
Related: #514 (Deferred pgbouncer implementation)

## Changes
This PR implements Django's persistent database connections via IaC, eliminating the need to hardcode configuration in settings.py.

### Infrastructure Changes
1. **gke-deploy role defaults** ():
   - Added `gke_db_conn_max_age` with default value of 300 seconds (5 minutes)
   - Comprehensive documentation of connection pooling options

2. **k8s-secrets template** (`infrastructure/ansible/roles/gke-deploy/templates/k8s-secrets.yml.j2`):
   - Added `DB_CONN_MAX_AGE` environment variable to Kubernetes secrets

3. **Django settings** (`manage2soar/settings.py`):
   - Updated `DATABASES` configuration to read `CONN_MAX_AGE` from environment
   - Default fallback: 300 seconds

4. **Inventory example** (`infrastructure/ansible/inventory/gcp_app.yml.example`):
   - Documented `postgresql_conn_max_age` configuration option

## How It Works
- **Default behavior**: Connections are reused for 5 minutes (300 seconds)
- **Per-request behavior**: Django checks for a valid connection before each request
  - If connection exists and is alive → reuse it
  - If connection is stale or closed → create new connection
- **Benefits**: Reduces ~5-10ms connection establishment overhead per request

## Configuration Options
In your `inventory/gcp_app.yml`:
```yaml
# Optional: Override default connection pooling
postgresql_conn_max_age: 300   # Default: 5 minutes
# postgresql_conn_max_age: 600  # Aggressive: 10 minutes
# postgresql_conn_max_age: 0    # Disable: new connection per request
```

## Benefits
✅ **Performance**: Eliminates 5-10ms connection overhead per request  
✅ **Scalability**: Protects against connection exhaustion during traffic spikes  
✅ **Resource efficiency**: Fewer PostgreSQL connections = less memory usage  
✅ **Production-ready**: Simple connection pooling without pgbouncer complexity  

## Risks Mitigated (from previous analysis)
- **Connection exhaustion** (Medium Risk): With 2 pods and unlimited connections, traffic spikes could exhaust PostgreSQL's 100-200 connection limit. Persistent connections reduce the number of concurrent connections.
- **Performance overhead** (Low Risk): Eliminates connection establishment latency for most requests.
- **Cascading failures** (Medium Risk): Connection exhaustion can cause health check failures, CronJob failures, and impact other apps sharing the database.

## Testing
- ✅ Pre-commit hooks passed (bandit, isort, black)
- ✅ IaC-first approach: configuration managed via Ansible, not hardcoded
- ✅ Multi-tenant compatible: no tenant-specific hardcoded values

## Deployment Impact
- **Zero downtime**: Rolling deployment will apply new configuration
- **No database changes**: This is application-level connection pooling only
- **Reversible**: Can set `postgresql_conn_max_age: 0` to disable if needed

## Next Steps
After this PR:
1. Merge to main
2. Deploy to production: `ansible-playbook -i inventory/gcp_app.yml playbooks/gcp-app-deploy.yml`
3. Monitor connection pool metrics
4. Consider #514 (pgbouncer) for future scalability at 50+ concurrent users

## Related Issues
- #499 - Pre-Go-Live Checklist (connection pooling item - ✅ addressed)
- #514 - Deploy PgBouncer (deferred for future scaling needs)