### PR TITLE
Make user-submitted feedback fields read-only in admin (#597)

### DIFF
--- a/cms/admin.py
+++ b/cms/admin.py
@@ -468,10 +468,13 @@ class SiteFeedbackAdmin(admin.ModelAdmin):
     search_fields = ("subject", "user__first_name", "user__last_name", "message")
     readonly_fields = (
         "user",
+        "feedback_type",
+        "subject",
+        "message",
+        "referring_url",
         "created_at",
         "updated_at",
         "responded_by",
-        "referring_url",
     )
 
     # Group fields logically


### PR DESCRIPTION
## Summary

Fixes #597 — The Django admin for `SiteFeedback` allowed webmasters to edit the member's original message, subject, and feedback type. These are user-submitted fields and should be immutable.

## Root Cause

`SiteFeedbackAdmin.readonly_fields` only listed `user`, `created_at`, `updated_at`, `responded_by`, and `referring_url`. The `message`, `subject`, and `feedback_type` fields — all submitted by the user — were left editable.

## Change

**`cms/admin.py` — `SiteFeedbackAdmin.readonly_fields`:**

Added the following to `readonly_fields`:
- `message` — the customer's submitted message body (primary field from the issue)
- `subject` — user-provided subject line
- `feedback_type` — bug/feature/general as submitted by the user

**Still editable by staff:**
- `status` — open / in_progress / resolved / closed
- `admin_response` — webmaster's reply
- `resolved_at` — resolution timestamp

No model changes, no migrations needed.