### PR TITLE
Add PostgreSQL password safeguards and vault consolidation

### DIFF
--- a/docs/runbooks/ansible-playbook-guide.md
+++ b/docs/runbooks/ansible-playbook-guide.md
@@ -6,6 +6,24 @@ Complete reference for all Ansible playbooks used in Manage2Soar infrastructure 
 
 This guide documents all Ansible playbooks in `infrastructure/ansible/playbooks/`, their purpose, usage patterns, and common scenarios. Always refer to this guide before manual operations - IaC-first approach.
 
+## 🔐 Vault Architecture: One Vault To Rule Them All
+
+**IMPORTANT**: All production secrets are stored in a **single master vault file**:
+
+```
+infrastructure/ansible/group_vars/localhost/vault.yml  ← MASTER VAULT
+```
+
+Other vault locations are **symlinks** to this master file:
+- `group_vars/gcp_app/vault.yml` → symlink to `localhost/vault.yml`
+- `group_vars/gcp_provisioner/vault.yml` → symlink to `localhost/vault.yml`
+
+**Specialized vaults** (different structure/password):
+- `group_vars/gcp_mail/vault.yml` - SMTP2Go API credentials (different structure)
+- `group_vars/single_host/vault.yml` - Dev/test environment (different password)
+
+**WHY**: Single source of truth prevents drift, simplifies secret management, enforces IaC-first philosophy. All production secrets are synchronized with K8s secrets.
+
 ## 🗂️ Playbook Index
 
 | Playbook | Purpose | Frequency | Tags |
@@ -39,6 +57,399 @@ ansible-playbook -i inventory/gcp_app.yml \
 ansible-playbook -i inventory/gcp_database.yml \
   --vault-password-file ~/.ansible_vault_pass \
   playbooks/gcp-database.yml --tags postgresql
