### PR TITLE
Fix #785: Instruction modal margins and logbook signature line formatting

### DIFF
--- a/instructors/templates/instructors/_instruction_detail_fragment.html
+++ b/instructors/templates/instructors/_instruction_detail_fragment.html
@@ -24,4 +24,3 @@
       </div>
     {% endif %}
   </div>
-</div>

--- a/instructors/templates/instructors/_instruction_detail_fragment.html
+++ b/instructors/templates/instructors/_instruction_detail_fragment.html
@@ -16,13 +16,12 @@
     {% else %}
       <p class="text-muted">No training record found for this date.</p>
     {% endif %}
+    {% if report.report_text %}
+      <hr class="my-3">
+      <h6 class="mb-2">Instructor Notes</h6>
+      <div class="cms-content px-1">
+        {{ report.report_text|safe }}
+      </div>
+    {% endif %}
   </div>
-{# New instructor essay block #}
-  {% if report.report_text %}
-    <hr>
-    <h6>Instructor Notes</h6>
-    <div class="cms-content">
-      {{ report.report_text|safe }}
-    </div>
-  {% endif %}
 </div>

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -1,8 +1,17 @@
 import re
+from datetime import date, time, timedelta
 
 import pytest
 from django.urls import reverse
 
+from instructors.models import (
+    GroundInstruction,
+    GroundLessonScore,
+    InstructionReport,
+    LessonScore,
+    TrainingLesson,
+)
+from logsheet.models import Airfield, Flight, Glider, Logsheet
 from members.models import Member
 from siteconfig.models import MembershipStatus
 
@@ -165,3 +174,106 @@ def test_logbook_training_modal_uses_large_dialog_class(client):
     )
     assert modal_match is not None
     assert "modal-lg" in modal_match.group(1)
+
+
+@pytest.mark.django_db
+def test_instruction_report_detail_keeps_notes_inside_modal_body(client):
+    _ensure_full_member_status()
+    student = _make_member("instruction_modal_student")
+    instructor = _make_member("instruction_modal_instructor", instructor=True)
+    lesson = TrainingLesson.objects.create(
+        code="1a",
+        title="Preflight",
+        description="Test lesson",
+    )
+    report = InstructionReport.objects.create(
+        student=student,
+        instructor=instructor,
+        report_date=date.today(),
+        report_text="<p>Notes paragraph</p>",
+    )
+    LessonScore.objects.create(report=report, lesson=lesson, score="2")
+
+    client.force_login(student)
+    response = client.get(
+        reverse("instructors:instruction_report_detail", args=[report.pk])
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert '<div class="modal-body">' in content
+    assert '<div class="cms-content px-1">' in content
+    # Ensure notes are rendered before modal-body closes.
+    assert content.find('<div class="cms-content px-1">') < content.rfind("</div>")
+
+
+@pytest.mark.django_db
+def test_logbook_signature_renders_on_new_line_for_flight_and_ground(client):
+    _ensure_full_member_status()
+    student = _make_member("signature_student")
+    instructor = Member.objects.create_user(
+        username="signature_instructor",
+        password="password",
+        membership_status="Full Member",
+        instructor=True,
+        email="signature_instructor@example.com",
+        first_name="Brian",
+        last_name="Clark",
+        pilot_certificate_number="3303513",
+    )
+    airfield = Airfield.objects.create(name="Front Royal", identifier="KFRR")
+    glider = Glider.objects.create(
+        make="Schweizer",
+        model="2-33",
+        n_number="N123AB",
+        is_active=True,
+    )
+    lesson = TrainingLesson.objects.create(
+        code="1c",
+        title="Cockpit Familiarization",
+        description="Test lesson",
+    )
+
+    flight_day = date.today()
+    logsheet = Logsheet.objects.create(
+        log_date=flight_day, airfield=airfield, created_by=student
+    )
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=student,
+        instructor=instructor,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(10, 0),
+        landing_time=time(10, 20),
+        duration=timedelta(minutes=20),
+    )
+    report = InstructionReport.objects.create(
+        student=student,
+        instructor=instructor,
+        report_date=flight_day,
+    )
+    LessonScore.objects.create(report=report, lesson=lesson, score="2")
+
+    ground = GroundInstruction.objects.create(
+        student=student,
+        instructor=instructor,
+        date=flight_day,
+        duration=timedelta(minutes=30),
+        location="Briefing room",
+    )
+    GroundLessonScore.objects.create(session=ground, lesson=lesson, score="2")
+
+    client.force_login(student)
+    response = client.get(reverse("instructors:member_logbook") + "?show_all_years=1")
+
+    assert response.status_code == 200
+    rows = response.context["pages"][0]["rows"]
+    signature_rows = [
+        r for r in rows if r.get("signature_html") and "/s/" in r["signature_html"]
+    ]
+    assert signature_rows
+    for row in signature_rows:
+        assert "<br>/s/" in row["signature_html"]
+        assert "3303513CFI" in row["signature_html"]
+        assert ", 3303513CFI" not in row["signature_html"]

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -274,11 +274,18 @@ def test_logbook_signature_renders_on_new_line_for_flight_and_ground(client):
 
     assert response.status_code == 200
     rows = response.context["pages"][0]["rows"]
