### PR TITLE
Analytics: Bootstrap 5 migration + mobile UX fixes (Issue #721)

### DIFF
--- a/analytics/templates/analytics/dashboard.html
+++ b/analytics/templates/analytics/dashboard.html
@@ -1,26 +1,27 @@
 {% extends "base.html" %}
 {% load static %}
 {% load json_script %}
+{% block page_container_class %}container-fluid px-2 px-sm-3{% endblock %}
 {% block content %}
-<div class="container mt-4">
+<div class="mt-4">
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h2 class="mb-0">Operations Analytics</h2>
   </div>
 
   <form class="row g-2 mb-4" id="annual-range" action="#annual-range">
-    <div class="col-auto">
+    <div class="col-6 col-sm-auto">
       <label class="form-label">Start</label>
       <input class="form-control" type="number" name="start" value="{{ start }}">
     </div>
-    <div class="col-auto">
+    <div class="col-6 col-sm-auto">
       <label class="form-label">End</label>
       <input class="form-control" type="number" name="end" value="{{ end }}">
     </div>
-    <div class="col-auto form-check mt-4">
+    <div class="col-auto form-check mt-sm-4">
       <input class="form-check-input" type="checkbox" id="all" name="all" value="1" {% if not finalized %}checked{% endif %}>
       <label class="form-check-label" for="all">Include unfinalized</label>
     </div>
-    <div class="col-auto mt-4">
+    <div class="col-auto mt-sm-4">
       <button class="btn btn-primary">Update</button>
     </div>
   </form>
@@ -95,12 +96,12 @@
 
 <div class="alert alert-info py-2 small" id="date-range">
   The charts below show data for the selected date range:<br>
-  <form class="row g-2 align-items-end d-inline-flex" method="get" action="#date-range" style="margin-bottom:0;">
-    <div class="col-auto">
+  <form class="row g-2 align-items-end mt-1" method="get" action="#date-range">
+    <div class="col-12 col-sm-auto">
       <label class="form-label small mb-1">From</label>
       <input class="form-control form-control-sm" type="date" name="util_start" value="{{ util_start }}">
     </div>
-    <div class="col-auto">
+    <div class="col-12 col-sm-auto">
       <label class="form-label small mb-1">To</label>
       <input class="form-control form-control-sm" type="date" name="util_end" value="{{ util_end }}">
     </div>
@@ -123,7 +124,7 @@
       <button class="btn btn-outline-secondary chart-dl" data-type="svg">SVG</button>
       <button class="btn btn-outline-secondary chart-dl" data-type="csv">CSV</button>
     </div>
-    <h5 class="card-title mb-3">
+    <h5 class="card-title mb-3 chart-title-pad">
       Glider Utilization
       <span class="badge bg-info text-dark ms-2">Date range</span>
     </h5>
@@ -293,6 +294,7 @@
       </div>
     </div>
   </div>
+</div>
 
 
 <div class="row">
@@ -366,13 +368,6 @@
 
 </div>
 
-
-
-
-<style>
-  .chart-box { height: 440px; position: relative; }
-  #cumuChart { width: 100% !important; height: 100% !important; display: block; }
-</style>
 
 {{ analytics_data|json_script:"analytics-data" }}
 

--- a/e2e_tests/e2e/test_analytics_dashboard.py
+++ b/e2e_tests/e2e/test_analytics_dashboard.py
@@ -1,0 +1,160 @@
+"""
+E2E tests for the Analytics Dashboard (Issue #721).
+
+Tests Bootstrap 5 migration, mobile viewport layout, chart container sizing,
+and JS download-button interactions.
+"""
+
+from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+
+
+class TestAnalyticsDashboardE2E(DjangoPlaywrightTestCase):
+    """E2E tests for the analytics dashboard page."""
+
+    # ------------------------------------------------------------------ #
+    # Helpers                                                              #
+    # ------------------------------------------------------------------ #
+
+    def _go_to_analytics(self):
+        """Navigate to the analytics dashboard."""
+        self.page.goto(f"{self.live_server_url}/analytics/")
+        # Wait for Chart.js bundle to load (it's deferred)
+        self.page.wait_for_load_state("networkidle", timeout=10_000)
+
+    # ------------------------------------------------------------------ #
+    # Tests                                                                #
+    # ------------------------------------------------------------------ #
+
+    def test_page_loads_for_authenticated_member(self):
+        """Analytics page loads without errors for an authenticated member."""
+        self.create_test_member(username="analyst")
+        self.login(username="analyst")
+
+        self._go_to_analytics()
+
+        # Title is present
+        title = self.page.locator("h2", has_text="Operations Analytics")
+        assert title.is_visible(), "Page heading not found"
+
+        # No Django error page
+        body_text = self.page.inner_text("body")
+        assert "Server Error" not in body_text
+        assert "Exception Value" not in body_text
+
+    def test_chart_canvases_present(self):
+        """All expected chart canvas elements are rendered."""
+        self.create_test_member(username="analyst")
+        self.login(username="analyst")
+        self._go_to_analytics()
+
+        expected_canvas_ids = [
+            "cumuChart",
+            "byAcftChart",
+            "timeOpsChart",
+            "utilChart",
+            "utilPrivChart",
+            "fdChart",
+            "pgfChart",
+            "durChart",
+            "instChart",
+            "towChart",
+            "long3hChart",
+            "dutyChart",
+            "towSchedChart",
+            "instSchedChart",
+            "combinedDutyChart",
+        ]
+        for canvas_id in expected_canvas_ids:
+            canvas = self.page.locator(f"#{canvas_id}")
+            assert canvas.count() == 1, f"Canvas #{canvas_id} missing from page"
+
+    def test_chart_download_buttons_present(self):
+        """Each chart card contains PNG / SVG / CSV download buttons."""
+        self.create_test_member(username="analyst")
+        self.login(username="analyst")
+        self._go_to_analytics()
+
+        # There should be 3 × (number of charts) = 45 download buttons total
+        download_buttons = self.page.locator("button.chart-dl")
+        count = download_buttons.count()
+        assert count > 0, "No chart download buttons found"
+        # Each chart card contributes 3 buttons (PNG, SVG, CSV)
+        assert count % 3 == 0, f"Expected groups of 3 download buttons, got {count}"
+
+    def test_annual_range_form_visible(self):
+        """The year-range filter form is present and has the expected inputs."""
+        self.create_test_member(username="analyst")
+        self.login(username="analyst")
+        self._go_to_analytics()
+
+        form = self.page.locator("#annual-range")
+        assert form.is_visible(), "Annual range form not visible"
+
+        start_input = form.locator("input[name='start']")
+        end_input = form.locator("input[name='end']")
+        assert start_input.count() == 1, "Start year input missing"
+        assert end_input.count() == 1, "End year input missing"
+
+    def test_date_range_form_visible(self):
+        """The date-range filter form inside the info alert is present."""
+        self.create_test_member(username="analyst")
+        self.login(username="analyst")
+        self._go_to_analytics()
+
+        form = self.page.locator("#date-range form")
+        assert form.count() == 1, "Date-range form not found"
+
+        util_start = form.locator("input[name='util_start']")
+        util_end = form.locator("input[name='util_end']")
+        assert util_start.count() == 1, "util_start date input missing"
+        assert util_end.count() == 1, "util_end date input missing"
+
+    def test_no_horizontal_overflow_on_mobile_viewport(self):
+        """Page does not overflow horizontally at 390px (iPhone 12 width)."""
+        self.create_test_member(username="analyst")
+        self.login(username="analyst")
+
+        # Set mobile viewport
+        self.page.set_viewport_size({"width": 390, "height": 844})
+        self._go_to_analytics()
+
+        # document.documentElement.scrollWidth should not exceed the viewport width
+        scroll_width = self.page.evaluate("document.documentElement.scrollWidth")
+        viewport_width = self.page.evaluate("window.innerWidth")
+        assert scroll_width <= viewport_width, (
+            f"Horizontal overflow detected: scrollWidth={scroll_width}px "
+            f"> viewportWidth={viewport_width}px"
+        )
+
+    def test_chart_containers_have_nonzero_height_on_mobile(self):
+        """Chart containers are visible with non-zero height on a mobile viewport."""
+        self.create_test_member(username="analyst")
+        self.login(username="analyst")
+
+        self.page.set_viewport_size({"width": 390, "height": 844})
+        self._go_to_analytics()
+
+        # Check the first chart box
+        chart_box = self.page.locator(".chart-box").first
+        assert chart_box.is_visible(), "First .chart-box is not visible on mobile"
+
+        bounding_box = chart_box.bounding_box()
+        assert bounding_box is not None, "Could not get bounding box of chart-box"
+        assert (
+            bounding_box["height"] > 0
+        ), f"Chart box has zero height on mobile: {bounding_box}"
+
+    def test_no_horizontal_overflow_on_pixel_viewport(self):
+        """Page does not overflow horizontally at 412px (Pixel 9 width)."""
+        self.create_test_member(username="analyst")
+        self.login(username="analyst")
+
+        self.page.set_viewport_size({"width": 412, "height": 915})
+        self._go_to_analytics()
+
+        scroll_width = self.page.evaluate("document.documentElement.scrollWidth")
+        viewport_width = self.page.evaluate("window.innerWidth")
+        assert scroll_width <= viewport_width, (
+            f"Horizontal overflow at 412px: scrollWidth={scroll_width}px "
+            f"> viewportWidth={viewport_width}px"
+        )

--- a/static/analytics/analytics.css
+++ b/static/analytics/analytics.css
@@ -54,8 +54,26 @@
 
 /* ========= Responsive tweaks ========= */
 @media (max-width: 576px){
-  .chart-box{ height: 320px; }
-  .chart-box--xl{ height: 420px; }
+  :root {
+    --chart-title-pr: 4rem;
+  }
+  .chart-box        { height: 280px; }
+  .chart-box--short { height: 220px; }
+  .chart-box--tall  { height: 340px; }
+  .chart-box--xl    { height: 380px; }
+}
+
+/* Very narrow phones (≤430px) */
+@media (max-width: 430px){
+  :root {
+    --chart-title-pr: 3.5rem;
+  }
+  .chart-box        { height: 240px; }
+  .chart-box--short { height: 190px; }
+  .chart-box--tall  { height: 300px; }
+  .chart-box--xl    { height: 340px; }
+  /* Keep tool buttons compact on very small screens */
+  .chart-tools .btn { padding: .15rem .35rem; font-size: .75rem; }
 }
 
 /* ========= Print: hide controls, compress heights ========= */

--- a/templates/base.html
+++ b/templates/base.html
@@ -328,7 +328,7 @@
   <!-- Spacer to prevent content from hiding behind fixed navbar -->
   <div class="navbar-spacer"></div>
 
-  <div class="container">
+  <div class="{% block page_container_class %}container{% endblock %}">
     {% if user.is_authenticated %}
       {% include "notifications/notifications_dropdown.html" %}
     {% endif %}


### PR DESCRIPTION
## Summary

Resolves #721

## Changes

### Template fixes
- **Eliminated double container**: added `{% block page_container_class %}` to `base.html` so the analytics page can use `container-fluid px-2 px-sm-3` — removes the large wasted margins on ≤430px phones
- Fixed unclosed `</div>` on the "Long flights & Duty assignments" `<div class="row">`
- Date-range form: removed `d-inline-flex` + inline style; date pickers now stack full-width on mobile (`col-12 col-sm-auto`)
- Annual-range form: Start/End inputs use `col-6 col-sm-auto` (side-by-side on mobile); checkbox/button use `mt-sm-4` instead of `mt-4`
- Added missing `chart-title-pad` class to Glider Utilization heading
- Removed redundant inline `<style>` block that duplicated `analytics.css`

### CSS improvements (`static/analytics/analytics.css`)
- Full responsive height reductions at ≤576px and ≤430px for all four chart-box variants
- Compact tool button padding at ≤430px
- Reduced `--chart-title-pr` at narrow widths to prevent title/badge overlap

### Base template (`templates/base.html`)
- Added `{% block page_container_class %}container{% endblock %}` — all existing pages unaffected

### E2E tests
- New `TestAnalyticsDashboardE2E` suite covering page load, all 15 chart canvases, download buttons, form structure, and horizontal-overflow assertions at 390px (iPhone 12) and 412px (Pixel 9)