+
+# Update firewall rules (after adding co-webmaster)
+ansible-playbook -i inventory/gcp_database.yml \
+  --vault-password-file ~/.ansible_vault_pass \
+  playbooks/gcp-database.yml --tags gcp-provision
+```
+
+---
+
+## 🔐 Managing Admin SSH Access
+
+**⚠️ CRITICAL**: All admin SSH keys and IP addresses are centralized in `group_vars/all.yml`. This is the **SINGLE SOURCE OF TRUTH** for firewall rules across all infrastructure.
+
+### Adding a New Co-Webmaster
+
+**Step 1: Update centralized admin list**
+
+Edit `group_vars/all.yml`:
+
+```yaml
+admin_ssh_keys:
+  - user: "pb"
+    name: "Piet Barber"
+    key: "ssh-ed25519 AAAAC3... pb@host"
+    ip: "138.88.187.144/32"
+
+  # Add new entry:
+  - user: "newadmin"
+    name: "New Admin Name"
+    key: "ssh-ed25519 AAAAC3... newadmin@host"  # Get with: cat ~/.ssh/id_ed25519.pub
+    ip: "203.0.113.10/32"  # Their public IP + /32 CIDR
+```
+
+**Step 2: Update firewall rules on ALL servers**
+
+```bash
+cd infrastructure/ansible
+
+# OPTION A: Full playbook run (updates GCP + OS firewalls + user accounts)
+# Recommended for adding new admins (creates users, deploys SSH keys, configures both firewall layers)
+ansible-playbook -i inventory/gcp_database.yml \
+  --vault-password-file ~/.ansible_vault_pass \
+  playbooks/gcp-database.yml
+
+ansible-playbook -i inventory/gcp_mail.yml \
+  --vault-password-file ~/.ansible_vault_pass \
+  playbooks/gcp-mail-server.yml
+
+# OPTION B: GCP firewall only (cloud-level firewall rules)
+# Use when updating admin IPs but user accounts already exist
+ansible-playbook -i inventory/gcp_database.yml \
+  --vault-password-file ~/.ansible_vault_pass \
+  playbooks/gcp-database.yml --tags gcp-provision
+
+ansible-playbook -i inventory/gcp_mail.yml \
+  --vault-password-file ~/.ansible_vault_pass \
+  playbooks/gcp-mail-server.yml --tags gcp-provision
+```
+
+**⚠️ Important**: The `--tags firewall` filter does NOT work for GCP firewall updates because GCP firewall tasks are tagged as `gcp-provision`. Always use Option A (full playbook) or Option B (`--tags gcp-provision`) for firewall changes.
+
+**Two-layer firewall architecture:**
+- **GCP Cloud Firewall** (outer perimeter): Controls traffic reaching the VM from the internet. Updated via `--tags gcp-provision` or full playbook run.
+- **UFW OS Firewall** (host-level): Controls traffic reaching services on the VM. Updated via full playbook run only (no tag filter works correctly).
+
+For complete admin access setup, the full playbook run (Option A) is recommended because it:
+1. Updates GCP cloud firewall rules
+2. Creates OS user accounts for new admins
+3. Deploys SSH keys to authorized_keys
+4. Updates UFW OS firewall rules
+5. Updates service-level access controls (e.g., PostgreSQL pg_hba.conf)
+
+**Step 3: Verify firewall rule changes**
+
+```bash
+# Capture firewall state BEFORE changes
+gcloud compute firewall-rules list --format="yaml" --sort-by=name > /tmp/firewall-rules-before.yaml
+
+# Run playbooks (see Step 2 above)
+
+# Capture firewall state AFTER changes
+gcloud compute firewall-rules list --format="yaml" --sort-by=name > /tmp/firewall-rules-after.yaml
+
+# Compare to verify expected changes
+diff -u /tmp/firewall-rules-before.yaml /tmp/firewall-rules-after.yaml
+```
+
+**Step 4: Test SSH access**
+
+```bash
+# Test SSH connection
+gcloud compute ssh m2s-database --zone=us-east1-b -- "echo 'SSH working!'"
+gcloud compute ssh m2s-mail --zone=us-east1-b -- "echo 'SSH working!'"
+
+# Verify OS-level firewall rules on each server
+gcloud compute ssh m2s-database --zone=us-east1-b -- "sudo ufw status numbered"  # Database
+gcloud compute ssh m2s-mail --zone=us-east1-b -- "sudo ufw status numbered"  # Mail
+
+# Verify firewall rules were updated
+gcloud compute firewall-rules describe m2s-database-allow-ssh
+gcloud compute firewall-rules describe m2s-mail-allow-ssh
+```
+
+### Updating Existing Admin IP
+
+When a co-webmaster's IP address changes:
+
+**Step 1: Update IP in `group_vars/all.yml`**
+
+```yaml
+admin_ssh_keys:
+  - user: "brian"
+    name: "Brian [Last Name]"
+    key: "ssh-ed25519 AAAAC3... brian@host"
+    ip: "203.0.113.99/32"  # <-- Updated IP
+```
+
+**Step 2: Run firewall update** (same commands as above)
+
+### Removing Admin Access
+
+**Step 1: Comment out or remove entry in `group_vars/all.yml`**
+
+```yaml
+admin_ssh_keys:
+  - user: "pb"
+    # ...
+  # REMOVED: brian no longer needs access
+  # - user: "brian"
+  #   name: "Brian [Last Name]"
+  #   key: "..."
+  #   ip: "..."
+```
+
+**Step 2: Run firewall update** (same commands as above)
+
+### Troubleshooting
+
+**"Permission denied (publickey)" when SSHing**
+
+Check:
+1. Is the SSH key in `group_vars/all.yml`?
+2. Did you run the firewall update playbook?
+3. Is the IP address correct? (Check with `curl ifconfig.me`)
+4. Are you using the correct SSH key? (`ssh-add -l`)
+
+**Firewall rule shows old IPs**
+
+```bash
+# Verify all.yml is correct
+cat group_vars/all.yml | grep -A 20 "admin_ssh_keys:"
+
+# Re-run firewall update (GCP layer)
+ansible-playbook -i inventory/gcp_database.yml \
+  --vault-password-file ~/.ansible_vault_pass \
+  playbooks/gcp-database.yml --tags gcp-provision --check  # Dry run first
+
+# Then apply
+ansible-playbook -i inventory/gcp_database.yml \
+  --vault-password-file ~/.ansible_vault_pass \
+  playbooks/gcp-database.yml --tags gcp-provision
+```
+
+**"Module format_ssh_key not found"**
+
+This is a custom Jinja2 filter. If it's missing, the simplified approach is to manually format keys:
+
+```yaml
+# In gcp_mail/vars.yml
+gcp_ssh_public_keys:
+  - "{{ admin_ssh_keys[0].user }}:{{ admin_ssh_keys[0].key }}"
+  - "{{ admin_ssh_keys[1].user }}:{{ admin_ssh_keys[1].key }}"
+  # etc...
+```
+
+---
+
+## 🔑 PostgreSQL Password Management
+
+**CRITICAL**: PostgreSQL passwords must stay synchronized between Ansible vault and Kubernetes secrets. Mismatches cause production outages.
+
+### Password Synchronization Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Source of Truth: Kubernetes Secrets (Production)      │
+│  - manage2soar-env-ssc (tenant-ssc namespace)          │
+│  - manage2soar-env-masa (tenant-masa namespace)        │
+└─────────────────────────────────────────────────────────┘
+                           ↓
+                   Must match exactly
+                           ↓
+┌─────────────────────────────────────────────────────────┐
+│  Ansible Vault: group_vars/localhost/vault.yml         │
+│  - vault_postgresql_password_ssc                        │
+│  - vault_postgresql_password_masa                       │
+└─────────────────────────────────────────────────────────┘
+                           ↓
+                   Used by playbook
+                           ↓
+┌─────────────────────────────────────────────────────────┐
+│  PostgreSQL Database Server                             │
+│  - User: m2s_ssc with password                          │
+│  - User: m2s_masa with password                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Safeguard: Password Update Protection
+
+By default, the `gcp-database.yml` playbook will **NOT** update passwords for existing PostgreSQL users. This prevents accidental production outages.
+
+```yaml
+# roles/postgresql/defaults/main.yml
+postgresql_update_existing_passwords: false  # Default: safe mode
+```
+
+When you run the database playbook, existing users will show:
+```
+⚠️  User m2s_ssc already exists - password NOT updated
+To update passwords, set postgresql_update_existing_passwords: true
+WARNING: This will break Django apps until K8s secrets are updated!
+```
+
+### Intentional Password Rotation (6-Step Procedure)
+
+**Use this procedure when you want to intentionally change PostgreSQL passwords** (e.g., security policy, suspected compromise, periodic rotation):
+
+**Step 1: Generate new passwords**
+```bash
+cd infrastructure/ansible
+
+# Generate strong passwords (32 characters)
+NEW_SSC_PASSWORD="$(openssl rand -base64 32)"
+NEW_MASA_PASSWORD="$(openssl rand -base64 32)"
+
+# Save them temporarily (we'll update vault, K8s, and PostgreSQL)
+echo "SSC Password: $NEW_SSC_PASSWORD"
+echo "MASA Password: $NEW_MASA_PASSWORD"
+```
+
+**Step 2: Update Ansible vault with new passwords**
+```bash
+# Create timestamped backup before modifying vault
+cp group_vars/localhost/vault.yml "group_vars/localhost/vault.yml.bak.$(date +%Y%m%d_%H%M%S)"
+
+# Decrypt vault
+ansible-vault decrypt group_vars/localhost/vault.yml --vault-password-file ~/.ansible_vault_pass
+
+# Update passwords (escape sed metacharacters)
+SSC_ESCAPED="$(printf '%s\n' "$NEW_SSC_PASSWORD" | sed 's/[&/]/\\&/g')"
+MASA_ESCAPED="$(printf '%s\n' "$NEW_MASA_PASSWORD" | sed 's/[&/]/\\&/g')"
+sed -i "s/vault_postgresql_password_ssc: .*/vault_postgresql_password_ssc: \"${SSC_ESCAPED}\"/" group_vars/localhost/vault.yml
+sed -i "s/vault_postgresql_password_masa: .*/vault_postgresql_password_masa: \"${MASA_ESCAPED}\"/" group_vars/localhost/vault.yml
+
+# Re-encrypt vault
+ansible-vault encrypt group_vars/localhost/vault.yml --vault-password-file ~/.ansible_vault_pass
+
+# Commit to git
+git add group_vars/localhost/vault.yml
+git commit -m "security: rotate PostgreSQL passwords"
+```
+
+**Step 3: Update Kubernetes secrets with new passwords**
+```bash
+# Encode passwords to base64 (avoid exposing in command-line arguments visible to ps)
+SSC_DB_PASSWORD_B64="$(printf '%s' "$NEW_SSC_PASSWORD" | base64 | tr -d '\n')"
+MASA_DB_PASSWORD_B64="$(printf '%s' "$NEW_MASA_PASSWORD" | base64 | tr -d '\n')"
+
+# Update SSC namespace secret via stdin heredoc (preserves existing keys, only changes DB_PASSWORD)
+kubectl patch secret manage2soar-env-ssc -n tenant-ssc --type merge --patch "$(cat <<EOF
+data:
+  DB_PASSWORD: ${SSC_DB_PASSWORD_B64}
+EOF
+)"
+
+# Update MASA namespace secret via stdin heredoc (preserves existing keys, only changes DB_PASSWORD)
+kubectl patch secret manage2soar-env-masa -n tenant-masa --type merge --patch "$(cat <<EOF
+data:
+  DB_PASSWORD: ${MASA_DB_PASSWORD_B64}
+EOF
+)"
+
+# Clean up base64 variables
+unset SSC_DB_PASSWORD_B64 MASA_DB_PASSWORD_B64
+
+# Verify secrets updated (ensure non-empty decoded passwords)
+kubectl get secret -n tenant-ssc manage2soar-env-ssc -o jsonpath='{.data.DB_PASSWORD}' | base64 -d | grep -q . && echo "SSC DB_PASSWORD set"
+kubectl get secret -n tenant-masa manage2soar-env-masa -o jsonpath='{.data.DB_PASSWORD}' | base64 -d | grep -q . && echo "MASA DB_PASSWORD set"
+```
+
+**Step 4: Restart Django pods to pick up new passwords**
+```bash
+# Restart SSC deployment
+kubectl rollout restart deployment/django-app-ssc -n tenant-ssc
+kubectl rollout status deployment/django-app-ssc -n tenant-ssc
+
+# Restart MASA deployment
+kubectl rollout restart deployment/django-app-masa -n tenant-masa
+kubectl rollout status deployment/django-app-masa -n tenant-masa
+```
+
+**Step 5: Update PostgreSQL passwords via playbook**
+```bash
+# Run playbook with password update flag enabled
+ansible-playbook -i inventory/gcp_database.yml \
+  --vault-password-file ~/.ansible_vault_pass \
+  -e "postgresql_update_existing_passwords=true" \
+  playbooks/gcp-database.yml
+
+# Verify playbook success - look for "changed" status on user tasks
+```
+
+**Step 6: Verify sites are operational**
+```bash
+# Test site connectivity
+curl -I https://skylinesoaring.org/ | grep "HTTP"  # Should show 200 OK
+curl -I https://masa.manage2soar.com/ | grep "HTTP"
+
+# Check pod logs for database connection errors
+kubectl logs -n tenant-ssc deployment/django-app-ssc --tail=50 | grep -i "database\|error"
+kubectl logs -n tenant-masa deployment/django-app-masa --tail=50 | grep -i "database\|error"
+
+# Clean up temporary password variables
+unset NEW_SSC_PASSWORD NEW_MASA_PASSWORD SSC_ESCAPED MASA_ESCAPED
+```
+
+**CRITICAL**: Steps 3-5 will cause brief downtime (~30-60 seconds). K8s secrets are updated with NEW passwords, pods restart and attempt to connect, but PostgreSQL still has OLD passwords until Step 5 completes. This creates an authentication failure window. Plan a short maintenance window, or run Steps 3-5 rapidly to minimize the outage.
+
+### Syncing Vault to Match Production (Recommended)
+
+If Ansible vault passwords drift out of sync with production:
+
+```bash
+cd infrastructure/ansible
+
+# Extract production passwords from K8s into environment variables (in-memory, avoid /tmp files)
+export SSC_DB_PASSWORD="$(kubectl get secret -n tenant-ssc manage2soar-env-ssc -o jsonpath='{.data.DB_PASSWORD}' | base64 -d)"
+export MASA_DB_PASSWORD="$(kubectl get secret -n tenant-masa manage2soar-env-masa -o jsonpath='{.data.DB_PASSWORD}' | base64 -d)"
+
+# Decrypt vault
+ansible-vault decrypt group_vars/localhost/vault.yml --vault-password-file ~/.ansible_vault_pass
+
+# Update passwords using environment variables (escape sed metacharacters in passwords)
+SSC_DB_PASSWORD_ESCAPED="$(printf '%s\n' "$SSC_DB_PASSWORD" | sed 's/[&/]/\\&/g')"
+MASA_DB_PASSWORD_ESCAPED="$(printf '%s\n' "$MASA_DB_PASSWORD" | sed 's/[&/]/\\&/g')"
+sed -i.bak \
+  -e "s/vault_postgresql_password_ssc: .*/vault_postgresql_password_ssc: \"${SSC_DB_PASSWORD_ESCAPED}\"/" \
+  -e "s/vault_postgresql_password_masa: .*/vault_postgresql_password_masa: \"${MASA_DB_PASSWORD_ESCAPED}\"/" \
+  group_vars/localhost/vault.yml
+rm group_vars/localhost/vault.yml.bak
+
+# Re-encrypt vault
+ansible-vault encrypt group_vars/localhost/vault.yml --vault-password-file ~/.ansible_vault_pass
+
+# Clean up in-memory secrets (consider also clearing shell history)
+unset SSC_DB_PASSWORD MASA_DB_PASSWORD SSC_DB_PASSWORD_ESCAPED MASA_DB_PASSWORD_ESCAPED
+
+# Verify sync (optional - passwords will match but playbook won't update them)
+ansible-playbook -i inventory/gcp_database.yml \
+  --vault-password-file ~/.ansible_vault_pass \
+  playbooks/gcp-database.yml --check
+```
+
+### Emergency Recovery: Password Mismatch
+
+⚠️ **WARNING**: This procedure uses manual SSH/SQL commands and violates the IaC-first principle. Use only as a last resort when the production site is down and immediate recovery is required. After using this emergency procedure, you MUST update Ansible vault to match production (see "Syncing Vault to Match Production" above) to restore IaC consistency.
+
+**IaC-First Approach (Recommended)**: Update Ansible vault with K8s password values, then run playbook with `postgresql_update_existing_passwords=true` flag. This ensures infrastructure code matches reality.
+
+If Django apps can't connect to database due to password mismatch and immediate recovery is needed:
+
+```bash
+# Fetch passwords from K8s secrets into local shell variables (not files)
+SSC_DB_PASSWORD="$(kubectl get secret -n tenant-ssc manage2soar-env-ssc -o jsonpath='{.data.DB_PASSWORD}' | base64 -d)"
+MASA_DB_PASSWORD="$(kubectl get secret -n tenant-masa manage2soar-env-masa -o jsonpath='{.data.DB_PASSWORD}' | base64 -d)"
+
+# Apply passwords on the database host via psql variables (psql handles SQL quoting)
+# Using :'var' syntax lets psql properly quote the password as a SQL string literal
+gcloud compute ssh m2s-database --zone=us-east1-b -- "sudo -u postgres psql -v ssc_pwd='${SSC_DB_PASSWORD}'" <<'EOF'
+ALTER USER m2s_ssc WITH PASSWORD :'ssc_pwd';
+EOF
+gcloud compute ssh m2s-database --zone=us-east1-b -- "sudo -u postgres psql -v masa_pwd='${MASA_DB_PASSWORD}'" <<'EOF'
+ALTER USER m2s_masa WITH PASSWORD :'masa_pwd';
+EOF
+
+# Clean up in-memory variables
+unset SSC_DB_PASSWORD MASA_DB_PASSWORD
+
+# IMPORTANT: Consider clearing your shell history to remove these sensitive commands:
+# for i in {1..6}; do history -d -6; done  # Delete last 6 history entries
+# Or: history -c && history -r  # Clear all history and reload from file
+# CRITICAL: Sync Ansible vault to match production (restore IaC consistency)
+# See "Syncing Vault to Match Production" section above
 ```
 
 ---

--- a/infrastructure/ansible/group_vars/all.yml.example
+++ b/infrastructure/ansible/group_vars/all.yml.example
@@ -128,3 +128,40 @@ alert_email: "ops@manage2soar.com"
 
 # Threshold for queue size warning
 queue_alert_threshold: 100
+
+# ============================================================
+# ADMIN SSH ACCESS
+# ============================================================
+# SSH public keys and IPs for co-webmasters with server access
+#
+# ⚠️  CRITICAL: This is the SINGLE SOURCE OF TRUTH for admin IPs
+# ⚠️  All firewall rules reference this list - update here ONLY!
+#
+# To add a new co-webmaster:
+# 1. Add their entry to admin_ssh_keys below
+# 2. Run the appropriate playbook to update firewall rules:
+#    Recommended (full playbook run, especially for new admins):
+#      - Database: ansible-playbook -i inventory/gcp_database.yml playbooks/gcp-database.yml
+#      - Mail: ansible-playbook -i inventory/gcp_mail.yml playbooks/gcp-mail-server.yml
+#      - Provisioner: ansible-playbook -i inventory/gcp_provisioner.yml playbooks/gcp-provisioner.yml
+#    Advanced (GCP firewall-only update, if you know no other changes are needed):
+#      - ansible-playbook -i inventory/gcp_provisioner.yml playbooks/gcp-provisioner.yml --tags gcp-provision
+#
+# See docs/runbooks/ansible-playbook-guide.md for detailed instructions
+
+admin_ssh_keys:
+  - user: "your_username"
+    name: "Your Full Name"
+    key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... your_username@laptop"  # Get with: cat ~/.ssh/id_ed25519.pub
+    ip: "203.0.113.10/32"  # Your public IP (get with: curl -4 ifconfig.me)
+
+  # Add more co-webmasters as needed:
+  # - user: "admin2"
+  #   name: "Second Admin Name"
+  #   key: "ssh-rsa AAAAB3NzaC1yc2E... admin2@workstation"
+  #   ip: "198.51.100.20/32"
+
+# Derived list of IPs for firewall rules (DO NOT EDIT - auto-generated from admin_ssh_keys)
+# Use this variable in host-specific vars files like:
+#   gcp_ssh_allowed_sources: "{{ admin_ssh_ips }}"
+admin_ssh_ips: "{{ admin_ssh_keys | map(attribute='ip') | list }}"

--- a/infrastructure/ansible/group_vars/gcp_app.vault.yml.example
+++ b/infrastructure/ansible/group_vars/gcp_app.vault.yml.example
@@ -1,15 +1,24 @@
 # GCP App Deployment Vault Secrets
 #
-# COPY THIS FILE AND FILL IN YOUR SECRETS:
-#   mkdir -p group_vars/gcp_app
-#   cp group_vars/gcp_app.vault.yml.example group_vars/gcp_app/vault.yml
-#   ansible-vault encrypt group_vars/gcp_app/vault.yml
+# ⚠️  IMPORTANT: This vault is now a SYMLINK to the master vault!
 #
-# This file should be encrypted with ansible-vault:
-#   ansible-vault encrypt group_vars/gcp_app/vault.yml
-#   ansible-vault edit group_vars/gcp_app/vault.yml
+# VAULT ARCHITECTURE: One Vault To Rule Them All
 #
-# All variables in this file should be prefixed with 'vault_' for clarity.
+#   Master vault (single source of truth):
+#     group_vars/localhost/vault.yml
+#
+#   This file (gcp_app/vault.yml) should be a SYMLINK:
+#     cd group_vars/gcp_app
+#     ln -sf ../localhost/vault.yml vault.yml
+#
+# WHY: Single source of truth prevents drift, simplifies secret management.
+#
+# To edit secrets, edit the MASTER vault:
+#   ansible-vault edit group_vars/localhost/vault.yml --vault-password-file ~/.ansible_vault_pass
+#
+# DO NOT create a separate vault file here - use the symlink!
+#
+# See: group_vars/localhost.vault.yml.example for full documentation
 
 ---
 # ============================================================

--- a/infrastructure/ansible/group_vars/gcp_database.vars.yml.example
+++ b/infrastructure/ansible/group_vars/gcp_database.vars.yml.example
@@ -55,31 +55,43 @@ gcp_network: "default"
 # Whether to allow SSH access (recommend: true for initial setup)
 gcp_allow_ssh: true
 
-# SSH source ranges - RESTRICT IN PRODUCTION!
-# For production, use your office IP or VPN CIDR
-gcp_ssh_allowed_sources: []
-#   - "203.0.113.10/32"  # EXAMPLE: replace with your public IP CIDR
-#   - "YOUR_OFFICE_IP/32"
-#   - "YOUR_VPN_CIDR"
+# SSH source ranges - CENTRALLY MANAGED
+# Admin IPs are defined in all.yml as the SINGLE SOURCE OF TRUTH
+# See docs/runbooks/ansible-playbook-guide.md for instructions on adding co-webmasters
+gcp_ssh_allowed_sources: "{{ admin_ssh_ips }}"
 
-# SSH public keys to add to VM metadata
-# CRITICAL: Add your SSH public key here or Ansible won't be able to connect!
-# Get your key: cat ~/.ssh/id_ed25519.pub (or id_rsa.pub)
+# SSH public keys - CENTRALLY MANAGED
+# Admin SSH keys are defined in all.yml - this references that centralized list
+# CRITICAL: You MUST define admin_ssh_keys in all.yml before deploying!
 # Format: "username:ssh-type key-data username@hostname"
-gcp_ssh_public_keys:
-  - "pb:ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyDataHere pb@laptop"
-  # Add multiple keys if needed:
-  # - "admin:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQ... admin@workstation"
+#
+# NOTE: Jinja2's regex_replace cannot safely access dict attributes like .user and .key.
+#       Use the explicit index-based mapping below, or implement a custom filter if you
+#       need automatic formatting.
+# CRITICAL: You MUST have at least one admin defined in admin_ssh_keys in all.yml!
+#           The first line (admin_ssh_keys[0]) will cause a runtime error if the list is empty.
+# IMPORTANT: Add this validation to your playbook before using this vars file:
+#   - name: Validate admin SSH keys exist
+#     ansible.builtin.assert:
+#       that:
+#         - admin_ssh_keys is defined
+#         - admin_ssh_keys | length >= 1
+#       fail_msg: "admin_ssh_keys must be defined in all.yml with at least one entry"
+gcp_ssh_public_keys: "{{ [admin_ssh_keys[0].user + ':' + admin_ssh_keys[0].key] if (admin_ssh_keys is defined and admin_ssh_keys | length > 0) else [] }}"
+  # Uncomment ONLY if you have 2+ admins defined in admin_ssh_keys:
+  # - "{{ admin_ssh_keys[1].user }}:{{ admin_ssh_keys[1].key }}"
+  # Uncomment ONLY if you have 3+ admins defined in admin_ssh_keys:
+  # - "{{ admin_ssh_keys[2].user }}:{{ admin_ssh_keys[2].key }}"
 
 # Ansible SSH connection settings (optional - defaults to your local username)
 # gcp_ansible_user: "pb"  # Must match the username in gcp_ssh_public_keys
 # gcp_ansible_ssh_private_key_file: "~/.ssh/id_ed25519"
 
-# PostgreSQL source ranges - your K8s cluster or app servers
-gcp_postgresql_allowed_sources:
-  - "10.0.0.0/8"      # Internal GCP network
-  # - "35.192.0.0/12"  # GKE cluster IP range
-  # - "YOUR_APP_SERVER_IP/32"
+# PostgreSQL source ranges - includes admin IPs + internal network + app servers
+# Admin IPs are centrally managed in all.yml - see admin_ssh_ips variable
+# To add non-admin IPs, extend the list like:
+#   gcp_postgresql_allowed_sources: "{{ admin_ssh_ips + ['10.0.0.0/8', '35.192.0.0/12', 'YOUR_APP_SERVER_IP/32'] }}"
+gcp_postgresql_allowed_sources: "{{ admin_ssh_ips + ['10.0.0.0/8'] }}"
 
 # ============================================================
 # POSTGRESQL CONFIGURATION
@@ -92,8 +104,9 @@ postgresql_version: "17"
 postgresql_listen_addresses: "0.0.0.0"
 
 # Remote access CIDRs (must match gcp_postgresql_allowed_sources)
-postgresql_remote_access_cidrs:
-  - "10.0.0.0/8"
+# Admin IPs are centrally managed in all.yml
+# To add non-admin IPs, extend the list to match gcp_postgresql_allowed_sources
+postgresql_remote_access_cidrs: "{{ admin_ssh_ips + ['10.0.0.0/8'] }}"
 
 # ============================================================
 # SSL/TLS CONFIGURATION

--- a/infrastructure/ansible/group_vars/gcp_database.vault.yml.example
+++ b/infrastructure/ansible/group_vars/gcp_database.vault.yml.example
@@ -1,25 +1,25 @@
-# GCP Database Server Secrets - Vault Template
+# GCP Database Server Secrets
 #
-# This file should be encrypted with ansible-vault.
+# ⚠️  IMPORTANT: Database secrets are in the MASTER vault, not here!
 #
-# SETUP INSTRUCTIONS:
+# VAULT ARCHITECTURE: One Vault To Rule Them All
 #
-# 1. Create vault password file (if not already done):
-#    echo "your-secure-vault-password" > ~/.ansible_vault_pass
-#    chmod 600 ~/.ansible_vault_pass
+#   Master vault (single source of truth):
+#     group_vars/localhost/vault.yml
 #
-# 2. Create the directory structure:
-#    mkdir -p group_vars/gcp_provisioner
+#   Contains all database passwords:
+#     vault_postgresql_password_ssc
+#     vault_postgresql_password_masa
 #
-# 3. Copy and encrypt this file:
-#    cp group_vars/gcp_database.vault.yml.example group_vars/gcp_provisioner/vault.yml
-#    ansible-vault encrypt group_vars/gcp_provisioner/vault.yml \
-#      --vault-password-file ~/.ansible_vault_pass
+# Database playbooks automatically read from localhost/vault.yml.
+# You do NOT need a separate vault file here.
 #
-# OR use the automated script:
-#    infrastructure/scripts/initialize-vault-secrets.sh group_vars/gcp_provisioner/vault.yml
+# To edit database passwords:
+#   ansible-vault edit group_vars/localhost/vault.yml --vault-password-file ~/.ansible_vault_pass
 #
-# NOTE: Use group_vars/gcp_provisioner/ to match the playbook's vars_files paths.
+# See:
+#   - group_vars/localhost.vault.yml.example for full vault documentation
+#   - docs/runbooks/ansible-playbook-guide.md for password management workflows
 
 ---
 # ALTERNATIVE: Use the automated secret generator:

--- a/infrastructure/ansible/group_vars/gcp_mail.vars.yml.example
+++ b/infrastructure/ansible/group_vars/gcp_mail.vars.yml.example
@@ -54,22 +54,32 @@ gcp_network: "default"
 # Whether to allow SSH access (recommend: true for initial setup)
 gcp_allow_ssh: true
 
-# SSH source ranges - RESTRICT IN PRODUCTION!
-# For production, use your office IP or VPN CIDR
-# CRITICAL: Replace this placeholder with your actual public IP/VPN CIDR before deployment!
-gcp_ssh_allowed_sources:
-  - "YOUR_IP_HERE/32"  # EXAMPLE ONLY - REPLACE with your public IP/VPN CIDR before deployment
+# SSH source ranges - CENTRALLY MANAGED
+# Admin IPs are defined in all.yml as the SINGLE SOURCE OF TRUTH
+# See docs/runbooks/ansible-playbook-guide.md for instructions on adding co-webmasters
+gcp_ssh_allowed_sources: "{{ admin_ssh_ips }}"
 
-# SSH public keys to add to VM metadata
-# CRITICAL: You MUST add at least one valid SSH public key here or Ansible won't be able to connect!
-# Get your key: cat ~/.ssh/id_ed25519.pub (or id_rsa.pub)
+# SSH public keys - CENTRALLY MANAGED
+# Admin SSH keys are defined in all.yml - this references that centralized list
+# CRITICAL: You MUST define admin_ssh_keys in all.yml before deploying!
 # Format: "username:ssh-type key-data username@hostname"
-gcp_ssh_public_keys: []
-# Example (uncomment and REPLACE with your actual key):
-# gcp_ssh_public_keys:
-#   - "pb:ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAYourRealKeyDataHere pb@laptop"
-#   # Add multiple keys if needed:
-#   # - "admin:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQ... admin@workstation"
+#
+# NOTE: Jinja2's regex_replace cannot safely access dict attributes like .user and .key.
+#       Use the explicit index-based mapping below, or implement a custom filter if you
+#       need automatic formatting.
+# IMPORTANT: Add this validation to your playbook before using this vars file:
+#   - name: Validate admin SSH keys exist
+#     ansible.builtin.assert:
+#       that:
+#         - admin_ssh_keys is defined
+#         - admin_ssh_keys | length >= 1
+#       fail_msg: "admin_ssh_keys must be defined in all.yml with at least one entry"
+gcp_ssh_public_keys:
+  - "{{ admin_ssh_keys[0].user }}:{{ admin_ssh_keys[0].key }}"
+  # Uncomment ONLY if you have 2+ admins defined in admin_ssh_keys:
+  # - "{{ admin_ssh_keys[1].user }}:{{ admin_ssh_keys[1].key }}"
+  # Uncomment ONLY if you have 3+ admins defined in admin_ssh_keys:
+  # - "{{ admin_ssh_keys[2].user }}:{{ admin_ssh_keys[2].key }}"
 
 # Ansible SSH connection settings (optional - defaults to your local username)
 # gcp_ansible_user: "pb"  # Must match the username in gcp_ssh_public_keys

--- a/infrastructure/ansible/group_vars/localhost.vault.yml.example
+++ b/infrastructure/ansible/group_vars/localhost.vault.yml.example
@@ -1,0 +1,113 @@
+# M2S Master Vault - Single Source of Truth
+#
+# ⚠️  CRITICAL: This is the MASTER vault file - all other vaults are symlinks to this!
+#
+# This file is the canonical example vault definition.
+# Other example or per-environment vault templates should treat THIS file as authoritative.
+# If they differ, update the other files to match this example and its documentation.
+#
+# VAULT ARCHITECTURE: One Vault To Rule Them All
+#
+#   Master vault (YOU ARE HERE):
+#     group_vars/localhost/vault.yml  ← MASTER (single source of truth)
+#
+#   Symlinked vaults (point to master):
+#     group_vars/gcp_app/vault.yml → ../localhost/vault.yml
+#     group_vars/gcp_provisioner/vault.yml → ../localhost/vault.yml
+#
+#   Specialized vaults (different structure):
+#     group_vars/gcp_mail/vault.yml (SMTP2Go API credentials - different structure)
+#     group_vars/single_host/vault.yml (dev/test - different vault password, deprecated)
+#
+# SETUP INSTRUCTIONS:
+#
+# 1. Create vault password file (if not already done):
+#    echo "your-secure-vault-password" > ~/.ansible_vault_pass
+#    chmod 600 ~/.ansible_vault_pass
+#
+# 2. Create the master vault from this template:
+#    mkdir -p group_vars/localhost
+#    cp group_vars/localhost.vault.yml.example group_vars/localhost/vault.yml
+#    # Edit vault.yml and fill in real secrets
+#    ansible-vault encrypt group_vars/localhost/vault.yml \
+#      --vault-password-file ~/.ansible_vault_pass
+#
+# 3. Create symlinks from other locations:
+#    mkdir -p group_vars/gcp_app
+#    mkdir -p group_vars/gcp_provisioner
+#    ln -sf ../localhost/vault.yml group_vars/gcp_app/vault.yml
+#    ln -sf ../localhost/vault.yml group_vars/gcp_provisioner/vault.yml
+#
+# TO EDIT LATER:
+#    ansible-vault edit group_vars/localhost/vault.yml \
+#      --vault-password-file ~/.ansible_vault_pass
+#
+# TO VIEW:
+#    ansible-vault view group_vars/localhost/vault.yml \
+#      --vault-password-file ~/.ansible_vault_pass
+#
+# GENERATE SECRETS:
+#   PostgreSQL password: openssl rand -base64 32
+#   Django secret key: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+#   Mail API key: (get from K8s: kubectl get secret -n tenant-ssc manage2soar-env-ssc -o jsonpath='{.data.M2S_MAIL_API_KEY}' | base64 -d)
+#   SMTP relay: (get from SMTP2Go dashboard)
+#   OAuth: (get from Google Cloud Console)
+
+---
+# ============================================================
+# DJANGO SECRETS
+# ============================================================
+
+# Django secret key (required, 50+ characters)
+# Generate with: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+vault_django_secret_key: "REPLACE-ME-WITH-DJANGO-SECRET-KEY-FROM-GENERATOR"
+
+# ============================================================
+# POSTGRESQL PASSWORDS
+# ============================================================
+# Generate with: openssl rand -base64 32
+
+# Single-tenant mode password (deprecated)
+vault_postgresql_password: "REPLACE-WITH-32-CHAR-PASSWORD"
+
+# Multi-tenant passwords (one per club)
+vault_postgresql_password_ssc: "REPLACE-WITH-SSC-DATABASE-PASSWORD"
+vault_postgresql_password_masa: "REPLACE-WITH-MASA-DATABASE-PASSWORD"
+# vault_postgresql_password_nfss: "nfss-database-password-32-chars"
+
+# ============================================================
+# MAIL CREDENTIALS
+# ============================================================
+
+# Django's direct SMTP API key (used by Django to send mail via SMTP2Go API)
+# Get from K8s production: kubectl get secret -n tenant-ssc manage2soar-env-ssc -o jsonpath='{.data.M2S_MAIL_API_KEY}' | base64 -d
+vault_smtp_password: "REPLACE-WITH-SMTP2GO-API-KEY"
+
+# ============================================================
+# SMTP RELAY CREDENTIALS (for Postfix mail server)
+# ============================================================
+# NOTE: These are DIFFERENT from Django's SMTP API key above
+# Get from SMTP2Go dashboard → Settings → Users
+# Used by Postfix to relay mail through [mail.smtp2go.com]:587
+
+# External SMTP relay credentials (used by m2s-mail server)
+vault_smtp_relay_username: "example-smtp-username"
+vault_smtp_relay_password: "example-smtp-password-replace-with-real-value"
+
+# ============================================================
+# GOOGLE OAUTH CREDENTIALS (OPTIONAL)
+# ============================================================
+# Get from: https://console.cloud.google.com/apis/credentials
+# Leave commented out to disable Google OAuth login
+
+# vault_google_oauth_client_id: "REPLACE-WITH-OAUTH-CLIENT-ID.apps.googleusercontent.com"
+# vault_google_oauth_client_secret: "REPLACE-WITH-OAUTH-CLIENT-SECRET"
+
+# ============================================================
+# GCP SERVICE ACCOUNT CREDENTIALS (OPTIONAL)
+# ============================================================
+# Only needed for GCP API access (Cloud Storage, etc.)
+
+# vault_gcp_project_id: "REPLACE-WITH-GCP-PROJECT-ID"
+# vault_gcp_service_account_email: "REPLACE-WITH-SERVICE-ACCOUNT@project.iam.gserviceaccount.com"
+# vault_gcp_service_account_key: "REPLACE-WITH-SERVICE-ACCOUNT-JSON-KEY"

--- a/infrastructure/ansible/group_vars/single_host.vault.yml.example
+++ b/infrastructure/ansible/group_vars/single_host.vault.yml.example
@@ -1,21 +1,21 @@
-# Single-Host Deployment Secrets - vault.yml Example
+# Single-Host Deployment Secrets
 #
-# This file should be encrypted with ansible-vault.
+# ⚠️  DEPRECATED: Single-host deployment mode is no longer actively maintained.
 #
-# SETUP INSTRUCTIONS:
-# 1. Create vault password file:
-#      echo "your-secure-vault-password" > ~/.ansible_vault_pass
-#      chmod 600 ~/.ansible_vault_pass
+# RECOMMENDED: Use GCP multi-tenant deployment with the master vault:
+#   group_vars/localhost/vault.yml (master - single source of truth)
 #
-# 2. Create the encrypted vault file:
+# See: group_vars/localhost.vault.yml.example for full documentation
+#
+# If you still need single-host deployment:
+# 1. This vault file uses a DIFFERENT password than the master vault
+# 2. Create separate vault password file:
+#      echo "your-single-host-vault-password" > ~/.ansible_vault_pass_single_host
+#      chmod 600 ~/.ansible_vault_pass_single_host
+#
+# 3. Create the encrypted vault file:
 #      ansible-vault create group_vars/single_host/vault.yml \
-#        --vault-password-file ~/.ansible_vault_pass
-#
-# 3. Paste the contents below and customize:
-#
-# 4. To edit later:
-#      ansible-vault edit group_vars/single_host/vault.yml \
-#        --vault-password-file ~/.ansible_vault_pass
+#        --vault-password-file ~/.ansible_vault_pass_single_host
 #
 # GENERATE SECRETS:
 #   PostgreSQL password: openssl rand -base64 32

--- a/infrastructure/ansible/roles/common/tasks/main.yml
+++ b/infrastructure/ansible/roles/common/tasks/main.yml
@@ -31,6 +31,43 @@
       - mailutils
     state: present
 
+- name: Validate SSH key format
+  ansible.builtin.assert:
+    that:
+      - item.key is defined
+      - item.key | length > 0
+      - item.key is match('^(ssh-rsa|ssh-ed25519|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521) ')
+    fail_msg: "Invalid SSH key format for user {{ item.user }}: {{ (item.key | default('key not defined'))[:50] }}..."
+    quiet: yes
+  loop: "{{ admin_ssh_keys }}"
+  when: admin_ssh_keys is defined
+
+- name: Create admin user accounts for SSH access
+  ansible.builtin.user:
+    name: "{{ item.user }}"
+    shell: /bin/bash
+    create_home: yes
+    state: present
+  loop: "{{ admin_ssh_keys }}"
+  when: admin_ssh_keys is defined
+
+- name: Add SSH keys to admin user authorized_keys
+  ansible.posix.authorized_key:
+    user: "{{ item.user }}"
+    key: "{{ item.key }}"
+    state: present
+    exclusive: no
+  loop: "{{ admin_ssh_keys }}"
+  when: admin_ssh_keys is defined
+
+- name: Add admin users to sudo group
+  ansible.builtin.user:
+    name: "{{ item.user }}"
+    groups: sudo
+    append: yes
+  loop: "{{ admin_ssh_keys }}"
+  when: admin_ssh_keys is defined
+
 - name: Configure UFW defaults
   community.general.ufw:
     direction: "{{ item.direction }}"
@@ -39,11 +76,21 @@
     - { direction: incoming, policy: deny }
     - { direction: outgoing, policy: allow }
 
-- name: Allow SSH
+- name: Allow SSH from specific IPs (if configured)
   community.general.ufw:
     rule: allow
     port: "22"
     proto: tcp
+    from_ip: "{{ item }}"
+  loop: "{{ admin_ssh_ips }}"
+  when: admin_ssh_ips is defined and admin_ssh_ips | length > 0
+
+- name: Allow SSH from anywhere (if no IPs configured)
+  community.general.ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+  when: admin_ssh_ips is not defined or admin_ssh_ips | length == 0
 
 - name: Allow SMTP
   community.general.ufw:

--- a/infrastructure/ansible/roles/postgresql/defaults/main.yml
+++ b/infrastructure/ansible/roles/postgresql/defaults/main.yml
@@ -20,6 +20,13 @@ postgresql_user: "m2s"
 # Enable multi-tenant mode (one database per tenant)
 postgresql_multi_tenant: false
 
+# Update passwords for existing users (default: false to prevent production outages)
+# Set to true ONLY when intentionally rotating passwords
+# WARNING: Changing this to true will update PostgreSQL user passwords.
+# You MUST then manually update K8s secrets AND restart Django pods,
+# or the applications will lose database connectivity.
+postgresql_update_existing_passwords: false
+
 # List of tenants (used when postgresql_multi_tenant is true)
 # Each tenant gets their own database: m2s_{prefix}
 postgresql_tenants: []

--- a/infrastructure/ansible/roles/postgresql/tasks/tenant.yml
+++ b/infrastructure/ansible/roles/postgresql/tasks/tenant.yml
@@ -1,7 +1,20 @@
 # PostgreSQL Multi-Tenant Database/User Creation Tasks
 # Called in a loop for each tenant
 ---
+- name: "Check if database user exists for tenant: {{ tenant.prefix }}"
+  community.postgresql.postgresql_query:
+    query: "SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = %s) as user_exists"
+    positional_args:
+      - "m2s_{{ tenant.prefix }}"
+  become: true
+  become_user: postgres
+  register: user_exists_check
+  changed_when: false
+
 - name: "Create database user for tenant: {{ tenant.prefix }}"
+  # NOTE: When postgresql_update_existing_passwords is true, this task always reports 'changed'
+  # even if the password is already correct, because the module re-applies role attributes
+  # (NOSUPERUSER, NOCREATEDB). This is safe but means 'changed' doesn't confirm password change.
   community.postgresql.postgresql_user:
     name: "m2s_{{ tenant.prefix }}"
     password: "{{ tenant.password }}"
@@ -10,6 +23,17 @@
   become: true
   become_user: postgres
   no_log: true
+  when: not user_exists_check.query_result[0].user_exists or postgresql_update_existing_passwords | default(false)
+
+- name: "Warn about skipping password update for tenant: {{ tenant.prefix }}"
+  ansible.builtin.debug:
+    msg: |
+      ⚠️  User m2s_{{ tenant.prefix }} already exists - password NOT updated
+      To update passwords, set postgresql_update_existing_passwords: true
+      WARNING: This will break Django apps until K8s secrets are updated!
+  when:
+    - user_exists_check.query_result[0].user_exists
+    - not (postgresql_update_existing_passwords | default(false))
 
 - name: "Create database for tenant: {{ tenant.prefix }}"
   community.postgresql.postgresql_db:


### PR DESCRIPTION
## 🚨 CRITICAL FIX: Prevent Accidental Password Resets

This PR prevents production outages caused by Ansible playbook runs accidentally resetting PostgreSQL passwords and breaking Django app database connectivity.

## What Happened

Production incident timeline:
1. Ran `gcp-database.yml` playbook to update UFW firewall rules
2. Playbook **silently reset PostgreSQL user passwords** to Ansible vault values
3. Django apps in K8s used different passwords → immediate production outage
4. All websites returned HTTP 500 (database authentication failures)
5. Emergency fix: Reset PostgreSQL passwords back to match K8s secrets

## Root Cause

The `community.postgresql.postgresql_user` module **always updates passwords** when run, even for existing users. There was no safeguard to prevent this during routine infrastructure updates.

Additionally, discovered **massive vault drift** - 5 separate vault files with different secrets, none synchronized with production K8s.

## Solution

### 1. Password Update Protection (Default: Safe Mode)

Added `postgresql_update_existing_passwords: false` flag to PostgreSQL role:

```yaml
# roles/postgresql/defaults/main.yml
postgresql_update_existing_passwords: false  # Prevents accidental resets
```

When playbook runs, existing users now show:
```
⚠️  User m2s_ssc already exists - password NOT updated
To update passwords, set postgresql_update_existing_passwords: true
WARNING: This will break Django apps until K8s secrets are updated!
```

### 2. Vault Consolidation: One Vault To Rule Them All

**Master vault** (single source of truth):
```
group_vars/localhost/vault.yml  ← MASTER
```

**Symlinked vaults** (point to master):
- `group_vars/gcp_app/vault.yml` → `../localhost/vault.yml`
- `group_vars/gcp_provisioner/vault.yml` → `../localhost/vault.yml`

**Specialized vaults** (different structure):
- `group_vars/gcp_mail/vault.yml` (SMTP2Go API)
- `group_vars/single_host/vault.yml` (deprecated)

**Why**: Single source of truth prevents drift, simplifies secret management, enforces IaC-first philosophy.

### 3. Comprehensive Runbook Documentation

Added to `docs/runbooks/ansible-playbook-guide.md`:

- **🔐 Vault Architecture** section documenting master vault + symlinks
- **🔑 PostgreSQL Password Management** section with:
  - Password synchronization architecture diagram
  - Syncing vault to match production (recommended workflow)
  - 6-step intentional password rotation procedure
  - Emergency recovery procedures with IaC-first warnings
- **🔐 Managing Admin SSH Access** section with DRY configuration
- Fixed firewall documentation (`--tags gcp-provision` not `--tags firewall`)

### 4. Security Improvements (from Copilot Review)

**Security fixes:**
- Replaced `/tmp` password files with environment variables (no world-writable directory risk)
- Fixed SQL injection vulnerability using proper quote escaping
- Replaced hardcoded IPs with `gcloud compute ssh` commands

**Code quality fixes:**
- Used `EXISTS` query instead of unreliable `rowcount` for user checks
- Fixed YAML syntax ambiguities in example files
- Added SSH key format validation
- Added idempotency checks for user/group operations

### 5. Vault Example Files Updated

**Created:**
- ✨ **NEW**: `localhost.vault.yml.example` - comprehensive master vault template

**Updated:**
- `gcp_app.vault.yml.example` - Instructs to create symlink to master
- `gcp_database.vault.yml.example` - References master vault for passwords
- `single_host.vault.yml.example` - Marked as deprecated
- Playbooks directory examples - Added canonical location notes

### 6. DRY Admin SSH Configuration

**Before**: Admin IPs hardcoded in 13+ locations  
**After**: Single source of truth in `group_vars/all.yml`

```yaml
admin_ssh_keys:
  - user: "pb"
    name: "Piet Barber"
    key: "ssh-ed25519 AAAAC3..."
    ip: "138.88.187.144/32"

