### PR TITLE
fix: stop comment text leaking into HTML from _student_record_links include

### DIFF
--- a/duty_roster/templates/duty_roster/_student_record_links.html
+++ b/duty_roster/templates/duty_roster/_student_record_links.html
@@ -1,8 +1,9 @@
-{# Reusable snippet: Training Grid + Instruction Record icon links for a student.
-   Expected variables:
-     student    – the Member object
-     link_class – optional extra CSS class on the <a> tags (default: "ms-1")
-#}
+{% comment %}
+Reusable snippet: Training Grid + Instruction Record icon links for a student.
+Expected variables:
+  student    – the Member object
+  link_class – optional extra CSS class on the <a> tags (default: "ms-1")
+{% endcomment %}
 {% with lc=link_class|default:"ms-1" %}
 <a href="{% url 'instructors:member_training_grid' member_id=student.pk %}"
    class="{{ lc }} text-muted"


### PR DESCRIPTION
## Bug

The include snippet `duty_roster/_student_record_links.html` (added in #699) used a multi-line `{# ... #}` comment block. Django's `{# #}` syntax **only supports single-line comments** — multi-line content between the delimiters is passed through to the rendered output as plain text, causing the entire docstring to appear verbatim on the page next to every student name.

## Fix

Replace the `{# ... #}` block with `{% comment %}...{% endcomment %}`, which is the correct Django tag for multi-line comments.

## Root Cause

This was introduced during the PR #699 review cycle when the Copilot reviewer suggested extracting the repeated link markup into a shared include. The comment syntax bug was not caught in tests because template rendering tests don't assert on the absence of leaked comment text.

Fixes the production regression visible in the screenshot (comment text appearing after each student's name on the instructor requests page).