### PR TITLE
Add 4 missing member-facing nav links to navbar (#711)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -136,6 +136,9 @@
                 <a class="dropdown-item" href="{% url 'duty_roster:my_swap_requests' %}"><i class="fas fa-exchange-alt me-1"></i> My Swap Requests</a>
               </li>
               <li class="nav-item">
+                <a class="dropdown-item" href="{% url 'duty_roster:my_instruction_requests' %}"><i class="fas fa-chalkboard-teacher me-1"></i> My Instruction Requests</a>
+              </li>
+              <li class="nav-item">
                 <a class="dropdown-item" href="{% url 'duty_roster:open_swap_requests' %}"><i class="fas fa-hands-helping me-1"></i> Help Others</a>
               </li>
               {% if siteconfig.allow_glider_reservations %}
@@ -249,6 +252,9 @@
                 <a class="dropdown-item" href="{% url 'logsheet:maintenance_issues' %}">🔧 Maintenance Issues</a>
               </li>
               <li class="nav-item">
+                <a class="dropdown-item" href="{% url 'logsheet:maintenance_log' %}">📋 Maintenance Log</a>
+              </li>
+              <li class="nav-item">
                 <a class="dropdown-item" href="{% url 'logsheet:maintenance_deadlines' %}">⏰ Maintenance Deadlines</a>
               </li>
               {% webcam_enabled as webcam_feature_on %}
@@ -291,6 +297,10 @@
                 <i class="fas fa-book me-1"></i> View Training Syllabus
               </a></li>
               <li><a class="dropdown-item" href="{% url 'instructors:member_logbook' %}">🗒️ My Logbook</a></li>
+              <li><a class="dropdown-item" href="{% url 'knowledgetest:quiz-pending' %}">📝 My Pending Tests</a></li>
+              <li><a class="dropdown-item" href="{% url 'knowledgetest:member-test-history' %}">📊 My Test History</a></li>
+              <li><hr class="dropdown-divider"></li>
+              <li><a class="dropdown-item" href="{% url 'members:safety_report_submit' %}">💡 Suggestion Box</a></li>
               {% if user.glider_rating != "private" and user.glider_rating != "commercial" %}
               <li><hr class="dropdown-divider"></li>
               <li><a class="dropdown-item" href="{% url 'instructors:needed_for_solo' member_id=user.pk %}">


### PR DESCRIPTION
## Summary

Fixes #711 — Several member-facing pages existed and worked but had no navbar entry, making them impossible to discover without knowing the direct URL.

All URLs were already implemented and functional. This is a pure navigation/discoverability fix in `templates/base.html`.

## Changes

### Duty Roster dropdown (active members)
- Added **"My Instruction Requests"** after "My Swap Requests"
  → `duty_roster:my_instruction_requests` (`/duty_roster/instruction/my-requests/`)

### Equipment dropdown
- Added **"Maintenance Log"** between Maintenance Issues and Maintenance Deadlines
  → `logsheet:maintenance_log` (`/logsheet/maintenance/log/`)

### User dropdown (authenticated members)
- Added **"My Pending Tests"** after "My Logbook"
  → `knowledgetest:quiz-pending` (`/pending/`)
- Added **"My Test History"** after "My Pending Tests"
  → `knowledgetest:member-test-history` (`/history/`)
- Added **"Suggestion Box"** (with divider) before the training-readiness section
  → `members:safety_report_submit` (`/members/safety-report/submit/`)

## No template, model, or URL changes
Only `templates/base.html` modified. No migrations needed.