### PR TITLE
Issue #798: homepage/public view and mobile user actions fixes

### DIFF
--- a/cms/templates/cms/homepage.html
+++ b/cms/templates/cms/homepage.html
@@ -3,15 +3,15 @@
 
 {% block content %}
   <div class="homepage-content">
-    <div style="display:flex;align-items:center;justify-content:space-between;">
-      <h1 style="margin:0">{{ page.title }}</h1>
-      {% if can_edit_page %}
+    {% if can_edit_page %}
+      <div class="page-title-row mb-3">
+        <span></span>
         <div>
           <a class="btn btn-sm btn-primary me-2" href="{% url 'cms:edit_homepage' page.id %}">✏️ Edit Homepage</a>
           <a class="btn btn-sm btn-outline-secondary" href="{% url 'admin:cms_homepagecontent_change' page.pk %}">⚙️ Admin</a>
         </div>
-      {% endif %}
-    </div>
+      </div>
+    {% endif %}
     <div class="cms-content">
       {{ page.content|fix_youtube_embeds|safe }}
     </div>

--- a/cms/tests/test_cms.py
+++ b/cms/tests/test_cms.py
@@ -46,6 +46,47 @@ def test_homepagecontent_view_logged_in(client, django_user_model):
 
 
 @pytest.mark.django_db
+def test_homepagecontent_public_override_for_logged_in_member(
+    client, django_user_model
+):
+    django_user_model.objects.create_user(
+        username="member", password="pass", membership_status="Full Member"
+    )
+    client.login(username="member", password="pass")
+    HomePageContent.objects.create(
+        title="Public Home",
+        slug="home",
+        audience="public",
+        content="<p>Public Content</p>",
+    )
+    HomePageContent.objects.create(
+        title="Member Home",
+        slug="member-home",
+        audience="member",
+        content="<p>Member Content</p>",
+    )
+
+    response = client.get("/?view=public")
+    assert response.status_code == 200
+    assert b"Public Content" in response.content
+    assert b"Member Content" not in response.content
+
+
+@pytest.mark.django_db
+def test_homepage_template_does_not_render_hardcoded_h1(client):
+    HomePageContent.objects.create(
+        title="Skyline Soaring Club",
+        slug="home",
+        audience="public",
+        content="<p>Homepage body content</p>",
+    )
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b'<h1 style="margin:0">Skyline Soaring Club</h1>' not in response.content
+
+
+@pytest.mark.django_db
 def test_homepagecontent_404(client):
     # Since there is no detail view, just check a non-existent path returns 404
     response = client.get("/nonexistent-path/")

