### PR TITLE
Fix redirect loop after saving logsheet finances

### DIFF
--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -1231,7 +1231,7 @@ def manage_logsheet_finances(request, pk):
                 )
 
             messages.success(request, "Payment methods updated.")
-            return redirect("logsheet:manage_logsheet_finances", pk=logsheet.pk)
+            return redirect("logsheet:manage", pk=logsheet.pk)
 
     # Sort pilot_summary by pilot last name
     pilot_summary_sorted = sorted(


### PR DESCRIPTION
Fixed a bug where clicking "Save Payment Methods" would reload the form instead of redirecting the user to the dashboard.

Changes:

Changed redirection target in views.py from logsheet_detail to manage.