### PR TITLE
Issue #702: Parallelize multi-tenant rollout waiting

### DIFF
--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -404,19 +404,20 @@
           echo "Rollout failed for tenant(s): ${failed[*]}" >&2
           echo "Attempting rollback for failed tenant(s)..." >&2
 
-          # Build a map from tenant name to index for direct namespace lookup.
-          declare -A tenant_index_map
-          for idx in "${!names[@]}"; do
-            tenant_index_map["${names[$idx]}"]=$idx
-          done
-
           for failed_tenant in "${failed[@]}"; do
-            if [[ -z "${tenant_index_map[$failed_tenant]+_}" ]]; then
+            tenant_idx=-1
+            for idx in "${!names[@]}"; do
+              if [[ "${names[$idx]}" == "$failed_tenant" ]]; then
+                tenant_idx=$idx
+                break
+              fi
+            done
+
+            if [[ "$tenant_idx" -lt 0 ]]; then
               echo "Unable to determine namespace for failed tenant $failed_tenant" >&2
               continue
             fi
 
-            tenant_idx=${tenant_index_map[$failed_tenant]}
             tenant_namespace="${namespaces[$tenant_idx]}"
             # Avoid aborting the whole script on history lookup failure.
             if ! history_output=$(kubectl rollout history "deployment/django-app-$failed_tenant" -n "$tenant_namespace" 2>/dev/null); then

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -380,6 +380,7 @@
       loop_control:
         loop_var: tenant
         label: "{{ tenant.prefix }}"
+      when: not ansible_check_mode
       tags: [deploy, ingress, tls, cert-cleanup, healthcheck]
 
     - name: Wait for all tenant rollouts in parallel

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -421,12 +421,21 @@
             fi
 
             tenant_namespace="${namespaces[$tenant_idx]}"
-            history_lines=$(kubectl rollout history "deployment/django-app-$failed_tenant" -n "$tenant_namespace" | wc -l | tr -d ' ')
+            # Avoid aborting the whole script on history lookup failure.
+            if ! history_output=$(kubectl rollout history "deployment/django-app-$failed_tenant" -n "$tenant_namespace" 2>/dev/null); then
+              history_lines=0
+            else
+              history_lines=$(printf '%s\n' "$history_output" | wc -l | tr -d ' ')
+            fi
 
             if [[ "$history_lines" -gt 2 ]]; then
-              kubectl rollout undo "deployment/django-app-$failed_tenant" -n "$tenant_namespace"
+              # Keep processing other tenants even if rollback command fails.
+              if ! kubectl rollout undo "deployment/django-app-$failed_tenant" -n "$tenant_namespace"; then
+                echo "Rollback command failed for tenant $failed_tenant" >&2
+                continue
+              fi
               if ! kubectl rollout status "deployment/django-app-$failed_tenant" -n "$tenant_namespace" --timeout={{ gke_rollout_timeout }}s; then
-                echo "Rollback failed for tenant $failed_tenant" >&2
+                echo "Rollback verification failed for tenant $failed_tenant" >&2
               fi
             else
               echo "Skipping rollback for tenant $failed_tenant (no rollout history)" >&2

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -367,6 +367,15 @@
             (gke_deploy_tenants | length == 1)
             and (gke_wait_for_rollout | default(true) | bool)
           }}
+        # Skip role-level verification during the multi-tenant apply phase when
+        # centralized parallel rollout waiting is enabled below.
+        gke_run_verify: >-
+          {{
+            not (
+              (gke_deploy_tenants | length > 1)
+              and (gke_wait_for_rollout | default(true) | bool)
+            )
+          }}
         # Run backfill in post_tasks after migrations for multi-tenant safety.
         gke_run_backfill_document_sizes: false
       loop: "{{ gke_deploy_tenants }}"
@@ -384,9 +393,9 @@
         declare -a failed=()
 
         {% for tenant in gke_deploy_tenants %}
