### PR TITLE
Show pairing preferences as badges on Duty Blackout page

### DIFF
--- a/duty_roster/templates/duty_roster/blackout_calendar.html
+++ b/duty_roster/templates/duty_roster/blackout_calendar.html
@@ -410,6 +410,18 @@
                         <i class="fas fa-thumbs-up me-2 text-success"></i>
                         Prefer to work with:
                       </label>
+                      {% if pair_with %}
+                      <div class="mb-2">
+                        <small class="text-muted">Currently selected:</small>
+                        <div class="d-flex flex-wrap gap-1 mt-1">
+                          {% for m in pair_with %}
+                          <span class="badge bg-success-subtle text-success border border-success">
+                            <i class="fas fa-user me-1"></i>{{ m.full_display_name }}
+                          </span>
+                          {% endfor %}
+                        </div>
+                      </div>
+                      {% endif %}
                       <select name="pair_with" id="pairWith" class="form-select multi-select-responsive" multiple>
                         {% for group_name, members in member_optgroups %}
                           <optgroup label="{{ group_name }}">
@@ -432,6 +444,18 @@
                         <i class="fas fa-user-times me-2 text-warning"></i>
                         Please avoid scheduling me with:
                       </label>
+                      {% if avoid_with %}
+                      <div class="mb-2">
+                        <small class="text-muted">Currently selected:</small>
+                        <div class="d-flex flex-wrap gap-1 mt-1">
+                          {% for m in avoid_with %}
+                          <span class="badge bg-warning-subtle text-warning border border-warning">
+                            <i class="fas fa-user me-1"></i>{{ m.full_display_name }}
+                          </span>
+                          {% endfor %}
+                        </div>
+                      </div>
+                      {% endif %}
                       <select name="avoid_with" id="avoidWith" class="form-select multi-select-responsive" multiple>
                         {% for group_name, members in member_optgroups %}
                           <optgroup label="{{ group_name }}">


### PR DESCRIPTION
## Summary

Fixes #561 - Add visual indication for saved pairing preferences on the Duty Blackout page.

## Problem

When selecting pairing preferences, there was no visual indication after saving changes. Users couldn't easily see who they had previously selected in the multi-select dropdowns.

## Solution

Added "Currently selected:" badge displays above both pairing preference dropdowns:

- **Prefer to work with:** Shows green badges with the names of selected members
- **Please avoid scheduling me with:** Shows orange/warning badges with the names of selected members

Badges only appear when preferences are set. This gives users immediate visual feedback about their current selections.

## Changes

- Modified `duty_roster/templates/duty_roster/blackout_calendar.html`:
  - Added badge display section for `pair_with` preferences (green badges)
  - Added badge display section for `avoid_with` preferences (orange badges)

- Added 4 new tests in `duty_roster/tests.py`:
  - `test_pairing_preferences_display_without_preferences`
  - `test_pairing_preferences_display_with_pair_with`
  - `test_pairing_preferences_display_with_avoid_with`
  - `test_pairing_preferences_display_with_both`

## Testing

All 4 new tests pass.