### PR TITLE
Complete rewrite: Pre-render qualification icons to eliminate DOM XSS

### DIFF
--- a/instructors/templates/instructors/_qualification_form_partial.html
+++ b/instructors/templates/instructors/_qualification_form_partial.html
@@ -25,17 +25,31 @@
           <i class="bi bi-award me-2"></i>Qualification
         </strong>
       </label>
-      <select name="qualification" id="{{ form.qualification.id_for_label }}" class="form-select qualification-select">
-        <option value="">Select a qualification...</option>
-        {% for qual in all_qualifications %}
-          <option value="{{ qual.pk }}"
-                  data-icon="{% if qual.icon %}{{ qual.icon.url }}{% endif %}"
-                  data-name="{{ qual.name }}"
-                  {% if form.qualification.value == qual.pk %}selected{% endif %}>
-            {{ qual.name }}
-          </option>
-        {% endfor %}
-      </select>
+      <div class="d-flex align-items-center gap-2">
+        <select name="qualification" id="{{ form.qualification.id_for_label }}" class="form-select qualification-select">
+          <option value="">Select a qualification...</option>
+          {% for qual in all_qualifications %}
+            <option value="{{ qual.pk }}"
+                    {% if form.qualification.value == qual.pk %}selected{% endif %}>
+              {{ qual.name }}
+            </option>
+          {% endfor %}
+        </select>
+        {# Pre-render all qualification icons - show/hide with CSS based on selection #}
+        <div class="qualification-icon-container">
+          {% for qual in all_qualifications %}
+            {% if qual.icon %}
+              <img src="{{ qual.icon.url }}"
+                   alt="{{ qual.name }} icon"
+                   title="{{ qual.name }}"
+                   class="qualification-icon qual-icon-{{ qual.pk }}"
+                   width="24"
+                   height="24"
+                   style="display: {% if form.qualification.value == qual.pk %}inline-block{% else %}none{% endif %}; vertical-align: middle;">
+            {% endif %}
+          {% endfor %}
+        </div>
+      </div>
     </div>
 
     <div class="col-md-6">
@@ -91,39 +105,22 @@
   </div>
 </form>
 
-<script src="{% static 'instructors/js/security-helpers.js' %}"></script>
 <script>
-// Enhanced qualification dropdown with icons for modal
-// Note: isSafeImageUrl and escapeForAttribute are loaded from security-helpers.js
+// Qualification icon preview - pure show/hide, no DOM text manipulation
 document.addEventListener('DOMContentLoaded', function() {
   const qualSelect = document.querySelector('#qualification-modal .qualification-select');
   if (qualSelect) {
     qualSelect.addEventListener('change', function() {
-      const selectedOption = this.options[this.selectedIndex];
-      const iconUrl = selectedOption.getAttribute('data-icon');
+      // Hide all icons in this modal
+      document.querySelectorAll('#qualification-modal .qualification-icon').forEach(icon => {
+        icon.style.display = 'none';
+      });
 
-      if (iconUrl && this.value && isSafeImageUrl(iconUrl)) {
-        let iconPreview = document.getElementById('modal-qualification-icon-preview');
-        if (!iconPreview) {
-          iconPreview = document.createElement('img');
-          iconPreview.id = 'modal-qualification-icon-preview';
-          iconPreview.className = 'qualification-icon ms-2';
-          iconPreview.width = 24;
-          iconPreview.height = 24;
-          iconPreview.style.verticalAlign = 'middle';
-          this.parentNode.appendChild(iconPreview);
-        }
-        // URL is validated by isSafeImageUrl() before reaching here, so setAttribute is safe
-        iconPreview.setAttribute('src', iconUrl);
-        // Use data attribute (not textContent) to avoid DOM-to-HTML XSS pattern per CodeQL guidance
-        const qualName = selectedOption.getAttribute('data-name') || 'Qualification';
-        iconPreview.setAttribute('alt', qualName);
-        iconPreview.style.display = 'inline-block';
-        iconPreview.setAttribute('title', qualName);
-      } else {
-        const iconPreview = document.getElementById('modal-qualification-icon-preview');
-        if (iconPreview) {
-          iconPreview.style.display = 'none';
+      // Show selected icon (if one exists)
+      if (this.value) {
+        const selectedIcon = document.querySelector('#qualification-modal .qual-icon-' + this.value);
+        if (selectedIcon) {
+          selectedIcon.style.display = 'inline-block';
         }
       }
     });

--- a/instructors/templates/instructors/fill_instruction_report.html
+++ b/instructors/templates/instructors/fill_instruction_report.html
@@ -237,14 +237,30 @@
                     <label for="{{ qualification_form.qualification.id_for_label }}" class="form-label">
                       <strong>Qualification</strong>
                     </label>
-                    <select name="qualification" id="{{ qualification_form.qualification.id_for_label }}" class="form-select qualification-select">
-                      <option value="">Select a qualification...</option>
-                      {% for qual in all_qualifications %}
-                        <option value="{{ qual.pk }}" data-icon="{% if qual.icon %}{{ qual.icon.url }}{% endif %}" data-name="{{ qual.name }}">
-                          {{ qual.name }}
-                        </option>
-                      {% endfor %}
-                    </select>
+                    <div class="d-flex align-items-center gap-2">
+                      <select name="qualification" id="{{ qualification_form.qualification.id_for_label }}" class="form-select qualification-select">
+                        <option value="">Select a qualification...</option>
+                        {% for qual in all_qualifications %}
+                          <option value="{{ qual.pk }}">
+                            {{ qual.name }}
+                          </option>
+                        {% endfor %}
+                      </select>
+                      {# Pre-render all qualification icons - show/hide with CSS based on selection #}
+                      <div class="qualification-icon-container">
+                        {% for qual in all_qualifications %}
+                          {% if qual.icon %}
+                            <img src="{{ qual.icon.url }}"
+                                 alt="{{ qual.name }} icon"
+                                 title="{{ qual.name }}"
+                                 class="qualification-icon qual-icon-{{ qual.pk }}"
+                                 width="24"
+                                 height="24"
+                                 style="display: none; vertical-align: middle;">
+                          {% endif %}
+                        {% endfor %}
+                      </div>
+                    </div>
                   </div>
                   <div class="col-md-2">
                     <label class="form-label"><strong>Status</strong></label>
@@ -394,39 +410,21 @@ function submitFlightInstruction() {
   return true; // Allow form submission
 }
 
-// Enhanced qualification dropdown with icons
-// Note: isSafeImageUrl and escapeForAttribute are loaded from security-helpers.js
+// Enhanced qualification dropdown with icons - rewritten to avoid DOM text reads
 document.addEventListener('DOMContentLoaded', function() {
   const qualSelect = document.querySelector('.qualification-select');
   if (qualSelect) {
-    // Update display when selection changes
     qualSelect.addEventListener('change', function() {
-      const selectedOption = this.options[this.selectedIndex];
-      const iconUrl = selectedOption.getAttribute('data-icon');
+      // Hide all icons
+      document.querySelectorAll('.qualification-icon').forEach(icon => {
+        icon.style.display = 'none';
+      });
 
-      if (iconUrl && this.value && isSafeImageUrl(iconUrl)) {
-        // Show icon next to the dropdown when selection is made
-        let iconPreview = document.getElementById('qualification-icon-preview');
-        if (!iconPreview) {
-          iconPreview = document.createElement('img');
-          iconPreview.id = 'qualification-icon-preview';
-          iconPreview.className = 'qualification-icon ms-2';
-          iconPreview.width = 24;
-          iconPreview.height = 24;
-          iconPreview.style.verticalAlign = 'middle';
-          this.parentNode.appendChild(iconPreview);
-        }
-        // URL is validated by isSafeImageUrl() before reaching here, so setAttribute is safe
-        iconPreview.setAttribute('src', iconUrl);
-        // Use data attribute (not textContent) to avoid DOM-to-HTML XSS pattern per CodeQL guidance
-        const qualName = selectedOption.getAttribute('data-name') || 'Qualification';
-        iconPreview.setAttribute('alt', qualName);
-        iconPreview.style.display = 'inline-block';
-        iconPreview.setAttribute('title', qualName);
-      } else {
-        const iconPreview = document.getElementById('qualification-icon-preview');
-        if (iconPreview) {
-          iconPreview.style.display = 'none';
+      // Show selected icon (if one exists)
+      if (this.value) {
+        const selectedIcon = document.querySelector('.qual-icon-' + this.value);
+        if (selectedIcon) {
+          selectedIcon.style.display = 'inline-block';
         }
       }
     });

--- a/instructors/templates/instructors/log_ground_instruction.html
+++ b/instructors/templates/instructors/log_ground_instruction.html
@@ -360,14 +360,30 @@
                   <label for="{{ qualification_form.qualification.id_for_label }}" class="form-label">
                     <strong>Qualification</strong>
                   </label>
-                  <select name="qualification" id="{{ qualification_form.qualification.id_for_label }}" class="form-select qualification-select">
-                    <option value="">Select a qualification...</option>
-                    {% for qual in all_qualifications %}
-                      <option value="{{ qual.pk }}" data-icon="{% if qual.icon %}{{ qual.icon.url }}{% endif %}" data-name="{{ qual.name }}">
-                        {{ qual.name }}
-                      </option>
-                    {% endfor %}
-                  </select>
+                  <div class="d-flex align-items-center gap-2">
+                    <select name="qualification" id="{{ qualification_form.qualification.id_for_label }}" class="form-select qualification-select">
+                      <option value="">Select a qualification...</option>
+                      {% for qual in all_qualifications %}
+                        <option value="{{ qual.pk }}">
+                          {{ qual.name }}
+                        </option>
+                      {% endfor %}
+                    </select>
+                    {# Pre-render all qualification icons - show/hide with CSS based on selection #}
+                    <div class="qualification-icon-container">
+                      {% for qual in all_qualifications %}
+                        {% if qual.icon %}
+                          <img src="{{ qual.icon.url }}"
+                               alt="{{ qual.name }} icon"
+                               title="{{ qual.name }}"
+                               class="qualification-icon qual-icon-{{ qual.pk }}"
+                               width="24"
+                               height="24"
+                               style="display: none; vertical-align: middle;">
+                        {% endif %}
+                      {% endfor %}
+                    </div>
+                  </div>
                 </div>
                 <div class="col-md-2">
                   <label class="form-label"><strong>Status</strong></label>
@@ -559,39 +575,21 @@ function submitInstructionSession() {
   return false; // Prevent default button action since we're calling submit() explicitly
 }
 
-// Enhanced qualification dropdown with icons
-// Note: isSafeImageUrl and escapeForAttribute are loaded from security-helpers.js
+// Qualification icon preview - pure show/hide, no DOM text manipulation
 document.addEventListener('DOMContentLoaded', function() {
   const qualSelect = document.querySelector('.qualification-select');
   if (qualSelect) {
-    // Update display when selection changes
     qualSelect.addEventListener('change', function() {
-      const selectedOption = this.options[this.selectedIndex];
-      const iconUrl = selectedOption.getAttribute('data-icon');
+      // Hide all icons
+      document.querySelectorAll('.qualification-icon').forEach(icon => {
+        icon.style.display = 'none';
+      });
 
-      if (iconUrl && this.value && isSafeImageUrl(iconUrl)) {
-        // Show icon next to the dropdown when selection is made
-        let iconPreview = document.getElementById('qualification-icon-preview');
-        if (!iconPreview) {
-          iconPreview = document.createElement('img');
-          iconPreview.id = 'qualification-icon-preview';
-          iconPreview.className = 'qualification-icon ms-2';
-          iconPreview.width = 24;
-          iconPreview.height = 24;
-          iconPreview.style.verticalAlign = 'middle';
-          this.parentNode.appendChild(iconPreview);
-        }
-        // URL is validated by isSafeImageUrl() before reaching here, so setAttribute is safe
-        iconPreview.setAttribute('src', iconUrl);
-        // Use data attribute (not textContent) to avoid DOM-to-HTML XSS pattern per CodeQL guidance
-        const qualName = selectedOption.getAttribute('data-name') || 'Qualification';
-        iconPreview.setAttribute('alt', qualName);
-        iconPreview.style.display = 'inline-block';
-        iconPreview.setAttribute('title', qualName);
-      } else {
-        const iconPreview = document.getElementById('qualification-icon-preview');
-        if (iconPreview) {
-          iconPreview.style.display = 'none';
+      // Show selected icon (if one exists)
+      if (this.value) {
+        const selectedIcon = document.querySelector('.qual-icon-' + this.value);
+        if (selectedIcon) {
+          selectedIcon.style.display = 'inline-block';
         }
       }
     });


### PR DESCRIPTION
## Summary

**Complete re-architecture** of qualification icon preview functionality across 3 templates. This approach **eliminates DOM text/attribute reading entirely** to satisfy CodeQL's static analysis.

## Problem: The Thrashing Cycle

Alerts #55-66 kept regenerating despite multiple fix attempts because:
- CodeQL tracks **any DOM read** → **any reuse** pattern as potential XSS
- Even reading from `data-name` attributes triggers tracking
- Using `setAttribute()` doesn't help - it's about the **data source**
- This is API misuse pattern detection, not actual vulnerability

## Root Cause

CodeQL's taint analysis treats ALL DOM-derived values as attacker-controlled:
```javascript
// This triggers alert even though safe:
const name = element.getAttribute('data-name');  // DOM READ
img.setAttribute('alt', name);  // REUSE → FLAG
```

The scanner doesn't care that Django escapes the data or that we use `setAttribute()`. It sees: **DOM → JavaScript → Output** and flags it.

## Solution: Pre-Render Everything

**Don't read from DOM at all.** Generate all possible icons in Django templates.

### Before (Dynamic Creation - Flagged)
```javascript
// JavaScript creates img element
const img = document.createElement('img');
img.src = element.getAttribute('data-icon');  // DOM read #1
img.alt = element.getAttribute('data-name');  // DOM read #2 → ALERT
```

### After (Pre-Rendered - Clean)
```django
{# Django template renders all icons #}
{% for qual in all_qualifications %}
  {% if qual.icon %}
    <img src="{{ qual.icon.url }}"
         alt="{{ qual.name }} icon"
         class="qual-icon-{{ qual.pk }}"
         style="display: none;">
  {% endif %}
{% endfor %}
```

```javascript
// JavaScript only toggles visibility - NO DOM reads
document.querySelector('.qual-icon-' + selectValue).style.display = 'inline-block';
```

## Data Flow Comparison

**Before (Flagged)**:
```
Django Template → Option Element → JavaScript reads data-name → setAttribute
                   (DOM Storage)    (TRACKED PATH)
```

**After (Clean)**:
```
Django Template → img alt="{{ qual.name }}" → JavaScript toggles display style
                   (STATIC HTML)                  (NO DOM TEXT READS)
```

## Changes

### 1. log_ground_instruction.html
- ✅ Pre-render all qualification icons with proper alt text from Django
- ✅ Wrap select + icons in flexbox container
- ✅ JavaScript only toggles `display` style (no DOM reads)

### 2. fill_instruction_report.html
- ✅ Pre-render all qualification icons with proper alt text from Django
- ✅ Wrap select + icons in flexbox container
- ✅ JavaScript only toggles `display` style (no DOM reads)

### 3. _qualification_form_partial.html
- ✅ Pre-render all qualification icons with proper alt text from Django
- ✅ Show correct icon on modal open (for edit mode)
- ✅ JavaScript only toggles `display` style (no DOM reads)

## Benefits

### 1. Security
- **NO DOM XSS alerts** - zero DOM text/attribute reading
- **No data flow** from DOM to outputs
- CodeQL sees: Static HTML → Style manipulation only

### 2. Accessibility
- Alt text from Django templates (always correct)
- Works with screen readers
- Descriptive titles for tooltips

### 3. Performance
- No createElement() or appendChild() calls
- No DOM tree manipulation
- Faster initial render (browser caches all icons)

### 4. Maintainability
- Simpler JavaScript (10 lines vs 40)
- No security-helpers.js dependency
- Clear separation: Django renders, JS shows/hides

### 5. Graceful Degradation
- Icons visible for pre-selected qualifications (edit forms)
- Works with JavaScript disabled (shows selected icon)

## Testing Checklist
- [ ] CodeQL scan shows 0 instances of alerts # 64, # 65, # 66
- [ ] Icon appears when qualification selected
- [ ] Icon changes when different qualification selected
- [ ] Icon hidden when "Select a qualification..." chosen
- [ ] Modal edit mode shows correct icon initially
- [ ] No JavaScript errors in console
- [ ] Alt text appears in img elements (accessibility)

## Closes
Fixes # 64, # 65, # 66 (and prevents all future regenerations of this pattern)