-        kubectl rollout status deployment/django-app-{{ tenant.prefix }} \
-          -n {{ tenant.namespace | default('tenant-' + tenant.prefix) }} \
-          --timeout={{ gke_rollout_timeout }}s &
+        kubectl rollout status "deployment/django-app-{{ tenant.prefix }}" \
+          -n "{{ tenant.namespace | default('tenant-' + tenant.prefix) }}" \
+          --timeout="{{ gke_rollout_timeout }}s" &
         pids+=("$!")
         names+=("{{ tenant.prefix }}")
         namespaces+=("{{ tenant.namespace | default('tenant-' + tenant.prefix) }}")
@@ -432,7 +441,7 @@
                 echo "Rollback command failed for tenant $failed_tenant" >&2
                 continue
               fi
-              if ! kubectl rollout status "deployment/django-app-$failed_tenant" -n "$tenant_namespace" --timeout={{ gke_rollout_timeout }}s; then
+              if ! kubectl rollout status "deployment/django-app-$failed_tenant" -n "$tenant_namespace" --timeout="{{ gke_rollout_timeout }}s"; then
                 echo "Rollback verification failed for tenant $failed_tenant" >&2
               fi
             else

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -342,6 +342,11 @@
             - gke_image_tag is defined
       tags: [deploy]
 
+    - name: Compute global rollout wait flag
+      ansible.builtin.set_fact:
+        gke_wait_for_rollout_enabled: "{{ gke_wait_for_rollout | default(true) | bool }}"
+      tags: [always]
+
     # Deploy each tenant
     - name: Deploy each tenant
       ansible.builtin.include_role:
@@ -365,14 +370,14 @@
         gke_wait_for_rollout: >-
           {{
             (gke_deploy_tenants | length == 1)
-            and (gke_wait_for_rollout | default(true) | bool)
+            and (gke_wait_for_rollout_enabled | bool)
           }}
         # Skip role-level verification during the multi-tenant apply phase when
         # centralized parallel rollout waiting is enabled below.
         gke_run_verify: >-
           {{
             (gke_deploy_tenants | length == 1)
-            and (gke_wait_for_rollout | default(true) | bool)
+            and (gke_wait_for_rollout_enabled | bool)
           }}
         # Run backfill in post_tasks after migrations for multi-tenant safety.
         gke_run_backfill_document_sizes: false
@@ -456,7 +461,7 @@
       changed_when: false
       when:
         - (gke_deploy_tenants | length) > 1
-        - gke_wait_for_rollout | default(true) | bool
+        - gke_wait_for_rollout_enabled | bool
         - not ansible_check_mode
       tags: [deploy, healthcheck, ingress, tls, cert-cleanup]
 
@@ -478,7 +483,7 @@
         label: "{{ tenant.prefix }}"
       when:
         - (gke_deploy_tenants | length) > 1
-        - gke_wait_for_rollout | default(true) | bool
+        - gke_wait_for_rollout_enabled | bool
         - not ansible_check_mode
       tags: [verify]
 

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -448,7 +448,7 @@
       when:
         - (gke_deploy_tenants | length) > 1
         - gke_wait_for_rollout | default(true) | bool
-      tags: [deploy, healthcheck]
+      tags: [deploy, healthcheck, ingress, tls, cert-cleanup]
 
   post_tasks:
     # Auto-run migrations for any tenant with unapplied migrations.

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -360,6 +360,9 @@
         # Disable the role's own migration step - post_tasks handles it via
         # migrate --check detection to avoid running migrations twice.
         gke_run_migrations: false
+        # Multi-tenant mode applies each manifest first, then waits for all
+        # rollouts in parallel in the next task.
+        gke_wait_for_rollout: false
         # Run backfill in post_tasks after migrations for multi-tenant safety.
         gke_run_backfill_document_sizes: false
       loop: "{{ gke_deploy_tenants }}"
@@ -367,6 +370,40 @@
         loop_var: tenant
         label: "{{ tenant.prefix }}"
       tags: [deploy, ingress, tls, cert-cleanup, healthcheck]