--- a/cms/tests/test_cms.py
+++ b/cms/tests/test_cms.py
@@ -73,6 +73,26 @@ def test_homepagecontent_public_override_for_logged_in_member(
 
 
 @pytest.mark.django_db
+def test_homepagecontent_public_override_falls_back_when_public_missing(
+    client, django_user_model
+):
+    django_user_model.objects.create_user(
+        username="member2", password="pass", membership_status="Full Member"
+    )
+    client.login(username="member2", password="pass")
+    HomePageContent.objects.create(
+        title="Member Home",
+        slug="member-home",
+        audience="member",
+        content="<p>Member Fallback</p>",
+    )
+
+    response = client.get("/?view=public")
+    assert response.status_code == 200
+    assert b"Member Fallback" in response.content
+
+
+@pytest.mark.django_db
 def test_homepage_template_does_not_render_hardcoded_h1(client):
     HomePageContent.objects.create(
         title="Skyline Soaring Club",

--- a/cms/views.py
+++ b/cms/views.py
@@ -270,17 +270,21 @@ def homepage(request):
     # Allow authenticated, non-kiosk users to explicitly view the public homepage.
     if user.is_authenticated and public_override and not kiosk_mode:
         page = HomePageContent.objects.filter(audience="public", slug="home").first()
-    # Show member content if: authenticated + (kiosk session OR active membership)
-    elif user.is_authenticated and (
-        kiosk_mode
-        or user.is_superuser
-        or getattr(user, "membership_status", None) in allowed_statuses
-    ):
-        page = HomePageContent.objects.filter(
-            audience="member", slug="member-home"
-        ).first()
-    else:
-        page = HomePageContent.objects.filter(audience="public", slug="home").first()
+
+    if page is None:
+        # Show member content if: authenticated + (kiosk session OR active membership)
+        if user.is_authenticated and (
+            kiosk_mode
+            or user.is_superuser
+            or getattr(user, "membership_status", None) in allowed_statuses
+        ):
+            page = HomePageContent.objects.filter(
+                audience="member", slug="member-home"
+            ).first()
+        else:
+            page = HomePageContent.objects.filter(
+                audience="public", slug="home"
+            ).first()
 
     if page:
         # Homepage editing is webmaster-only

--- a/cms/views.py
+++ b/cms/views.py
@@ -264,9 +264,15 @@ def homepage(request):
     page = None
     from members.utils import is_kiosk_session
 
+    kiosk_mode = is_kiosk_session(request)
+    public_override = request.GET.get("view") == "public"
+
+    # Allow authenticated, non-kiosk users to explicitly view the public homepage.
+    if user.is_authenticated and public_override and not kiosk_mode:
+        page = HomePageContent.objects.filter(audience="public", slug="home").first()
     # Show member content if: authenticated + (kiosk session OR active membership)
-    if user.is_authenticated and (
-        is_kiosk_session(request)
+    elif user.is_authenticated and (
+        kiosk_mode
         or user.is_superuser
         or getattr(user, "membership_status", None) in allowed_statuses
     ):

--- a/e2e_tests/e2e/test_issue_798_mobile_user_actions.py
+++ b/e2e_tests/e2e/test_issue_798_mobile_user_actions.py
@@ -1,0 +1,75 @@
+"""E2E coverage for Issue #798 mobile user actions and public-home access."""
+
+from cms.models import HomePageContent
+from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+
+
+class TestIssue798MobileUserActions(DjangoPlaywrightTestCase):
+    """Validate mobile profile actions added for Issue #798."""
+
+    def setUp(self):
+        super().setUp()
+        HomePageContent.objects.get_or_create(
+            slug="home",
+            defaults={
+                "title": "Public Home",
+                "audience": "public",
+                "content": "<p>Public homepage content</p>",
+            },
+        )
+        HomePageContent.objects.get_or_create(
+            slug="member-home",
+            defaults={
+                "title": "Member Home",
+                "audience": "member",
+                "content": "<p>Member homepage content</p>",
+            },
+        )
+
+    def _open_mobile_menu(self):
+        self.page.set_viewport_size({"width": 390, "height": 844})
+        self.page.goto(f"{self.live_server_url}/")
+        self.page.click(".navbar-toggler")
+        self.page.wait_for_selector("#navbarOffcanvas.show")
+
+    def test_mobile_user_section_shows_logout_and_public_home_link(self):
+        self.create_test_member(username="issue798member")
+        self.login(username="issue798member")
+
+        self._open_mobile_menu()
+
+        offcanvas = self.page.locator("#navbarOffcanvas")
+        assert offcanvas.locator(".user-section").count() == 1
+        assert (
+            offcanvas.locator(".user-section", has_text="View Public Homepage").count()
+            == 1
+        )
+        assert offcanvas.locator(".user-section button", has_text="Logout").count() == 1
+
+    def test_mobile_admin_link_visible_for_admin_capable_user(self):
+        self.create_test_member(username="issue798admin", is_superuser=True)
+        self.login(username="issue798admin")
+
+        self._open_mobile_menu()
+
+        admin_link = self.page.locator(
+            "#navbarOffcanvas .user-section a", has_text="Admin Interface"
+        )
+        assert admin_link.count() == 1
+        admin_link.click()
+        self.page.wait_for_url(f"{self.live_server_url}/admin/**")
+
+    def test_public_home_link_loads_public_homepage_for_logged_in_member(self):
+        self.create_test_member(username="issue798publicview")
+        self.login(username="issue798publicview")
+
+        self._open_mobile_menu()
+
+        self.page.click(
+            "#navbarOffcanvas .user-section a:has-text('View Public Homepage')"
+        )
+        self.page.wait_for_url(f"{self.live_server_url}/?view=public")
+
+        body_text = self.page.locator("body").inner_text()
+        assert "Public homepage content" in body_text
+        assert "Member homepage content" not in body_text

--- a/templates/base.html
+++ b/templates/base.html
@@ -316,6 +316,11 @@
               </a></li>
               <li><a class="dropdown-item" href="{% url 'knowledgetest:quiz-pending' %}">📝 My Pending Tests</a></li>
               <li><a class="dropdown-item" href="{% url 'knowledgetest:member-test-history' %}">📊 My Test History</a></li>
+              {% if not kiosk_mode %}
+              <li><a class="dropdown-item" href="{% url 'home' %}?view=public">
+                <i class="fas fa-globe me-1"></i> View Public Homepage
+              </a></li>
+              {% endif %}
               <li><hr class="dropdown-divider"></li>
               <li><a class="dropdown-item" href="{% url 'members:safety_report_submit' %}">💡 Suggestion Box</a></li>
               {% if user.glider_rating != "private" and user.glider_rating != "commercial" %}
@@ -329,7 +334,7 @@
               {% endif %}
               {% if user.is_staff or user.webmaster or user.rostermeister or user.member_manager or user.instructor %}
               <li><hr class="dropdown-divider"></li>
-              <li><a class="dropdown-item" href="/admin/">Admin Interface</a></li>
+              <li><a class="dropdown-item" href="{% url 'admin:index' %}">Admin Interface</a></li>
               {% endif %}
               {% if not kiosk_mode %}
               <li>
@@ -342,8 +347,32 @@
             </ul>
           </li>
         </ul>
+
+        <div class="user-section d-lg-none">
+          {% if not kiosk_mode %}
+          <a class="nav-link" href="{% url 'home' %}?view=public">
+            <i class="fas fa-globe me-1"></i> View Public Homepage
+          </a>
+          {% endif %}
+
+          {% if user.is_staff or user.webmaster or user.rostermeister or user.member_manager or user.instructor %}
+          <a class="nav-link" href="{% url 'admin:index' %}">
+            <i class="fas fa-user-shield me-1"></i> Admin Interface
+          </a>
+          {% endif %}
+
+          {% if not kiosk_mode %}
+          <form action="{% url 'logout' %}" method="post" class="d-flex">
+            {% csrf_token %}
+            <button class="btn btn-outline-light btn-sm navbar-auth-btn w-100" type="submit">Logout</button>
+          </form>
+          {% endif %}
+        </div>
         {% else %}
-        <a class="btn btn-outline-light btn-sm navbar-auth-btn" href="{% url 'login' %}">Login</a>
+        <a class="btn btn-outline-light btn-sm navbar-auth-btn d-none d-lg-inline-flex" href="{% url 'login' %}">Login</a>
+        <div class="user-section d-lg-none">
+          <a class="btn btn-outline-light btn-sm navbar-auth-btn w-100" href="{% url 'login' %}">Login</a>
+        </div>
         {% endif %}
 
         </div><!-- /.offcanvas-body -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -348,7 +348,7 @@
           </li>
         </ul>
 
-        <div class="user-section d-lg-none">
+        <div class="user-section d-flex d-lg-none">
           {% if not kiosk_mode %}
           <a class="nav-link" href="{% url 'home' %}?view=public">
             <i class="fas fa-globe me-1"></i> View Public Homepage
@@ -370,7 +370,7 @@
         </div>
         {% else %}
         <a class="btn btn-outline-light btn-sm navbar-auth-btn d-none d-lg-inline-flex" href="{% url 'login' %}">Login</a>
-        <div class="user-section d-lg-none">
+        <div class="user-section d-flex d-lg-none">
           <a class="btn btn-outline-light btn-sm navbar-auth-btn w-100" href="{% url 'login' %}">Login</a>
         </div>
         {% endif %}


### PR DESCRIPTION
## Summary
Implements issue #798 with four user-facing fixes on homepage and mobile navigation behavior.

### What changed
- Added explicit public-home override for authenticated non-kiosk users via `/?view=public` in homepage selection logic.
- Added a "View Public Homepage" action in user profile actions.
- Removed hardcoded homepage H1 wrapper so visible homepage title is controlled by CMS content.
- Added reliable mobile off-canvas user actions section for authenticated users.
- Ensured logout remains available on mobile for non-kiosk sessions.
- Ensured Admin Interface action is reachable on mobile for authorized users.

### Tests added/updated
- `cms/tests/test_cms.py`
  - public override behavior for logged-in member
  - assertion that old hardcoded homepage H1 is not rendered
- `e2e_tests/e2e/test_issue_798_mobile_user_actions.py`
  - mobile logout + public-home visibility
  - mobile admin interface visibility/navigation
  - logged-in public-home navigation behavior

## Validation
- `pytest cms/tests/test_cms.py -q`
- `pytest e2e_tests/e2e/test_issue_798_mobile_user_actions.py -q`

## Notes
- Kiosk constraints are preserved (logout still hidden in kiosk mode).
- Browser tab title behavior was intentionally left unchanged per scope decision.
