### PR TITLE
fix: remove unused nltk dependency (CVE-2025-14009)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,6 @@ mccabe==0.7.0
 mdurl==0.1.2
 msgpack==1.1.2
 mypy_extensions==1.1.0
-nltk==3.9.2
 nodeenv==1.9.1
 oauthlib==3.3.1
 ortools==9.12.4544


### PR DESCRIPTION
## Summary

Removes the unused `nltk==3.9.2` dependency to resolve Dependabot alert # 23.

**CVE-2025-14009** — NLTK Zip Slip vulnerability (critical severity). No patched version exists yet, so removal is the only available remediation.

## Why safe to remove

`nltk` was never imported anywhere in the application codebase (`grep` for `import nltk` / `from nltk` returns zero results). It appears to have been added speculatively or as a leftover from an experiment that was never completed.

## Testing

Removing it has no impact on any test — full test suite passes unchanged.