+
+    - name: Wait for all tenant rollouts in parallel
+      ansible.builtin.shell: |
+        set -euo pipefail
+        declare -a pids=()
+        declare -a names=()
+        declare -a failed=()
+
+        {% for tenant in gke_deploy_tenants %}
+        kubectl rollout status deployment/django-app-{{ tenant.prefix }} \
+          -n {{ tenant.namespace | default('tenant-' + tenant.prefix) }} \
+          --timeout={{ gke_rollout_timeout }}s &
+        pids+=("$!")
+        names+=("{{ tenant.prefix }}")
+        {% endfor %}
+
+        idx=0
+        for pid in "${pids[@]}"; do
+          if ! wait "$pid"; then
+            failed+=("${names[$idx]}")
+          fi
+          idx=$((idx + 1))
+        done
+
+        if [[ -n "${failed[*]:-}" ]]; then
+          echo "Rollout failed for tenant(s): ${failed[*]}" >&2
+          exit 1
+        fi
+      args:
+        executable: /bin/bash
+      delegate_to: localhost
+      register: parallel_rollout_result
+      changed_when: false
+      tags: [deploy, healthcheck]
 
   post_tasks:
     # Auto-run migrations for any tenant with unapplied migrations.

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -477,6 +477,7 @@
         gke_secret_name: "manage2soar-env-{{ tenant.prefix }}"
         gke_wait_for_rollout: true
         gke_image_tag: "{{ gke_shared_image_tag | trim }}"
+        gke_computed_image_tag: "{{ gke_shared_image_tag | trim }}"
       loop: "{{ gke_deploy_tenants }}"
       loop_control:
         loop_var: tenant

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -481,6 +481,7 @@
         gke_deployment_name: "django-app-{{ tenant.prefix }}"
         gke_service_name: "django-app-{{ tenant.prefix }}"
         gke_secret_name: "manage2soar-env-{{ tenant.prefix }}"
+        gke_app_domain: "{{ tenant.domain | default(tenant.prefix + '.' + gke_base_domain | default('manage2soar.com')) }}"
         gke_wait_for_rollout: true
         gke_image_tag: "{{ gke_shared_image_tag | trim }}"
         gke_computed_image_tag: "{{ gke_shared_image_tag | trim }}"

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -411,6 +411,7 @@
         declare -a names=()
         declare -a namespaces=()
         declare -a failed=()
+        declare -a failed_indices=()
 
         {% for tenant in gke_deploy_tenants %}
         kubectl rollout status "deployment/django-app-{{ tenant.prefix }}" \
@@ -425,6 +426,7 @@
         for pid in "${pids[@]}"; do
           if ! wait "$pid"; then
             failed+=("${names[$idx]}")
+            failed_indices+=("$idx")
           fi
           idx=$((idx + 1))
         done
@@ -433,20 +435,8 @@
           echo "Rollout failed for tenant(s): ${failed[*]}" >&2
           echo "Attempting rollback for failed tenant(s)..." >&2
 
-          for failed_tenant in "${failed[@]}"; do
-            tenant_idx=-1
-            for idx in "${!names[@]}"; do
-              if [[ "${names[$idx]}" == "$failed_tenant" ]]; then
-                tenant_idx=$idx
-                break
-              fi
-            done
-
-            if [[ "$tenant_idx" -lt 0 ]]; then
-              echo "Unable to determine namespace for failed tenant $failed_tenant" >&2
-              continue
-            fi
-
+          for tenant_idx in "${failed_indices[@]}"; do
+            failed_tenant="${names[$tenant_idx]}"
             tenant_namespace="${namespaces[$tenant_idx]}"
             # Avoid aborting the whole script on history lookup failure.
             if ! history_output=$(kubectl rollout history "deployment/django-app-$failed_tenant" -n "$tenant_namespace" 2>/dev/null); then

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -456,6 +456,7 @@
       when:
         - (gke_deploy_tenants | length) > 1
         - gke_wait_for_rollout | default(true) | bool
+        - not ansible_check_mode
       tags: [deploy, healthcheck, ingress, tls, cert-cleanup]
 
     - name: Verify each tenant after parallel rollout

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -360,9 +360,13 @@
         # Disable the role's own migration step - post_tasks handles it via
         # migrate --check detection to avoid running migrations twice.
         gke_run_migrations: false
