### PR TITLE
Fix Dependabot alert #28: bump PyJWT to 2.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ pydenticon==0.3.1
 pyee==13.0.0
 pyflakes==3.4.0
 Pygments==2.19.2
-PyJWT==2.10.1
+PyJWT==2.12.0
 pyparsing==3.2.5
 pytest==8.4.2
 pytest-base-url==2.1.0


### PR DESCRIPTION
## Summary
- fix Dependabot alert #28 for `PyJWT` (CVE-2026-32597 / GHSA-752w-5fwx-jx9f)
- bump `PyJWT` in `requirements.txt` from `2.10.1` to `2.12.0`

## Why
- alert #28 reports vulnerable range `<= 2.11.0`
- first patched version is `2.12.0`
- this repository uses `PyJWT` as a direct runtime dependency

## Validation
- pre-commit hooks passed on commit (including `safety`)
