### PR TITLE
Add make/model fields to Towplane admin interface (#724)

### DIFF
--- a/logsheet/admin.py
+++ b/logsheet/admin.py
@@ -53,6 +53,8 @@ class TowplaneAdmin(AdminHelperMixin, admin.ModelAdmin):
 
     list_display = (
         "name",
+        "make",
+        "model",
         "n_number",
         "is_active",
         "oil_change_interval",
@@ -61,11 +63,23 @@ class TowplaneAdmin(AdminHelperMixin, admin.ModelAdmin):
         "next_100hr_due",
     )
     list_filter = ("is_active", "requires_100hr_inspection")
-    search_fields = ("name", "n_number")
+    search_fields = ("name", "make", "model", "n_number")
     readonly_fields = ("photo_preview",)
     exclude = ("photo_medium", "photo_small")
     fieldsets = (
-        (None, {"fields": ("name", "n_number", "is_active", "club_owned")}),
+        (
+            None,
+            {
+                "fields": (
+                    "name",
+                    "make",
+                    "model",
+                    "n_number",
+                    "is_active",
+                    "club_owned",
+                )
+            },
+        ),
         ("Photo", {"fields": ("photo", "photo_preview")}),
         ("Rental Rates", {"fields": ("hourly_rental_rate",)}),
         ("Oil Change", {"fields": ("oil_change_interval", "next_oil_change_due")}),


### PR DESCRIPTION
## Summary

Fixes #724 — The Django admin interface for the `logsheet` app was missing the `make` and `model` fields for towplanes.

The `make` and `model` fields already existed on the `Towplane` model but were excluded from the admin `fieldsets`, making them invisible and un-editable in the admin UI.

## Changes

**`logsheet/admin.py` — `TowplaneAdmin`:**
- Added `make` and `model` to `list_display` (visible in the towplane changelist)
- Added `make` and `model` to `search_fields` (searchable by make/model)
- Added `make` and `model` to the first fieldset (editable on the add/change form)

## No migrations needed

Both fields were already on the model. This is a pure admin UI change.