-        # Multi-tenant mode applies each manifest first, then waits for all
-        # rollouts in parallel in the next task.
-        gke_wait_for_rollout: false
+        # For multi-tenant deploys with rollout waiting enabled, apply first and
+        # wait in parallel in the next task. Otherwise honor the global setting.
+        gke_wait_for_rollout: >-
+          {{
+            (gke_deploy_tenants | length > 1 and (gke_wait_for_rollout | default(true)))
+            | ternary(false, gke_wait_for_rollout | default(true))
+          }}
         # Run backfill in post_tasks after migrations for multi-tenant safety.
         gke_run_backfill_document_sizes: false
       loop: "{{ gke_deploy_tenants }}"
@@ -376,6 +380,7 @@
         set -euo pipefail
         declare -a pids=()
         declare -a names=()
+        declare -a namespaces=()
         declare -a failed=()
 
         {% for tenant in gke_deploy_tenants %}
@@ -384,6 +389,7 @@
           --timeout={{ gke_rollout_timeout }}s &
         pids+=("$!")
         names+=("{{ tenant.prefix }}")
+        namespaces+=("{{ tenant.namespace | default('tenant-' + tenant.prefix) }}")
         {% endfor %}
 
         idx=0
@@ -396,13 +402,46 @@
 
         if [[ -n "${failed[*]:-}" ]]; then
           echo "Rollout failed for tenant(s): ${failed[*]}" >&2
+          echo "Attempting rollback for failed tenant(s)..." >&2
+
+          for failed_tenant in "${failed[@]}"; do
+            tenant_idx=-1
+            idx=0
+            for tenant_name in "${names[@]}"; do
+              if [[ "$tenant_name" == "$failed_tenant" ]]; then
+                tenant_idx=$idx
+                break
+              fi
+              idx=$((idx + 1))
+            done
+
+            if [[ "$tenant_idx" -lt 0 ]]; then
+              echo "Unable to determine namespace for failed tenant $failed_tenant" >&2
+              continue
+            fi
+
+            tenant_namespace="${namespaces[$tenant_idx]}"
+            history_lines=$(kubectl rollout history "deployment/django-app-$failed_tenant" -n "$tenant_namespace" | wc -l | tr -d ' ')
+
+            if [[ "$history_lines" -gt 2 ]]; then
+              kubectl rollout undo "deployment/django-app-$failed_tenant" -n "$tenant_namespace"
+              if ! kubectl rollout status "deployment/django-app-$failed_tenant" -n "$tenant_namespace" --timeout={{ gke_rollout_timeout }}s; then
+                echo "Rollback failed for tenant $failed_tenant" >&2
+              fi
+            else
+              echo "Skipping rollback for tenant $failed_tenant (no rollout history)" >&2
+            fi
+          done
+
           exit 1
         fi
       args:
         executable: /bin/bash
       delegate_to: localhost
-      register: parallel_rollout_result
       changed_when: false
+      when:
+        - (gke_deploy_tenants | length) > 1
+        - gke_wait_for_rollout | default(true) | bool
       tags: [deploy, healthcheck]
 
   post_tasks:

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -371,10 +371,8 @@
         # centralized parallel rollout waiting is enabled below.
         gke_run_verify: >-
           {{
-            not (
-              (gke_deploy_tenants | length > 1)
-              and (gke_wait_for_rollout | default(true) | bool)
-            )
+            (gke_deploy_tenants | length == 1)
+            and (gke_wait_for_rollout | default(true) | bool)
           }}
         # Run backfill in post_tasks after migrations for multi-tenant safety.
         gke_run_backfill_document_sizes: false

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -364,8 +364,8 @@
         # wait in parallel in the next task. Otherwise honor the global setting.
         gke_wait_for_rollout: >-
           {{
-            (gke_deploy_tenants | length > 1 and (gke_wait_for_rollout | default(true)))
-            | ternary(false, gke_wait_for_rollout | default(true))
+            (gke_deploy_tenants | length == 1)
+            and (gke_wait_for_rollout | default(true) | bool)
           }}
         # Run backfill in post_tasks after migrations for multi-tenant safety.
         gke_run_backfill_document_sizes: false