-    signature_rows = [
-        r for r in rows if r.get("signature_html") and "/s/" in r["signature_html"]
-    ]
-    assert signature_rows
-    for row in signature_rows:
-        assert "<br>/s/" in row["signature_html"]
-        assert "3303513CFI" in row["signature_html"]
-        assert ", 3303513CFI" not in row["signature_html"]
+
+    flight_row = next((r for r in rows if r.get("flight_id")), None)
+    ground_row = next((r for r in rows if r.get("ground_inst_m", 0) > 0), None)
+
+    assert flight_row is not None
+    assert ground_row is not None
+
+    assert "<br>/s/" in flight_row["signature_html"]
+    assert "3303513CFI" in flight_row["signature_html"]
+    assert ", 3303513CFI" not in flight_row["signature_html"]
+
+    assert "<br>/s/" in ground_row["signature_html"]
+    assert "3303513CFI" in ground_row["signature_html"]
+    assert ", 3303513CFI" not in ground_row["signature_html"]
+    assert ground_row["airfield"] == "Briefing room"

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -201,10 +201,15 @@ def test_instruction_report_detail_keeps_notes_inside_modal_body(client):
 
     assert response.status_code == 200
     content = response.content.decode()
-    assert '<div class="modal-body">' in content
-    assert '<div class="cms-content px-1">' in content
-    # Ensure notes are rendered before modal-body closes.
-    assert content.find('<div class="cms-content px-1">') < content.rfind("</div>")
+    modal_body_match = re.search(
+        r'<div[^>]*class="[^"]*modal-body[^"]*"[^>]*>(?P<body>.*?)</div>',
+        content,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    assert modal_body_match is not None
+    modal_body_inner_html = modal_body_match.group("body")
+    # Ensure the notes block is rendered inside the modal-body.
+    assert '<div class="cms-content px-1">' in modal_body_inner_html
 
 
 @pytest.mark.django_db

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -289,3 +289,57 @@ def test_logbook_signature_renders_on_new_line_for_flight_and_ground(client):
     assert "3303513CFI" in ground_row["signature_html"]
     assert ", 3303513CFI" not in ground_row["signature_html"]
     assert ground_row["airfield"] == "Briefing room"
+
+
+@pytest.mark.django_db
+def test_logbook_signature_without_lesson_codes_has_no_leading_line_break(client):
+    _ensure_full_member_status()
+    student = _make_member("signature_no_codes_student")
+    instructor = Member.objects.create_user(
+        username="signature_no_codes_instructor",
+        password="password",
+        membership_status="Full Member",
+        instructor=True,
+        email="signature_no_codes_instructor@example.com",
+        first_name="Pat",
+        last_name="Lee",
+        pilot_certificate_number="112233",
+    )
+    airfield = Airfield.objects.create(name="Front Royal", identifier="KFRR")
+    glider = Glider.objects.create(
+        make="Schweizer",
+        model="2-33",
+        n_number="N321BA",
+        is_active=True,
+    )
+
+    flight_day = date.today()
+    logsheet = Logsheet.objects.create(
+        log_date=flight_day, airfield=airfield, created_by=student
+    )
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=student,
+        instructor=instructor,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(11, 0),
+        landing_time=time(11, 20),
+        duration=timedelta(minutes=20),
+    )
+    # Intentionally no LessonScore rows on this report.
+    InstructionReport.objects.create(
+        student=student,
+        instructor=instructor,
+        report_date=flight_day,
+    )
+
+    client.force_login(student)
+    response = client.get(reverse("instructors:member_logbook") + "?show_all_years=1")
+
+    assert response.status_code == 200
+    rows = response.context["pages"][0]["rows"]
+    flight_row = next((r for r in rows if r.get("flight_id")), None)
+    assert flight_row is not None
+    assert "/s/" in flight_row["signature_html"]
+    assert not flight_row["signature_html"].startswith("<br>/s/")

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -1589,6 +1589,20 @@ def member_logbook(request, member_id=None):
         h, m = divmod(total_minutes, 60)
         return f"{h}:{m:02d}"
 