admin_ssh_ips: "{{ admin_ssh_keys | map(attribute='ip') | list }}"
```

## Changes

**Infrastructure Code:**
- `roles/postgresql/defaults/main.yml`: Added password protection flag
- `roles/postgresql/tasks/tenant.yml`: User existence check + conditional updates
- `roles/common/tasks/main.yml`: Added SSH key validation and error handling
- `group_vars/all.yml`: Centralized admin SSH configuration

**Documentation:**
- `docs/runbooks/ansible-playbook-guide.md`: 
  - Vault architecture section
  - Password management section with 6-step rotation procedure
  - Admin SSH access section
  - Fixed firewall commands
  - Two-layer firewall architecture explanation

**Example Files:**
- **NEW**: `localhost.vault.yml.example` - Master vault template
- Updated: `gcp_app.vault.yml.example`, `gcp_database.vault.yml.example`, `single_host.vault.yml.example`
- Updated: All corresponding playbooks directory examples

## Testing

✅ Ansible vault synced with production K8s secrets  
✅ Production websites operational (HTTP 200)  
✅ Django apps connecting to database successfully  
✅ Comprehensive audit: secrets, database, mail all healthy  
✅ Both SSC and MASA sites verified operational  
✅ Playbook dry run shows password protection working  

## Migration Path

**For Future Playbook Runs:**

Normal infrastructure updates (firewall, SSL, backups) will now skip password updates automatically. Users see warning messages but operations continue safely.

**For Intentional Password Rotation:**

Use `-e "postgresql_update_existing_passwords=true"` flag and follow documented 6-step procedure including K8s secret updates and pod restarts.

## Impact

**Before:** Running database playbook could silently break production  
**After:** Password updates require explicit flag and show clear warnings

**Before:** 5 vault files with different secrets, drift from production  
**After:** Single master vault, symlinks for consistency, no drift

## Related Issues

- Fixes follow-up issue from PR #604 (co-webmaster access)
- Prevents recurrence of production password reset outages
- Eliminates vault drift discovered during incident investigation

## Checklist

- [x] Ansible vault synced with production
- [x] Password protection flag added
- [x] Vault consolidation complete (One Vault To Rule Them All)
- [x] Runbook documentation complete
- [x] Security fixes from Copilot review applied
- [x] Vault example files updated
- [x] Production verified operational
- [x] Pre-commit hooks passing
