### PR TITLE
Fix missing rental fees when duration is not persisted

### DIFF
--- a/logsheet/models.py
+++ b/logsheet/models.py
@@ -239,7 +239,7 @@ class Flight(models.Model):
                 - free_rental is True (explicitly marked as free)
                 - is_retrieve is True AND site config waive_rental_fee_on_retrieve is True
                 - glider has no rental rate
-            None: If glider or duration is not set.
+            None: If glider is not set or duration cannot be computed.
 
         Note:
             Instance-level caching of SiteConfiguration via _site_config_cache helps

--- a/logsheet/models.py
+++ b/logsheet/models.py
@@ -256,11 +256,13 @@ class Flight(models.Model):
             if config and config.waive_rental_fee_on_retrieve:
                 return Decimal("0.00")
 
-        if not self.glider or not self.duration:
+        duration = self.computed_duration
+
+        if not self.glider or not duration:
             return None
         if not self.glider.rental_rate:
             return Decimal("0.00")
-        hours = Decimal(self.duration.total_seconds()) / Decimal(3600)
+        hours = Decimal(duration.total_seconds()) / Decimal(3600)
         return Decimal(str(self.glider.rental_rate)) * hours
 
     @property

--- a/logsheet/tests/test_kiosk_csrf.py
+++ b/logsheet/tests/test_kiosk_csrf.py
@@ -13,7 +13,7 @@ secret with the stable cookie value.
 
 import json
 import re
-from datetime import date, time
+from datetime import date, time, timedelta
 
 from django.conf import settings
 from django.test import Client, TestCase
@@ -270,3 +270,34 @@ class KioskCsrfRegressionTest(TestCase):
             403,
             "CSRF 403 after kiosk session expiry on land endpoint — Issue #709 regression!",
         )