@@ -404,22 +404,19 @@
           echo "Rollout failed for tenant(s): ${failed[*]}" >&2
           echo "Attempting rollback for failed tenant(s)..." >&2
 
-          for failed_tenant in "${failed[@]}"; do
-            tenant_idx=-1
-            idx=0
-            for tenant_name in "${names[@]}"; do
-              if [[ "$tenant_name" == "$failed_tenant" ]]; then
-                tenant_idx=$idx
-                break
-              fi
-              idx=$((idx + 1))
-            done
+          # Build a map from tenant name to index for direct namespace lookup.
+          declare -A tenant_index_map
+          for idx in "${!names[@]}"; do
+            tenant_index_map["${names[$idx]}"]=$idx
+          done
 
-            if [[ "$tenant_idx" -lt 0 ]]; then
+          for failed_tenant in "${failed[@]}"; do
+            if [[ -z "${tenant_index_map[$failed_tenant]+_}" ]]; then
               echo "Unable to determine namespace for failed tenant $failed_tenant" >&2
               continue
             fi
 
+            tenant_idx=${tenant_index_map[$failed_tenant]}
             tenant_namespace="${namespaces[$tenant_idx]}"
             # Avoid aborting the whole script on history lookup failure.
             if ! history_output=$(kubectl rollout history "deployment/django-app-$failed_tenant" -n "$tenant_namespace" 2>/dev/null); then

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -233,6 +233,22 @@
         label: "{{ item.prefix }}"
       tags: [always]
 
+    - name: Validate tenant prefix is shell-safe DNS label
+      # Prefix is interpolated into kubectl rollout shell commands later; enforce
+      # Kubernetes/DNS-label compatible values to avoid shell metacharacter risks.
+      ansible.builtin.assert:
+        that:
+          - item.prefix is match('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+          - item.prefix | length <= 63
+        fail_msg: |
+          Invalid tenant prefix '{{ item.prefix }}'.
+          Tenant prefixes must be lowercase DNS labels (a-z, 0-9, hyphen),
+          cannot start/end with '-', and must be <= 63 characters.
+      loop: "{{ gke_deploy_tenants }}"
+      loop_control:
+        label: "{{ item.prefix }}"
+      tags: [always]
+
     - name: Pre-create all tenant namespaces
       # Loops over ALL gke_tenants (not just gke_deploy_tenants) because the ingress
       # role iterates over the full tenant list when generating HTTPRoutes and

--- a/infrastructure/ansible/playbooks/gcp-app-deploy.yml
+++ b/infrastructure/ansible/playbooks/gcp-app-deploy.yml
@@ -458,6 +458,28 @@
         - gke_wait_for_rollout | default(true) | bool
       tags: [deploy, healthcheck, ingress, tls, cert-cleanup]
 
+    - name: Verify each tenant after parallel rollout
+      ansible.builtin.include_role:
+        name: gke-deploy
+        tasks_from: verify.yml
+      vars:
+        gke_club_prefix: "{{ tenant.prefix }}"
+        gke_namespace: "{{ tenant.namespace | default('tenant-' + tenant.prefix) }}"
+        gke_deployment_name: "django-app-{{ tenant.prefix }}"
+        gke_service_name: "django-app-{{ tenant.prefix }}"
+        gke_secret_name: "manage2soar-env-{{ tenant.prefix }}"
+        gke_wait_for_rollout: true
+        gke_image_tag: "{{ gke_shared_image_tag | trim }}"
+      loop: "{{ gke_deploy_tenants }}"
+      loop_control:
+        loop_var: tenant
+        label: "{{ tenant.prefix }}"
+      when:
+        - (gke_deploy_tenants | length) > 1
+        - gke_wait_for_rollout | default(true) | bool
+        - not ansible_check_mode
+      tags: [verify]
+
   post_tasks:
     # Auto-run migrations for any tenant with unapplied migrations.
     # Uses 'migrate --check' (exits non-zero if unapplied migrations exist) to detect

--- a/infrastructure/ansible/roles/gke-deploy/defaults/main.yml
+++ b/infrastructure/ansible/roles/gke-deploy/defaults/main.yml
@@ -224,6 +224,9 @@ gke_apply_config: true
 # Wait for rollout to complete
 gke_wait_for_rollout: true
 
+# Run verification tasks (status checks and env inspection)
+gke_run_verify: true
+
 # Rollout timeout (seconds)
 gke_rollout_timeout: 600  # 10 minutes - increased from 5 to handle slow startups and image pulls
 

--- a/infrastructure/ansible/roles/gke-deploy/tasks/ingress.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/ingress.yml
@@ -138,6 +138,7 @@
   failed_when: false
   delegate_to: localhost
   run_once: true
+  when: not ansible_check_mode
   tags: [ingress, ip]
 
 - name: Select IPv4 address from gateway status addresses
@@ -150,7 +151,7 @@
          | list | first | default('') }}
   run_once: true
   when:
-    - gateway_live_ip_raw.rc == 0
+    - (gateway_live_ip_raw.rc | default(-1)) == 0
     - (gateway_live_ip_raw.stdout | default('') | trim) | length > 0
   tags: [ingress, ip]
 
@@ -308,7 +309,9 @@
   changed_when: false
   delegate_to: localhost
   run_once: true
-  when: gke_enable_tls | default(true) | bool
+  when:
+    - not ansible_check_mode
+    - gke_enable_tls | default(true) | bool
   tags: [ingress, tls, gateway]
 
 - name: Build combined SSL cert annotation (preserve existing certs during transition)
@@ -324,7 +327,7 @@
   run_once: true
   when:
     - gke_enable_tls | default(true) | bool
-    - gateway_current_certs.rc == 0
+    - (gateway_current_certs.rc | default(-1)) == 0
   tags: [ingress, tls, gateway]
 
 - name: Set SSL cert annotation to new cert only (gateway read failed or first deploy)
@@ -336,7 +339,7 @@
   run_once: true
   when:
     - gke_enable_tls | default(true) | bool
-    - gateway_current_certs.rc != 0
+    - (gateway_current_certs.rc | default(-1)) != 0
   tags: [ingress, tls, gateway]
 
 - name: Display combined cert annotation

--- a/infrastructure/ansible/roles/gke-deploy/tasks/ingress.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/ingress.yml
@@ -359,6 +359,7 @@
   register: manifest_temp_dir
   delegate_to: localhost
   run_once: true
+  when: not ansible_check_mode
   tags: [ingress, gateway]
 
 - name: Generate Gateway manifest
@@ -368,6 +369,7 @@
     mode: "0600"
   delegate_to: localhost
   run_once: true
+  when: not ansible_check_mode
   tags: [ingress, gateway]
 
 - name: Apply Gateway configuration
@@ -377,12 +379,16 @@
   changed_when: "'created' in gateway_result.stdout or 'configured' in gateway_result.stdout"
   delegate_to: localhost
   run_once: true
+  when: not ansible_check_mode
   tags: [ingress, gateway]
 
 - name: Display Gateway result
   ansible.builtin.debug:
     msg: "{{ gateway_result.stdout_lines }}"
-  when: gateway_result is defined
+  when:
+    - not ansible_check_mode
+    - gateway_result is defined
+    - gateway_result.stdout_lines is defined
   run_once: true
   tags: [ingress, gateway]
 
@@ -392,7 +398,7 @@
     state: absent
   delegate_to: localhost
   run_once: true
-  when: not (gke_keep_manifests | default(false))
+  when: not ansible_check_mode and not (gke_keep_manifests | default(false))
   tags: [ingress, gateway]
 
 # ============================================================
@@ -571,6 +577,7 @@
   changed_when: false
   delegate_to: localhost
   run_once: true
+  when: not ansible_check_mode
   tags: [ingress, verify]
 
 - name: Get Gateway IP address
@@ -581,13 +588,16 @@
   failed_when: false
   delegate_to: localhost
   run_once: true