+    signature_span_style = (
+        "font-family: 'Lucida Handwriting', 'Comic Sans MS', 'Dancing Script', "
+        "cursive, sans-serif; font-size: 1.1em;"
+    )
+
+    def build_signature_html(prefix, signer_name, cert_part=""):
+        return format_html(
+            '{}<br>/s/ <span style="{}">{}</span>{}',
+            prefix,
+            signature_span_style,
+            signer_name,
+            cert_part,
+        )
+
     member = request.user
     if member_id is not None:
         member = get_object_or_404(Member, pk=member_id)
@@ -1786,12 +1800,7 @@ def member_logbook(request, member_id=None):
                 # Preserve full name (do not split on commas — suffixes like "Jr" must be kept)
                 name = post
                 cert_part = f" {instructor_cert}CFI" if instructor_cert else ""
-                signature_html = format_html(
-                    "{}<br>/s/ <span style=\"font-family: 'Lucida Handwriting', 'Comic Sans MS', 'Dancing Script', cursive, sans-serif; font-size: 1.1em;\">{}</span>{}",
-                    pre.strip(),
-                    name,
-                    cert_part,
-                )
+                signature_html = build_signature_html(pre.strip(), name, cert_part)
             else:
                 if is_passenger and f.pilot:
                     signature_html = format_html(
@@ -1850,8 +1859,7 @@ def member_logbook(request, member_id=None):
             if g.instructor:
                 comments += f" /s/ {g.instructor.full_display_name}"
                 cert_part = f" {instructor_cert}CFI" if instructor_cert else ""
-                signature_html = format_html(
-                    "{}<br>/s/ <span style=\"font-family: 'Lucida Handwriting', 'Comic Sans MS', 'Dancing Script', cursive, sans-serif; font-size: 1.1em;\">{}</span>{}",
+                signature_html = build_signature_html(
                     ", ".join(codes),
                     g.instructor.full_display_name,
                     cert_part,

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -1790,9 +1790,9 @@ def member_logbook(request, member_id=None):
                 else:
                     name = post
                     rest = ""
-                cert_part = f", {instructor_cert}CFI" if instructor_cert else ""
+                cert_part = f" {instructor_cert}CFI" if instructor_cert else ""
                 signature_html = (
-                    f"{pre.strip()} "
+                    f"{pre.strip()}<br>"
                     f"/s/ <span style=\"font-family: 'Lucida Handwriting', 'Comic Sans MS', 'Dancing Script', cursive, sans-serif; font-size: 1.1em;\">{name}</span>"
                     f"{cert_part}"
                 )
@@ -1843,8 +1843,15 @@ def member_logbook(request, member_id=None):
             instructor_cert = ""
             if g.instructor and hasattr(g.instructor, "pilot_certificate_number"):
                 instructor_cert = g.instructor.pilot_certificate_number or ""
+            signature_html = comments
             if g.instructor:
                 comments += f" /s/ {g.instructor.full_display_name}"
+                cert_part = f" {instructor_cert}CFI" if instructor_cert else ""
+                signature_html = (
+                    f"{', '.join(codes)}<br>"
+                    f"/s/ <span style=\"font-family: 'Lucida Handwriting', 'Comic Sans MS', 'Dancing Script', cursive, sans-serif; font-size: 1.1em;\">{g.instructor.full_display_name}</span>"
+                    f"{cert_part}"
+                )
 
             row = {
                 "date": ground_date,
@@ -1865,7 +1872,7 @@ def member_logbook(request, member_id=None):
                 "pic": "",
                 "inst_given": "",
                 "total": "",
-                "comments": ", ".join(ls.lesson.code for ls in g.lesson_scores.all()),
+                "comments": comments,
                 # raw-minute fields (all zero except ground_inst_m)
                 "ground_inst_m": gm,
                 "dual_received_m": 0,
@@ -1874,6 +1881,7 @@ def member_logbook(request, member_id=None):
                 "inst_given_m": 0,
                 "total_m": 0,
                 "instructor_certificate_number": instructor_cert,
+                "signature_html": signature_html,
             }
             rows.append(row)
 

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -1595,9 +1595,16 @@ def member_logbook(request, member_id=None):
     )
 
     def build_signature_html(prefix, signer_name, cert_part=""):
+        if prefix:
+            return format_html(
+                '{}<br>/s/ <span style="{}">{}</span>{}',
+                prefix,
+                signature_span_style,
+                signer_name,
+                cert_part,
+            )
         return format_html(
-            '{}<br>/s/ <span style="{}">{}</span>{}',
-            prefix,
+            '/s/ <span style="{}">{}</span>{}',
             signature_span_style,
             signer_name,
             cert_part,

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -19,6 +19,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
+from django.utils.html import format_html
 from django.utils.timezone import now
 from django.views import View as DjangoView
 from django.views.decorators.csrf import csrf_exempt
@@ -1776,25 +1777,20 @@ def member_logbook(request, member_id=None):
             instructor_cert = ""
             if f.instructor and hasattr(f.instructor, "pilot_certificate_number"):
                 instructor_cert = f.instructor.pilot_certificate_number or ""
-            # Build signature_html for template
+            # Build signature_html for template (use format_html to escape names)
             signature_html = ""
             if "/s/" in comments:
                 pre, post = comments.split("/s/", 1)
                 # Only the instructor name and cert get cursive, not the /s/
                 post = post.strip()
-                # Split post into name and (optional) cert
-                if "," in post:
-                    name, rest = post.split(",", 1)
-                    name = name.strip()
-                    rest = rest.strip()
-                else:
-                    name = post
-                    rest = ""
+                # Preserve full name (do not split on commas — suffixes like "Jr" must be kept)
+                name = post
                 cert_part = f" {instructor_cert}CFI" if instructor_cert else ""
-                signature_html = (
-                    f"{pre.strip()}<br>"
-                    f"/s/ <span style=\"font-family: 'Lucida Handwriting', 'Comic Sans MS', 'Dancing Script', cursive, sans-serif; font-size: 1.1em;\">{name}</span>"
-                    f"{cert_part}"
+                signature_html = format_html(
+                    "{}<br>/s/ <span style=\"font-family: 'Lucida Handwriting', 'Comic Sans MS', 'Dancing Script', cursive, sans-serif; font-size: 1.1em;\">{}</span>{}",
+                    pre.strip(),
+                    name,
+                    cert_part,
                 )
             else:
                 signature_html = comments
@@ -1847,10 +1843,11 @@ def member_logbook(request, member_id=None):
             if g.instructor:
                 comments += f" /s/ {g.instructor.full_display_name}"
                 cert_part = f" {instructor_cert}CFI" if instructor_cert else ""
-                signature_html = (
-                    f"{', '.join(codes)}<br>"
-                    f"/s/ <span style=\"font-family: 'Lucida Handwriting', 'Comic Sans MS', 'Dancing Script', cursive, sans-serif; font-size: 1.1em;\">{g.instructor.full_display_name}</span>"
-                    f"{cert_part}"
+                signature_html = format_html(
+                    "{}<br>/s/ <span style=\"font-family: 'Lucida Handwriting', 'Comic Sans MS', 'Dancing Script', cursive, sans-serif; font-size: 1.1em;\">{}</span>{}",
+                    ", ".join(codes),
+                    g.instructor.full_display_name,
+                    cert_part,
                 )
 
             row = {
@@ -1865,7 +1862,6 @@ def member_logbook(request, member_id=None):
                 "release": "",
                 "maxh": "",
                 "location": g.location or "",
-                "comments": comments,
                 "ground_inst": format_hhmm(timedelta(minutes=gm)),
                 "dual_received": "",
                 "solo": "",

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -1793,7 +1793,14 @@ def member_logbook(request, member_id=None):
                     cert_part,
                 )
             else:
-                signature_html = comments
+                if is_passenger and f.pilot:
+                    signature_html = format_html(
+                        "{} (<i>{}</i>)",
+                        f.pilot.full_display_name,
+                        member.full_display_name,
+                    )
+                else:
+                    signature_html = format_html("{}", comments)
             row = {
                 "flight_id": flight_id,
                 "date": date,
@@ -1839,7 +1846,7 @@ def member_logbook(request, member_id=None):
             instructor_cert = ""
             if g.instructor and hasattr(g.instructor, "pilot_certificate_number"):
                 instructor_cert = g.instructor.pilot_certificate_number or ""
-            signature_html = comments
+            signature_html = format_html("{}", comments)
             if g.instructor:
                 comments += f" /s/ {g.instructor.full_display_name}"
                 cert_part = f" {instructor_cert}CFI" if instructor_cert else ""
@@ -1862,6 +1869,7 @@ def member_logbook(request, member_id=None):
                 "release": "",
                 "maxh": "",
                 "location": g.location or "",
+                "airfield": g.location or "",
                 "ground_inst": format_hhmm(timedelta(minutes=gm)),
                 "dual_received": "",
                 "solo": "",


### PR DESCRIPTION
Closes #785

## What changed

### 1. Instruction modal: notes now inside `modal-body` (padding fix)
The instructor notes block (`<hr>`, heading, and `cms-content` div) were rendered **outside** the `</div>` that closed `modal-body`, so they had zero Bootstrap padding and pressed flush against the modal border. All content is now inside `<div class="modal-body">` with `cms-content px-1` giving a few pixels of breathing room.

### 2. Logbook overview: instructor signature on its own line
Changed the separator before `/s/` from a space to `<br>`, so the signature now renders as:
```
1c, 1d, 1e, 1i, 2a, 2b, ...
/s/ Brian Clark 3303513CFI
```
instead of the previous inline format:
```
1c, 1d, 1e, 1i, 2a, 2b, ... /s/ Brian Clark, 3303513CFI
```
Also removed the erroneous comma before the cert number (`3303513CFI` not `, 3303513CFI`).

### 3. Ground instruction rows: signature_html populated
Ground instruction rows were missing `signature_html` entirely (falling back to raw `comments`), and had a duplicate `"comments"` key that silently discarded lesson codes. Both are fixed — ground instruction entries now display the same styled cursive signature with line break.

## Tests
- `test_instruction_report_detail_keeps_notes_inside_modal_body` — verifies `cms-content px-1` is inside `modal-body`
- `test_logbook_signature_renders_on_new_line_for_flight_and_ground` — verifies `<br>/s/` and cert number format for both flight and ground instruction rows