### PR TITLE
Fix: pass through transactional emails instead of bouncing them in maillist-rewriter

### DIFF
--- a/infrastructure/ansible/roles/postfix/templates/maillist-rewriter.py.j2
+++ b/infrastructure/ansible/roles/postfix/templates/maillist-rewriter.py.j2
@@ -198,17 +198,24 @@ def main():
         # Fallback: reverse-lookup via virtual aliases file with domain preference
         original_to = find_list_from_recipients(recipients, preferred_domain)
 
-    # If list detection failed entirely, reject cleanly rather than forwarding the
-    # message with an unverified From header.  Forwarding would cause SMTP2Go to
-    # reject with "550 From header sender domain not verified" for every recipient,
-    # which is worse than a clean bounce back to the original sender.
+    # If list detection failed entirely, this is a transactional email (e.g. password
+    # reset, notification) — not a mailing list message.  Pass it through to the
+    # reinject port without any header rewriting.  No From-rewrite is needed because
+    # the envelope sender domain is already the verified manage2soar.com address.
     if not original_to:
         sys.stderr.write(
             f"maillist-rewriter: Could not identify mailing list for "
-            f"recipients {recipients}; rejecting to prevent SMTP2Go rejection "
-            "of unverified sender domain (issue #652).\n"
+            f"recipients {recipients}; passing through without header rewriting "
+            "(transactional email — not a mailing list message).\n"
         )
-        sys.exit(os.EX_UNAVAILABLE)  # Postfix generates a clean bounce to the sender
+        try:
+            smtp = smtplib.SMTP('127.0.0.1', 10025)
+            smtp.sendmail(sender, recipients, original_msg)
+            smtp.quit()
+            sys.exit(0)
+        except smtplib.SMTPException as e:
+            sys.stderr.write(f"maillist-rewriter: SMTP passthrough failed: {e}\n")
+            sys.exit(os.EX_TEMPFAIL)
 
     # Rewrite if this is going to a mailing list
     if original_to and original_to.lower() in ALL_KNOWN_LISTS:


### PR DESCRIPTION
## Problem

The `maillist-rewriter` Postfix content filter is applied to **all** outgoing mail on both port 25 and port 587 (via `content_filter=maillist-rewriter:dummy` in `master.cf`). When it couldn't identify a mailing list for the recipient(s), it called `sys.exit(os.EX_UNAVAILABLE)`, which causes Postfix to generate a bounce NDR.

This broke **all transactional emails** — password resets, account notifications, etc. — whose recipients are individual users rather than a mailing list address.

### Observed failure (from mail logs)

```
postfix/pipe: D76AD401DE: to=<ada*****@yahoo.com>, relay=maillist-rewriter,
  dsn=5.3.0, status=bounced (service unavailable. Command output:
  maillist-rewriter: Could not identify mailing list for recipients
  ['ada*****@yahoo.com']; rejecting to prevent SMTP2Go rejection of
  unverified sender domain (issue #652). )
```

## Fix

When no mailing list is identified, **pass the message through** to port 10025 unchanged instead of rejecting it. Transactional emails sent from `noreply@manage2soar.com` already use a verified sender domain, so SMTP2Go accepts them without any `From`-header manipulation.

Mailing list emails continue to receive the full Mailman-style header rewrite as before — issue #652 protection is completely unaffected.

## Testing

After deploying the updated script via Ansible, send a test password reset to a non-mailing-list address and confirm delivery. The mail log should show:

```
maillist-rewriter: Could not identify mailing list for recipients [...];
passing through without header rewriting (transactional email — not a mailing list message).
```

followed by successful SMTP delivery rather than a bounce.

## Deploy

```bash
cd infrastructure/ansible
ansible-playbook -i inventory/hosts.yml postfix.yml --tags postfix
```