+  when: not ansible_check_mode
   tags: [ingress, verify]
 
 - name: Update ingress IP from Gateway status
   ansible.builtin.set_fact:
     gke_ingress_ip: "{{ gateway_ip.stdout | trim }}"
   run_once: true
-  when: gateway_ip.stdout | trim | length > 0
+  when:
+    - not ansible_check_mode
+    - gateway_ip.stdout | trim | length > 0
   tags: [ingress, verify]
 
 - name: Get Gateway status
@@ -598,6 +608,7 @@
   failed_when: false
   delegate_to: localhost
   run_once: true
+  when: not ansible_check_mode
   tags: [ingress, verify]
 
 - name: Get HTTPRoute status
@@ -608,6 +619,7 @@
   failed_when: false
   delegate_to: localhost
   run_once: true
+  when: not ansible_check_mode
   tags: [ingress, verify]
 
 - name: Get SSL certificate status
@@ -622,7 +634,7 @@
   failed_when: false
   delegate_to: localhost
   run_once: true
-  when: gke_enable_tls | default(true) | bool
+  when: not ansible_check_mode and gke_enable_tls | default(true) | bool
   tags: [ingress, verify]
 
 - name: Display Gateway configuration summary
@@ -684,6 +696,7 @@
 
       ========================================
   run_once: true
+  when: not ansible_check_mode
   tags: [ingress, verify]
 
 # ============================================================

--- a/infrastructure/ansible/roles/gke-deploy/tasks/main.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/main.yml
@@ -239,7 +239,9 @@
 
 - name: Include verification tasks
   ansible.builtin.include_tasks: verify.yml
-  when: gke_run_verify | default(true) | bool
+  when:
+    - gke_run_verify | default(true) | bool
+    - not ansible_check_mode
   tags: [verify]
 
 # ============================================================

--- a/infrastructure/ansible/roles/gke-deploy/tasks/main.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/main.yml
@@ -83,6 +83,7 @@
   delegate_to: localhost
   run_once: true
   changed_when: false
+  when: not ansible_check_mode
   tags: [gke-auth]
 
 - name: Verify kubectl context
@@ -92,6 +93,7 @@
   run_once: true
   register: kubectl_context
   changed_when: false
+  when: not ansible_check_mode
   tags: [gke-auth]
 
 - name: Validate kubectl context

--- a/infrastructure/ansible/roles/gke-deploy/tasks/main.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/main.yml
@@ -93,7 +93,6 @@
   run_once: true
   register: kubectl_context
   changed_when: false
-  when: not ansible_check_mode
   tags: [gke-auth]
 
 - name: Validate kubectl context
@@ -107,7 +106,6 @@
       Expected context for cluster: {{ gke_cluster_name }} in project: {{ gcp_project }}
   delegate_to: localhost
   run_once: true
-  when: not ansible_check_mode
   tags: [gke-auth]
 
 # ============================================================

--- a/infrastructure/ansible/roles/gke-deploy/tasks/main.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/main.yml
@@ -236,6 +236,7 @@
 
 - name: Include verification tasks
   ansible.builtin.include_tasks: verify.yml
+  when: gke_run_verify | default(true) | bool
   tags: [verify]
 
 # ============================================================

--- a/infrastructure/ansible/roles/gke-deploy/tasks/main.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/main.yml
@@ -105,6 +105,7 @@
       Expected context for cluster: {{ gke_cluster_name }} in project: {{ gcp_project }}
   delegate_to: localhost
   run_once: true
+  when: not ansible_check_mode
   tags: [gke-auth]
 
 # ============================================================


### PR DESCRIPTION
Closes #702

## Summary
- Parallelize multi-tenant rollout waiting in the app deploy playbook.
- Set role invocations to apply without waiting (`gke_wait_for_rollout: false`).
- Add a centralized parallel rollout wait phase that runs `kubectl rollout status` for all tenants and fails with tenant-specific names when any rollout fails.

## Validation
- `ANSIBLE_ROLES_PATH=roles ansible-playbook playbooks/gcp-app-deploy.yml --syntax-check`
