### PR TITLE
Fix two Pylance diagnostics in member charge tests

### DIFF
--- a/logsheet/tests/test_member_charge_views.py
+++ b/logsheet/tests/test_member_charge_views.py
@@ -405,6 +405,8 @@ class AddMemberChargeViewTestCase(TestCase):
 
         charge = MemberCharge.objects.first()
         self.assertIsNotNone(charge)
+        if charge is None:
+            self.fail("Expected a MemberCharge to be created")
         self.assertEqual(charge.logsheet, self.logsheet)
 
     def test_charge_date_matches_logsheet_date(self):
@@ -422,6 +424,8 @@ class AddMemberChargeViewTestCase(TestCase):
 
         charge = MemberCharge.objects.first()
         self.assertIsNotNone(charge)
+        if charge is None:
+            self.fail("Expected a MemberCharge to be created")
         self.assertEqual(charge.date, self.logsheet.log_date)
 
     def test_success_message_displayed(self):


### PR DESCRIPTION
## Summary
- add explicit  narrowing guards after  in two tests
- resolves the two Pylance Optional-attribute diagnostics in 

## Validation
- .........................................                                [100%]
41 passed in 30.49s -> 41 passed