### PR TITLE
Fix Issue #524: Flight Instruction Form Submit Button Not Working

### DIFF
--- a/instructors/templates/instructors/fill_instruction_report.html
+++ b/instructors/templates/instructors/fill_instruction_report.html
@@ -446,31 +446,31 @@ function submitFlightInstruction() {
       const expirationDate = qualFields.querySelector('input[name="expiration_date"]');
       const notes = qualFields.querySelector('textarea[name="notes"]');
 
-    // Null checks for all qualification fields
-    if (!qualificationSelect || !isQualifiedCheck || !dateAwarded || !expirationDate || !notes) {
-      console.error('Missing qualification form fields');
-      return false;
-    }
+      // Null checks for all qualification fields
+      if (!qualificationSelect || !isQualifiedCheck || !dateAwarded || !expirationDate || !notes) {
+        console.error('Missing qualification form fields');
+        return false;
+      }
 
-    // Remove any existing qualification fields
-    mainForm.querySelectorAll('input[name^="qual_"]').forEach(field => field.remove());
+      // Remove any existing qualification fields
+      mainForm.querySelectorAll('input[name^="qual_"]').forEach(field => field.remove());
 
-    // Add qualification data as hidden fields
-    const hiddenFields = [
-      {name: 'qual_qualification', value: qualificationSelect.value},
-      {name: 'qual_is_qualified', value: isQualifiedCheck.checked ? 'on' : ''},
-      {name: 'qual_date_awarded', value: dateAwarded.value},
-      {name: 'qual_expiration_date', value: expirationDate.value},
-      {name: 'qual_notes', value: notes.value}
-    ];
+      // Add qualification data as hidden fields
+      const hiddenFields = [
+        {name: 'qual_qualification', value: qualificationSelect.value},
+        {name: 'qual_is_qualified', value: isQualifiedCheck.checked ? 'on' : ''},
+        {name: 'qual_date_awarded', value: dateAwarded.value},
+        {name: 'qual_expiration_date', value: expirationDate.value},
+        {name: 'qual_notes', value: notes.value}
+      ];
 
-    hiddenFields.forEach(field => {
-      const input = document.createElement('input');
-      input.type = 'hidden';
-      input.name = field.name;
-      input.value = field.value;
-      mainForm.appendChild(input);
-    });
+      hiddenFields.forEach(field => {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = field.name;
+        input.value = field.value;
+        mainForm.appendChild(input);
+      });
     }
   }
 


### PR DESCRIPTION
## Overview
Fixes #524 - Flight instruction form had the same critical bugs as ground instruction (fixed in PR #388).

## The Embarrassing Demo Bug
During the demo a few weeks ago, when the instructor tried to fill out the flight instruction report and clicked "Save Complete Session", **the button did nothing**. No submission, no feedback, nothing. This was the same bug that affected ground instruction in Issue #377.

## Root Cause: DRY Violation
The ground instruction template was fixed in PR #388, but the flight instruction template (`fill_instruction_report.html`) was never updated. Both templates had identical bugs but only one was fixed, violating the DRY principle.

## Issues Fixed

### 1. Submit Button Not Working
- **Problem**: `submitFlightInstruction()` returned `true` without validation check or `form.submit()` call
- **Solution**: Added explicit form validation check and `form.submit()` call (same pattern as PR #388)

### 2. Nested Forms (Invalid HTML)
- **Problem**: Qualification form nested inside main form causing unpredictable browser behavior
- **Solution**: Moved qualification section entirely outside main form, converted to div container

### 3. Duplicate Field Names → Data Loss
- **Problem**: Both forms had `name="notes"` field - instructor's flight notes were being overwritten by empty qualification notes
- **Solution**: Separated forms completely, eliminating field name conflicts

### 4. Missing Form Validation
- **Problem**: No `checkValidity()` check before submission
- **Solution**: Added Bootstrap 5 validation pattern with proper error display

## Changes Made

### Template Changes
- `instructors/templates/instructors/fill_instruction_report.html`:
  - Fixed `submitFlightInstruction()` function with validation and explicit submit
  - Updated `submitQualificationOnly()` to copy fields to standalone form
  - Moved qualification UI fields to div container (`qualificationFormFields`)
  - Relocated entire Student Qualifications section outside main form
  - Added standalone hidden form for qualification-only submissions
  - Updated all JavaScript references from `qualificationForm` to `qualificationFormFields`

## Testing Verification

All scenarios from PR #388 apply here:
- ✅ Invalid form shows Bootstrap validation UI
- ✅ Valid form without qualifications submits successfully
- ✅ Valid form with qualifications submits both flight instruction and qualification
- ✅ Flight instruction notes/essay saves correctly (no more data loss)
- ✅ "Set first click to" functionality works
- ✅ "Add Qualification Only" button works independently

## Impact
- Flight instruction logging is now fully functional
- No data loss for instructor notes/reports
- Optional qualifications work correctly
- Form validation provides proper user feedback
- **The demo bug is fixed!** 🎉

## Deployment Notes
- No database migrations required
- Pure template and JavaScript changes
- Takes effect immediately upon deployment

## References
- **Issue**: #524
- **Related PR**: #388 (ground instruction fix)
- **Pattern Source**: Applied identical fixes from PR #388 to flight instruction form