+
+    def test_land_flight_now_persists_duration(self):
+        """Landing via endpoint should persist computed duration, not only landing_time."""
+        landing_flight = Flight.objects.create(
+            logsheet=self.logsheet,
+            glider=self.glider,
+            launch_time=time(10, 0),
+        )
+
+        client = self._csrf_client()
+        manage_url = reverse("logsheet:manage", kwargs={"pk": self.logsheet.pk})
+
+        response = client.get(manage_url)
+        self.assertEqual(response.status_code, 200)
+        csrf_token = self._extract_csrf_token(response.content.decode())
+        self.assertIsNotNone(csrf_token)
+        assert csrf_token is not None  # type narrowing for Pylance
+
+        land_url = reverse(
+            "logsheet:land_flight_now", kwargs={"flight_id": landing_flight.pk}
+        )
+        response = client.post(
+            land_url,
+            data=json.dumps({"landing_time": "11:00"}),
+            content_type="application/json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        landing_flight.refresh_from_db()
+        self.assertEqual(landing_flight.duration, timedelta(hours=1))

--- a/logsheet/tests/test_kiosk_csrf.py
+++ b/logsheet/tests/test_kiosk_csrf.py
@@ -301,3 +301,35 @@ class KioskCsrfRegressionTest(TestCase):
 
         landing_flight.refresh_from_db()
         self.assertEqual(landing_flight.duration, timedelta(hours=1))
+
+    def test_launch_flight_now_recomputes_and_persists_duration(self):
+        """Launch endpoint should recompute/persist duration when landing already exists."""
+        launch_flight = Flight.objects.create(
+            logsheet=self.logsheet,
+            glider=self.glider,
+            landing_time=time(11, 0),
+            duration=timedelta(hours=2),
+        )
+
+        client = self._csrf_client()
+        manage_url = reverse("logsheet:manage", kwargs={"pk": self.logsheet.pk})
+
+        response = client.get(manage_url)
+        self.assertEqual(response.status_code, 200)
+        csrf_token = self._extract_csrf_token(response.content.decode())
+        self.assertIsNotNone(csrf_token)
+        assert csrf_token is not None  # type narrowing for Pylance
+
+        launch_url = reverse(
+            "logsheet:launch_flight_now", kwargs={"flight_id": launch_flight.pk}
+        )
+        response = client.post(
+            launch_url,
+            data=json.dumps({"launch_time": "10:00"}),
+            content_type="application/json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        launch_flight.refresh_from_db()
+        self.assertEqual(launch_flight.duration, timedelta(hours=1))

--- a/logsheet/tests/test_update_flight_costs_command.py
+++ b/logsheet/tests/test_update_flight_costs_command.py
@@ -212,3 +212,46 @@ def test_skips_non_finalized_logsheets_when_backfilling(airfield, active_member)
     assert draft_flight.tow_cost_actual == Decimal("0.00")
     assert draft_flight.rental_cost_actual == Decimal("0.00")
     assert final_flight.rental_cost_actual == Decimal("45.00")
+
+
+@pytest.mark.django_db
+def test_backfills_rental_when_duration_missing_but_times_exist(
+    airfield, active_member
+):
+    """Backfill should use computed_duration fallback when persisted duration is null."""
+    glider = Glider.objects.create(
+        make="Schleicher",
+        model="ASK-21",
+        n_number="NTEST006",
+        rental_rate=Decimal("30.00"),
+        club_owned=True,
+        is_active=True,
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date(2026, 3, 10),
+        airfield=airfield,
+        created_by=active_member,
+        finalized=True,
+    )
+
+    flight = Flight.objects.create(
+        logsheet=logsheet,
+        pilot=active_member,
+        glider=glider,
+        flight_type="solo",
+        launch_time=time(10, 0),
+        landing_time=time(10, 30),
+        tow_cost_actual=Decimal("0.00"),
+        rental_cost_actual=Decimal("0.00"),
+    )
+
+    # Simulate legacy/corrupt row where duration was never persisted.
+    Flight.objects.filter(pk=flight.pk).update(duration=None)
+    flight.refresh_from_db()
+    assert flight.duration is None
+    assert flight.computed_duration is not None
+
+    call_command("update_flight_costs", after="2026-03-01")
+
+    flight.refresh_from_db()
+    assert flight.rental_cost_actual == Decimal("15.00")

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -779,7 +779,9 @@ def land_flight_now(request, flight_id):
             )
 
         flight.landing_time = landing_time
-        flight.save(update_fields=["landing_time"])
+        # Persist duration alongside landing_time because Flight.save() computes
+        # duration and update_fields would otherwise drop that write.
+        flight.save(update_fields=["landing_time", "duration"])
         return JsonResponse({"success": True})
     except Exception as e:
         logger.exception("Error landing flight %s", flight_id)
@@ -828,7 +830,8 @@ def launch_flight_now(request, flight_id):
             )
 
         flight.launch_time = launch_time
-        flight.save(update_fields=["launch_time"])
+        # Persist duration reset/compute together with launch_time updates.
+        flight.save(update_fields=["launch_time", "duration"])
         return JsonResponse({"success": True})
     except Exception as e:
         logger.exception("Error launching flight %s", flight_id)


### PR DESCRIPTION
## Summary
This PR fixes a follow-up gap where some flights could miss rental fees when duration was not persisted.

### What changed
- Updated Flight rental calculation to use computed duration fallback when stored duration is null.
- Added regression coverage for update_flight_costs backfill when launch and landing times exist but duration is null.
- Fixed Launch Now and Land Now endpoints to persist duration alongside time-field updates.
- Added regression coverage ensuring landing via endpoint persists duration.

## Root cause
A subset of workflows (commonly Copy flight followed by Launch Now and Land Now) could leave duration null in the database because endpoint saves used update_fields with only launch_time or landing_time.

## Validation
- pytest logsheet/tests/test_update_flight_costs_command.py -q
- pytest logsheet/tests/test_kiosk_csrf.py -q

## Notes
- update_flight_costs remains finalized-only by design.
- This ensures finalization writes rental actuals reliably once launch and landing times are present.
