### PR TITLE
Issues #803/#797/#717: duty day modal UX, intent workflow, and reservation integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,8 +13,5 @@
     "files.associations": {
         ".bandit": "yaml",
         "*.bandit": "yaml"
-    },
-    "chat.tools.terminal.autoApprove": {
-        "gh": true
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,8 @@
     "files.associations": {
         ".bandit": "yaml",
         "*.bandit": "yaml"
+    },
+    "chat.tools.terminal.autoApprove": {
+        "gh": true
     }
 }

--- a/duty_roster/models.py
+++ b/duty_roster/models.py
@@ -883,12 +883,13 @@ class GliderReservation(models.Model):
         )
 
     @classmethod
-    def can_member_reserve(cls, member, year=None, month=None):
+    def can_member_reserve(cls, member, year=None, month=None, config=None):
         """
         Check if a member can make a new reservation based on yearly and monthly limits.
         Returns tuple: (can_reserve: bool, message: str)
         """
-        config = SiteConfiguration.objects.first()
+        if config is None:
+            config = SiteConfiguration.objects.first()
         if not config:
             return False, "Site configuration is not available."
 

--- a/duty_roster/models.py
+++ b/duty_roster/models.py
@@ -645,15 +645,23 @@ class DutySwapOffer(models.Model):
 class OpsIntent(models.Model):
     member = models.ForeignKey(Member, on_delete=models.CASCADE)
     date = models.DateField(db_index=True)
-    # e.g. ["towpilot", "glider_pilot", "instruction"]
+    # e.g. ["club_single", "club_two", "guest"]
     # Centralize available activities so templates and admin can render
     # consistent labels. Keys here are stored in the JSONField.
     AVAILABLE_ACTIVITIES = [
-        ("club", "Club glider"),
-        ("private", "Private glider"),
-        ("towpilot", "Tow Pilot"),
-        ("glider_pilot", "Glider Pilot"),
+        ("club_single", "Fly Club Single-Seater"),
+        ("club_two", "Fly Club Two-Seater"),
+        ("guest", "Fly with Guest"),
+        ("private", "Fly Private Glider"),
     ]
+
+    # Backward-compatible labels for legacy stored activity keys.
+    LEGACY_ACTIVITY_LABELS = {
+        "club": "Club glider",
+        "towpilot": "Tow Pilot",
+        "glider_pilot": "Glider Pilot",
+        "instruction": "instruction",
+    }
 
     available_as = models.JSONField(default=list)
     glider = models.ForeignKey(
@@ -671,6 +679,7 @@ class OpsIntent(models.Model):
     def available_as_labels(self):
         """Return a list of human-friendly labels for the stored activity keys."""
         mapping = dict(self.AVAILABLE_ACTIVITIES)
+        mapping.update(self.LEGACY_ACTIVITY_LABELS)
         return [mapping.get(k, k) for k in (self.available_as or [])]
 
 

--- a/duty_roster/models.py
+++ b/duty_roster/models.py
@@ -653,6 +653,7 @@ class OpsIntent(models.Model):
         ("club_two", "Fly Club Two-Seater"),
         ("guest", "Fly with Guest"),
         ("private", "Fly Private Glider"),
+        ("faa_practical_test", "FAA Practical Test"),
     ]
 
     # Backward-compatible labels for legacy stored activity keys.

--- a/duty_roster/templates/duty_roster/_calendar_agenda.html
+++ b/duty_roster/templates/duty_roster/_calendar_agenda.html
@@ -110,7 +110,7 @@
                   <div class="col-md-6 mb-3">
                     <div class="duty-role-card bg-danger bg-opacity-10 border border-danger rounded p-3">
                       <h6 class="text-danger mb-2">
-                        <i class="fas fa-plane me-2"></i>
+                        <i class="bi bi-airplane me-2" aria-hidden="true"></i>
                         {{ config.towpilot_title|default:'Tow Pilot' }}
                       </h6>
                       <p class="mb-0 fw-bold">{{ assignment.tow_pilot.full_display_name }}</p>
@@ -170,7 +170,7 @@
                   <div class="col-md-6 mb-3">
                     <div class="duty-role-card bg-danger bg-opacity-10 border border-danger rounded p-3">
                       <h6 class="text-danger mb-2">
-                        <i class="fas fa-plane me-2"></i>
+                        <i class="bi bi-airplane me-2" aria-hidden="true"></i>
                         {{ config.surge_towpilot_title|default:'Surge Tow Pilot' }}
                       </h6>
                       <p class="mb-0 fw-bold">{{ assignment.surge_tow_pilot.full_display_name }}</p>

--- a/duty_roster/templates/duty_roster/_calendar_body.html
+++ b/duty_roster/templates/duty_roster/_calendar_body.html
@@ -37,20 +37,20 @@
     <!-- Calendar View -->
     <div id="calendar-view-content">
       {% include "duty_roster/_calendar_table.html" %}
+
+      <!-- Calendar Legend (Issue #690) -->
+      <div class="d-flex flex-wrap gap-2 justify-content-center mt-3 mb-1 px-2" aria-label="Calendar legend">
+        <span class="duty-badge badge-instructor"><i class="bi bi-mortarboard" aria-hidden="true"></i> {{ config.instructor_title|default:'Instructor' }}</span>
+        <span class="duty-badge badge-tow-pilot"><i class="bi bi-airplane" aria-hidden="true"></i> {{ config.towpilot_title|default:'Tow Pilot' }}</span>
+        <span class="duty-badge badge-duty-officer"><i class="bi bi-clipboard-check" aria-hidden="true"></i> {{ config.duty_officer_title|default:'Duty Officer' }}</span>
+        <span class="duty-badge badge-assistant-duty-officer"><i class="bi bi-person-badge" aria-hidden="true"></i> {{ config.assistant_duty_officer_title|default:'Assistant DO' }}</span>
+        <span class="duty-badge badge-surge"><i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Surge Demand</span>
+      </div>
     </div>
 
     <!-- Agenda View -->
     <div id="agenda-view-content" style="display: none;">
       {% include "duty_roster/_calendar_agenda.html" %}
-    </div>
-
-    <!-- Calendar Legend (Issue #690) -->
-    <div class="d-flex flex-wrap gap-2 justify-content-center mt-3 mb-1 px-2" aria-label="Calendar legend">
-      <span class="duty-badge badge-instructor"><i class="bi bi-mortarboard" aria-hidden="true"></i> {{ config.instructor_title|default:'Instructor' }}</span>
-      <span class="duty-badge badge-tow-pilot"><i class="bi bi-airplane" aria-hidden="true"></i> {{ config.towpilot_title|default:'Tow Pilot' }}</span>
-      <span class="duty-badge badge-duty-officer"><i class="bi bi-clipboard-check" aria-hidden="true"></i> {{ config.duty_officer_title|default:'Duty Officer' }}</span>
-      <span class="duty-badge badge-assistant-duty-officer"><i class="bi bi-person-badge" aria-hidden="true"></i> {{ config.assistant_duty_officer_title|default:'Assistant DO' }}</span>
-      <span class="duty-badge badge-surge"><i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Surge Demand</span>
     </div>
 
     {# Bottom navigation with simplified center (reuse shared month navigation partial) #}

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -558,7 +558,11 @@
       {% endif %}
       {% else %}
       <p class="text-muted mb-0">
+        {% if reservation_feature_enabled %}
+        <i class="bi bi-info-circle me-2" aria-hidden="true"></i>Glider reservations are currently unavailable for your account.
+        {% else %}
         <i class="bi bi-info-circle me-2" aria-hidden="true"></i>Glider reservations are not enabled.
+        {% endif %}
       </p>
       {% endif %}
     </div>

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -291,9 +291,9 @@
     </div>
     {% elif instruction_request_form %}
     {# Expandable instruction request form #}
-    <div class="card border-success mb-3">
-      <div class="card-header bg-success text-white py-2" id="instruction-request-header">
-        <button class="btn btn-link text-white text-decoration-none w-100 d-flex justify-content-between align-items-center p-0"
+    <div class="card border-primary mb-3">
+      <div class="card-header bg-primary py-2" id="instruction-request-header">
+        <button class="btn btn-primary w-100 d-flex justify-content-between align-items-center"
                 type="button"
                 data-bs-toggle="collapse"
                 data-bs-target="#instruction-request-form"
@@ -395,12 +395,57 @@
           <i class="bi bi-airplane-engines me-2" aria-hidden="true"></i>I Plan to Fly This Day
         </button>
       </form>
+      {% elif intent_blocked_reason %}
+      <div class="alert alert-warning mb-0" role="alert">
+        <i class="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{{ intent_blocked_reason }}
+      </div>
       {% else %}
       <div class="text-muted">
         <i class="bi bi-clock me-2" aria-hidden="true"></i>This date is in the past. You can no longer declare intent.
       </div>
       {% endif %}
     </div>
+
+    {% if reservation_enabled %}
+    <hr class="my-3">
+    <h6 class="fw-semibold text-secondary mb-2">
+      <i class="bi bi-calendar-check me-2" aria-hidden="true"></i>Glider Reservations
+    </h6>
+
+    {% if reservations_remaining is not None %}
+    <p class="text-muted small mb-2">
+      Guest reservations remaining this year: <strong>{{ reservations_remaining }}</strong>
+    </p>
+    {% endif %}
+
+    {% if day_reservations %}
+    <ul class="list-group mb-2">
+      {% for res in day_reservations %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <div>
+          <strong>{{ res.glider }}</strong>
+          <span class="text-muted ms-2">{{ res.member.full_display_name }}</span>
+          <div class="small text-muted">{{ res.get_reservation_type_display }}</div>
+        </div>
+        {% if res.is_trainer %}
+        <span class="badge bg-info" title="Two-seater">2S</span>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p class="text-muted small mb-2">
+      <i class="bi bi-info-circle me-1" aria-hidden="true"></i>No glider reservations for this day.
+    </p>
+    {% endif %}
+
+    {% if can_reserve_glider %}
+    <a href="{% url 'duty_roster:reservation_create_for_day' day.year day.month day.day %}"
+       class="btn btn-outline-primary btn-sm w-100">
+      <i class="bi bi-stars me-2" aria-hidden="true"></i>Reserve a Glider for This Day
+    </a>
+    {% endif %}
+    {% endif %}
 
     {# Rescind buttons for ad-hoc day crew (issue #696: signup via shovel buttons in duty crew card above) #}
     {% if assignment and not assignment.is_scheduled %}

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -6,12 +6,13 @@
   <h5 class="text-primary fw-bold mb-0">
     <i class="bi bi-calendar-event me-2" aria-hidden="true"></i>{{ day|date:"l, F j, Y" }}
   </h5>
+  <p class="text-muted small mb-0 mt-1">Choose one primary action first, then use additional tools if needed.</p>
 </div>
 
 {% if assignment %}
   {# Duty Crew Section #}
   <div class="card border-0 shadow-sm mb-3">
-    <div class="card-header bg-primary text-white py-2">
+    <div class="card-header bg-light text-dark py-2 border-bottom">
       <h6 class="mb-0 fw-semibold">
         <i class="bi bi-people-fill me-2" aria-hidden="true"></i>Assigned Duty Crew
       </h6>
@@ -176,16 +177,17 @@
   </div>
   {% endif %}
 
-  {# Request Swap/Coverage buttons for assigned members #}
+  {# Crew-specific controls #}
   {% if user.is_authenticated and day >= today %}
     {% if user == assignment.instructor or user == assignment.tow_pilot or user == assignment.duty_officer or user == assignment.assistant_duty_officer %}
     <div class="card border-0 shadow-sm mb-3">
-      <div class="card-header bg-info text-white py-2">
+      <div class="card-header bg-light text-dark py-2 border-bottom">
         <h6 class="mb-0 fw-semibold">
-          <i class="bi bi-arrow-left-right me-2" aria-hidden="true"></i>Need Coverage?
+          <i class="bi bi-person-workspace me-2" aria-hidden="true"></i>Your Crew Actions
         </h6>
       </div>
       <div class="card-body p-3">
+        <p class="text-muted small mb-2">Need coverage for your assigned role?</p>
         <div class="d-grid gap-2">
           {% if config.schedule_instructors and user == assignment.instructor %}
           <a href="{% url 'duty_roster:create_swap_request' year=day.year month=day.month day=day.day role='INSTRUCTOR' %}"
@@ -211,6 +213,61 @@
             <i class="bi bi-person-badge me-2" aria-hidden="true"></i>Request {{ config.assistant_duty_officer_title|default:'Assistant DO' }} Swap
           </a>
           {% endif %}
+
+          {% if assignment and not assignment.is_scheduled %}
+            {% if assignment.tow_pilot == user or assignment.instructor == user or assignment.duty_officer == user or assignment.assistant_duty_officer == user %}
+            <hr class="my-2">
+            <p class="text-muted small mb-2">Ad-hoc signup controls</p>
+
+            {# Tow Pilot rescind #}
+            {% if assignment.tow_pilot == user %}
+            <form method="post"
+                  hx-post="{% url 'duty_roster:calendar_tow_rescind' year=assignment.date.year month=assignment.date.month day=assignment.date.day %}">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-outline-danger w-100"
+                      onclick="return confirm('Are you sure you want to rescind your tow pilot signup?');">
+                <i class="bi bi-x-circle me-2" aria-hidden="true"></i>Rescind Tow Pilot Signup
+              </button>
+            </form>
+            {% endif %}
+
+            {# Duty Officer rescind #}
+            {% if assignment.duty_officer == user %}
+            <form method="post"
+                  hx-post="{% url 'duty_roster:calendar_dutyofficer_rescind' year=assignment.date.year month=assignment.date.month day=assignment.date.day %}">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-outline-danger w-100"
+                      onclick="return confirm('Are you sure you want to rescind your duty officer signup?');">
+                <i class="bi bi-x-circle me-2" aria-hidden="true"></i>Rescind Duty Officer Signup
+              </button>
+            </form>
+            {% endif %}
+
+            {# Instructor rescind #}
+            {% if assignment.instructor == user %}
+            <form method="post"
+                  hx-post="{% url 'duty_roster:calendar_instructor_rescind' year=assignment.date.year month=assignment.date.month day=assignment.date.day %}">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-outline-danger w-100"
+                      onclick="return confirm('Are you sure you want to rescind your instructor signup?');">
+                <i class="bi bi-x-circle me-2" aria-hidden="true"></i>Rescind Instructor Signup
+              </button>
+            </form>
+            {% endif %}
+
+            {# ADO rescind (supports ad-hoc ADO signup via shovel button, issue #614) #}
+            {% if assignment.assistant_duty_officer == user %}
+            <form method="post"
+                  hx-post="{% url 'duty_roster:calendar_ado_rescind' year=assignment.date.year month=assignment.date.month day=assignment.date.day %}">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-outline-danger w-100"
+                      onclick="return confirm('Are you sure you want to rescind your assistant duty officer signup?');">
+                <i class="bi bi-x-circle me-2" aria-hidden="true"></i>Rescind ADO Signup
+              </button>
+            </form>
+            {% endif %}
+            {% endif %}
+          {% endif %}
         </div>
       </div>
     </div>
@@ -222,7 +279,7 @@
   {# Students Requesting Instruction Section — cancelled requests excluded #}
   {% if active_slots %}
   <div class="card border-0 shadow-sm mb-3">
-    <div class="card-header bg-success text-white py-2">
+    <div class="card-header bg-light text-dark py-2 border-bottom">
       <h6 class="mb-0 fw-semibold">
         <i class="bi bi-person-raised-hand me-2" aria-hidden="true"></i>Students Requesting Instruction
       </h6>
@@ -291,9 +348,9 @@
     </div>
     {% elif instruction_request_form %}
     {# Expandable instruction request form #}
-    <div class="card border-primary mb-3">
-      <div class="card-header bg-primary py-2" id="instruction-request-header">
-        <button class="btn btn-primary w-100 d-flex justify-content-between align-items-center"
+    <div class="card border-success mb-3">
+      <div class="card-header bg-success py-2" id="instruction-request-header">
+        <button class="btn btn-success w-100 d-flex justify-content-between align-items-center"
                 type="button"
                 data-bs-toggle="collapse"
                 data-bs-target="#instruction-request-form"
@@ -362,14 +419,23 @@
 
 {# Flight Intent Section #}
 {% if user.is_authenticated %}
-<div class="card border-0 shadow-sm mb-3">
-  <div class="card-header bg-primary text-white py-2">
-    <h6 class="mb-0 fw-semibold">
-      <i class="bi bi-airplane-engines me-2" aria-hidden="true"></i>Flight Plans
-    </h6>
+<div class="card border-primary shadow-sm mb-3">
+  <div class="card-header bg-primary py-2" id="plan-to-fly-header">
+    <button class="btn btn-primary w-100 d-flex justify-content-between align-items-center"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#plan-to-fly-panel"
+            aria-expanded="false"
+            aria-controls="plan-to-fly-panel">
+      <span>
+        <i class="bi bi-airplane-engines me-2" aria-hidden="true"></i>I Plan to Fly This Day
+      </span>
+      <i class="bi bi-chevron-down" aria-hidden="true"></i>
+    </button>
   </div>
-  <div class="card-body p-3">
-    <div id="ops-intent-response">
+  <div class="collapse" id="plan-to-fly-panel">
+    <div class="card-body p-3">
+      <div id="ops-intent-response">
       {% if intent_exists %}
       <div class="alert alert-success d-flex align-items-center mb-2" role="alert">
         <i class="bi bi-check-circle-fill me-2" aria-hidden="true"></i>
@@ -386,15 +452,7 @@
         </button>
       </form>
       {% elif can_submit_intent %}
-      <form
-        hx-get="{% url 'duty_roster:ops_intent_form' year=day.year month=day.month day=day.day %}"
-        hx-target="#ops-intent-response"
-        hx-swap="innerHTML"
-      >
-        <button type="submit" class="btn btn-primary w-100">
-          <i class="bi bi-airplane-engines me-2" aria-hidden="true"></i>I Plan to Fly This Day
-        </button>
-      </form>
+      {% include "duty_roster/ops_intent_form.html" with day=day available_activities=available_activities %}
       {% elif intent_blocked_reason %}
       <div class="alert alert-warning mb-0" role="alert">
         <i class="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{{ intent_blocked_reason }}
@@ -404,127 +462,98 @@
         <i class="bi bi-clock me-2" aria-hidden="true"></i>This date is in the past. You can no longer declare intent.
       </div>
       {% endif %}
-    </div>
+      </div>
 
-    {% if reservation_enabled %}
-    <hr class="my-3">
-    <h6 class="fw-semibold text-secondary mb-2">
-      <i class="bi bi-calendar-check me-2" aria-hidden="true"></i>Glider Reservations
-    </h6>
-
-    {% if reservations_remaining is not None %}
-    <p class="text-muted small mb-2">
-      Guest reservations remaining this year: <strong>{{ reservations_remaining }}</strong>
-    </p>
-    {% endif %}
-
-    {% if day_reservations %}
-    <ul class="list-group mb-2">
-      {% for res in day_reservations %}
-      <li class="list-group-item d-flex justify-content-between align-items-center">
-        <div>
-          <strong>{{ res.glider }}</strong>
-          <span class="text-muted ms-2">{{ res.member.full_display_name }}</span>
-          <div class="small text-muted">{{ res.get_reservation_type_display }}</div>
-        </div>
-        {% if res.is_trainer %}
-        <span class="badge bg-info" title="Two-seater">2S</span>
-        {% endif %}
-      </li>
-      {% endfor %}
-    </ul>
-    {% else %}
-    <p class="text-muted small mb-2">
-      <i class="bi bi-info-circle me-1" aria-hidden="true"></i>No glider reservations for this day.
-    </p>
-    {% endif %}
-
-    {% if can_reserve_glider %}
-    <a href="{% url 'duty_roster:reservation_create_for_day' day.year day.month day.day %}"
-       class="btn btn-outline-primary btn-sm w-100">
-      <i class="bi bi-stars me-2" aria-hidden="true"></i>Reserve a Glider for This Day
-    </a>
-    {% endif %}
-    {% endif %}
-
-    {# Rescind buttons for ad-hoc day crew (issue #696: signup via shovel buttons in duty crew card above) #}
-    {% if assignment and not assignment.is_scheduled %}
-      {% if assignment.tow_pilot == user or assignment.instructor == user or assignment.duty_officer == user or assignment.assistant_duty_officer == user %}
-    <hr class="my-3">
-    <h6 class="fw-semibold text-secondary mb-2">
-      <i class="bi bi-person-check me-2" aria-hidden="true"></i>Your Ad-Hoc Assignment:
-    </h6>
-    <div class="d-grid gap-2">
-      {# Tow Pilot rescind #}
-      {% if assignment.tow_pilot == user %}
-      <form method="post"
-            hx-post="{% url 'duty_roster:calendar_tow_rescind' year=assignment.date.year month=assignment.date.month day=assignment.date.day %}">
-        {% csrf_token %}
-        <button type="submit" class="btn btn-outline-danger w-100"
-                onclick="return confirm('Are you sure you want to rescind your tow pilot signup?');">
-          <i class="bi bi-x-circle me-2" aria-hidden="true"></i>Rescind Tow Pilot Signup
-        </button>
-      </form>
-      {% endif %}
-
-      {# Duty Officer rescind #}
-      {% if assignment.duty_officer == user %}
-      <form method="post"
-            hx-post="{% url 'duty_roster:calendar_dutyofficer_rescind' year=assignment.date.year month=assignment.date.month day=assignment.date.day %}">
-        {% csrf_token %}
-        <button type="submit" class="btn btn-outline-danger w-100"
-                onclick="return confirm('Are you sure you want to rescind your duty officer signup?');">
-          <i class="bi bi-x-circle me-2" aria-hidden="true"></i>Rescind Duty Officer Signup
-        </button>
-      </form>
-      {% endif %}
-
-      {# Instructor rescind #}
-      {% if assignment.instructor == user %}
-      <form method="post"
-            hx-post="{% url 'duty_roster:calendar_instructor_rescind' year=assignment.date.year month=assignment.date.month day=assignment.date.day %}">
-        {% csrf_token %}
-        <button type="submit" class="btn btn-outline-danger w-100"
-                onclick="return confirm('Are you sure you want to rescind your instructor signup?');">
-          <i class="bi bi-x-circle me-2" aria-hidden="true"></i>Rescind Instructor Signup
-        </button>
-      </form>
-      {% endif %}
-
-      {# ADO rescind (supports ad-hoc ADO signup via shovel button, issue #614) #}
-      {% if assignment.assistant_duty_officer == user %}
-      <form method="post"
-            hx-post="{% url 'duty_roster:calendar_ado_rescind' year=assignment.date.year month=assignment.date.month day=assignment.date.day %}">
-        {% csrf_token %}
-        <button type="submit" class="btn btn-outline-danger w-100"
-                onclick="return confirm('Are you sure you want to rescind your assistant duty officer signup?');">
-          <i class="bi bi-x-circle me-2" aria-hidden="true"></i>Rescind ADO Signup
-        </button>
-      </form>
+      {# List of pilots planning to fly #}
+      {% if intents %}
+      <hr class="my-3">
+      <h6 class="fw-semibold text-primary mb-2">
+        <i class="bi bi-people me-2" aria-hidden="true"></i>Pilots Planning to Fly:
+      </h6>
+      <ul class="list-group list-group-flush">
+        {% for intent in intents %}
+        <li class="list-group-item px-0 py-1">
+          <i class="bi bi-person me-2 text-muted" aria-hidden="true"></i>{{ intent.member.full_display_name }}
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <hr class="my-3">
+      <p class="text-muted mb-0">
+        <i class="bi bi-info-circle me-2" aria-hidden="true"></i>No one has declared intent yet.
+      </p>
       {% endif %}
     </div>
-    {% endif %}
-    {% endif %}
+  </div>
+</div>
 
-    {# List of pilots planning to fly #}
-    {% if intents %}
-    <hr class="my-3">
-    <h6 class="fw-semibold text-primary mb-2">
-      <i class="bi bi-people me-2" aria-hidden="true"></i>Pilots Planning to Fly:
-    </h6>
-    <ul class="list-group list-group-flush">
-      {% for intent in intents %}
-      <li class="list-group-item px-0 py-1">
-        <i class="bi bi-person me-2 text-muted" aria-hidden="true"></i>{{ intent.member.full_display_name }}
-      </li>
-      {% endfor %}
-    </ul>
-    {% else %}
-    <hr class="my-3">
-    <p class="text-muted mb-0">
-      <i class="bi bi-info-circle me-2" aria-hidden="true"></i>No one has declared intent yet.
-    </p>
-    {% endif %}
+<div class="card border-info shadow-sm mb-3">
+  <div class="card-header bg-info py-2" id="reserve-glider-header">
+    <button class="btn btn-info text-dark w-100 d-flex justify-content-between align-items-center"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#reserve-glider-panel"
+            aria-expanded="false"
+            aria-controls="reserve-glider-panel">
+      <span>
+        <i class="bi bi-calendar-check me-2" aria-hidden="true"></i>Reserve a Glider
+      </span>
+      <i class="bi bi-chevron-down" aria-hidden="true"></i>
+    </button>
+  </div>
+  <div class="collapse" id="reserve-glider-panel">
+    <div class="card-body p-3">
+      <h6 class="fw-semibold text-secondary mb-2">Requirements</h6>
+      <ul class="mb-3 text-muted small">
+        <li>You must be an active member in good standing.</li>
+        <li>You must have guest reservations remaining for the year.</li>
+        <li>Glider availability and existing reservations still apply.</li>
+      </ul>
+
+      {% if reservation_enabled %}
+      <h6 class="fw-semibold text-secondary mb-2">
+        <i class="bi bi-calendar-check me-2" aria-hidden="true"></i>Glider Reservations
+      </h6>
+
+      {% if reservations_remaining is not None %}
+      <p class="text-muted small mb-2">
+        Guest reservations remaining this year: <strong>{{ reservations_remaining }}</strong>
+      </p>
+      {% endif %}
+
+      {% if day_reservations %}
+      <ul class="list-group mb-2">
+        {% for res in day_reservations %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <div>
+            <strong>{{ res.glider }}</strong>
+            <span class="text-muted ms-2">{{ res.member.full_display_name }}</span>
+            <div class="small text-muted">{{ res.get_reservation_type_display }}</div>
+          </div>
+          {% if res.is_trainer %}
+          <span class="badge bg-info" title="Two-seater">2S</span>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="text-muted small mb-2">
+        <i class="bi bi-info-circle me-1" aria-hidden="true"></i>No glider reservations for this day.
+      </p>
+      {% endif %}
+
+      {% if can_reserve_glider %}
+      <a href="{% url 'duty_roster:reservation_create_for_day' day.year day.month day.day %}"
+         class="btn btn-outline-primary btn-sm w-100">
+        <i class="bi bi-stars me-2" aria-hidden="true"></i>Reserve a Glider for This Day
+      </a>
+      {% endif %}
+      {% else %}
+      <p class="text-muted mb-0">
+        <i class="bi bi-info-circle me-2" aria-hidden="true"></i>Glider reservations are not enabled.
+      </p>
+      {% endif %}
+    </div>
   </div>
 </div>
 {% endif %}
@@ -532,36 +561,38 @@
 {# Admin Section: Edit Duty Crew #}
 {% if user.is_authenticated and user.rostermeister %}
 <div class="card border-0 shadow-sm mb-3">
-  <div class="card-header bg-dark text-white py-2">
-    <h6 class="mb-0 fw-semibold">
-      <i class="bi bi-gear me-2" aria-hidden="true"></i>Admin Options
-    </h6>
-  </div>
   <div class="card-body p-3">
-    <div id="assignment-edit-slot">
-      <form
-        hx-get="{% url 'duty_roster:assignment_edit_form' year=day.year month=day.month day=day.day %}"
-        hx-target="#assignment-edit-slot"
-        hx-swap="innerHTML"
-      >
-        <button type="submit" class="btn btn-outline-secondary w-100">
-          <i class="bi bi-pencil me-2" aria-hidden="true"></i>Edit Duty Crew
-        </button>
-      </form>
-    </div>
+    <details>
+      <summary class="fw-semibold text-secondary" style="cursor:pointer;">
+        <i class="bi bi-gear me-2" aria-hidden="true"></i>Admin Options
+      </summary>
+      <div class="mt-3">
+        <div id="assignment-edit-slot">
+          <form
+            hx-get="{% url 'duty_roster:assignment_edit_form' year=day.year month=day.month day=day.day %}"
+            hx-target="#assignment-edit-slot"
+            hx-swap="innerHTML"
+          >
+            <button type="submit" class="btn btn-outline-secondary w-100">
+              <i class="bi bi-pencil me-2" aria-hidden="true"></i>Edit Duty Crew
+            </button>
+          </form>
+        </div>
 
-    {% if assignment and not assignment.is_scheduled and assignment.date >= today %}
-    <div class="mt-2">
-      <button
-        class="btn btn-outline-danger w-100"
-        hx-get="{% url 'duty_roster:calendar_cancel_ops_modal' year=assignment.date.year month=assignment.date.month day=assignment.date.day %}"
-        hx-target="#modal-body"
-        hx-swap="innerHTML"
-      >
-        <i class="bi bi-x-octagon me-2" aria-hidden="true"></i>Cancel Operations for this day
-      </button>
-    </div>
-    {% endif %}
+        {% if assignment and not assignment.is_scheduled and assignment.date >= today %}
+        <div class="mt-2">
+          <button
+            class="btn btn-outline-danger w-100"
+            hx-get="{% url 'duty_roster:calendar_cancel_ops_modal' year=assignment.date.year month=assignment.date.month day=assignment.date.day %}"
+            hx-target="#modal-body"
+            hx-swap="innerHTML"
+          >
+            <i class="bi bi-x-octagon me-2" aria-hidden="true"></i>Cancel Operations for this day
+          </button>
+        </div>
+        {% endif %}
+      </div>
+    </details>
   </div>
 </div>
 {% endif %}

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -506,7 +506,7 @@
       <h6 class="fw-semibold text-secondary mb-2">Requirements</h6>
       <ul class="mb-3 text-muted small">
         <li>You must be an active member in good standing.</li>
-        <li>You must have guest reservations remaining for the year.</li>
+        <li>You must have reservations remaining for the year.</li>
         <li>Glider availability and existing reservations still apply.</li>
       </ul>
 
@@ -517,7 +517,7 @@
 
       {% if reservations_remaining is not None %}
       <p class="text-muted small mb-2">
-        Guest reservations remaining this year: <strong>{{ reservations_remaining }}</strong>
+        Reservations remaining this year: <strong>{{ reservations_remaining }}</strong>
       </p>
       {% endif %}
 
@@ -547,6 +547,14 @@
          class="btn btn-outline-primary btn-sm w-100">
         <i class="bi bi-stars me-2" aria-hidden="true"></i>Reserve a Glider for This Day
       </a>
+      {% elif reserve_message %}
+      <p class="text-muted small mb-0">
+        <i class="bi bi-info-circle me-2" aria-hidden="true"></i>{{ reserve_message }}
+      </p>
+      {% else %}
+      <p class="text-muted small mb-0">
+        <i class="bi bi-info-circle me-2" aria-hidden="true"></i>You don't currently meet the requirements to reserve a glider for this day.
+      </p>
       {% endif %}
       {% else %}
       <p class="text-muted mb-0">

--- a/duty_roster/templates/duty_roster/emails/ops_intent_notification.html
+++ b/duty_roster/templates/duty_roster/emails/ops_intent_notification.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Student Plans to Fly</title>
+    <title>Member Flight Intent</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
     <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #f4f4f4;">
@@ -26,8 +26,8 @@
                             {% if club_logo_url %}
                             <img src="{{ club_logo_url }}" alt="{{ club_name }} Logo" style="max-height: 60px; max-width: 200px; height: auto; margin-bottom: 15px;">
                             {% endif %}
-                            <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: bold;">Student Flight Intent</h1>
-                            <p style="margin: 10px 0 0 0; color: #ffffff; font-size: 14px;">A student is planning to fly on {{ ops_date }}</p>
+                            <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: bold;">Member Flight Intent</h1>
+                            <p style="margin: 10px 0 0 0; color: #ffffff; font-size: 14px;">A member has added flying intent for {{ ops_date }}</p>
                             <!--[if mso]>
                             </td>
                             </tr>
@@ -49,21 +49,26 @@
                                 Hi {{ instructor_name }},
                             </p>
 
-                            <!-- Student Info Card -->
+                            <!-- Intent Details Card -->
                             <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #e7f3ff; border-left: 4px solid #0066cc; border-radius: 4px; margin-bottom: 20px;">
                                 <tr>
                                     <td style="padding: 20px;">
-                                        <h2 style="margin: 0 0 15px 0; color: #0066cc; font-size: 18px;">👨‍🎓 {{ student_name }}</h2>
+                                        <h2 style="margin: 0 0 15px 0; color: #0066cc; font-size: 18px;">🛩️ {{ member_name }}</h2>
 
                                         <p style="margin: 0; color: #333333; font-size: 14px; line-height: 1.6;">
-                                            Your student has indicated their intent to fly on <strong>{{ ops_date }}</strong>.
+                                            This member has indicated the following intent for <strong>{{ ops_date }}</strong>:
                                         </p>
+                                        <ul style="margin: 10px 0 0 18px; padding: 0; color: #333333; font-size: 14px; line-height: 1.6;">
+                                            {% for label in intent_labels %}
+                                            <li>{{ label }}</li>
+                                            {% endfor %}
+                                        </ul>
                                     </td>
                                 </tr>
                             </table>
 
                             <p style="margin: 0 0 20px 0; color: #666666; font-size: 14px; line-height: 1.6;">
-                                This is a courtesy notification to help you plan your instructional availability. If you're available to instruct, please consider confirming your attendance to ensure {{ student_name }} can fly as planned.
+                                This is a courtesy notification to help you plan instructional availability. If instructional support is needed, please consider confirming your attendance.
                             </p>
 
                             <!-- Call to Action -->

--- a/duty_roster/templates/duty_roster/emails/ops_intent_notification.txt
+++ b/duty_roster/templates/duty_roster/emails/ops_intent_notification.txt
@@ -1,13 +1,17 @@
-👨‍🎓 Student Flight Intent - {{ ops_date }}
+🛩️ Member Flight Intent - {{ ops_date }}
 ================================================================================
 
 Hi {{ instructor_name }},
 
-Your student {{ student_name }} has indicated their intent to fly on {{ ops_date }}.
+{{ member_name }} has indicated a flying intent on {{ ops_date }}.
+
+Intent selected:
+{% for label in intent_labels %}
+- {{ label }}
+{% endfor %}
 
 This is a courtesy notification to help you plan your instructional availability.
-If you're available to instruct, please consider confirming your attendance to
-ensure {{ student_name }} can fly as planned.
+If instructional support is needed, please consider confirming your attendance.
 
 View Duty Roster: {{ roster_url }}
 

--- a/duty_roster/templates/duty_roster/ops_intent_form.html
+++ b/duty_roster/templates/duty_roster/ops_intent_form.html
@@ -4,8 +4,8 @@
   hx-swap="innerHTML"
 >
   {% csrf_token %}
-  <p class="mb-1">I plan to fly this day. My intent:</p>
-  <p class="text-muted small mb-2">
+  <p class="mb-1 fw-semibold">I plan to fly this day. My intent:</p>
+  <p class="text-muted small mb-3">
     This is for general flying plans. Use <strong>Request Instruction</strong> for instructor scheduling.
   </p>
   {% comment %} Render available activity checkboxes from the view-provided list. {% endcomment %}
@@ -16,5 +16,7 @@
   </div>
   {% endfor %}
 
-  <button type="submit" class="btn btn-sm btn-primary mt-2">Submit</button>
+  <button type="submit" class="btn btn-success w-100 mt-3">
+    <i class="bi bi-check-circle me-2" aria-hidden="true"></i>Submit Intent
+  </button>
 </form>

--- a/duty_roster/templates/duty_roster/ops_intent_form.html
+++ b/duty_roster/templates/duty_roster/ops_intent_form.html
@@ -16,7 +16,7 @@
   </div>
   {% endfor %}
 
-  <button type="submit" class="btn btn-success w-100 mt-3">
+  <button type="submit" class="btn btn-primary w-100 mt-3">
     <i class="bi bi-check-circle me-2" aria-hidden="true"></i>Submit Intent
   </button>
 </form>

--- a/duty_roster/templates/duty_roster/ops_intent_form.html
+++ b/duty_roster/templates/duty_roster/ops_intent_form.html
@@ -5,6 +5,9 @@
 >
   {% csrf_token %}
   <p class="mb-1">I plan to fly this day. My intent:</p>
+  <p class="text-muted small mb-2">
+    This is for general flying plans. Use <strong>Request Instruction</strong> for instructor scheduling.
+  </p>
   {% comment %} Render available activity checkboxes from the view-provided list. {% endcomment %}
   {% for key,label in available_activities %}
   <div class="form-check">

--- a/duty_roster/tests/test_ops_intent.py
+++ b/duty_roster/tests/test_ops_intent.py
@@ -12,13 +12,19 @@ def test_available_as_labels_returns_human_labels(db, django_user_model):
     # create an OpsIntent with two valid activities
     day = date(2025, 11, 8)
     intent = OpsIntent.objects.create(
-        member=user, date=day, available_as=["club", "towpilot"]
+        member=user, date=day, available_as=["club_single", "guest"]
     )
 
     labels = intent.available_as_labels()
     assert isinstance(labels, list)
-    assert "Club glider" in labels
-    assert "Tow Pilot" in labels
+    assert "Fly Club Single-Seater" in labels
+    assert "Fly with Guest" in labels
+
+
+@pytest.mark.django_db
+def test_available_activities_match_issue_803_choices():
+    keys = [key for key, _label in OpsIntent.AVAILABLE_ACTIVITIES]
+    assert keys == ["club_single", "club_two", "guest", "private"]
 
 
 @pytest.mark.django_db
@@ -44,3 +50,19 @@ def test_available_as_labels_falls_back_for_legacy_instruction_data(
     # Falls back to raw key for missing entry; "Club glider" is still mapped.
     assert "instruction" in labels
     assert "Club glider" in labels
+
+
+@pytest.mark.django_db
+def test_available_as_labels_supports_legacy_keys(db, django_user_model):
+    user = django_user_model.objects.create(
+        username="legacy_ops_user", email="legacy_ops@example.com"
+    )
+    intent = OpsIntent.objects.create(
+        member=user,
+        date=date(2025, 11, 9),
+        available_as=["towpilot", "glider_pilot"],
+    )
+
+    labels = intent.available_as_labels()
+    assert "Tow Pilot" in labels
+    assert "Glider Pilot" in labels

--- a/duty_roster/tests/test_ops_intent.py
+++ b/duty_roster/tests/test_ops_intent.py
@@ -24,7 +24,13 @@ def test_available_as_labels_returns_human_labels(db, django_user_model):
 @pytest.mark.django_db
 def test_available_activities_match_issue_803_choices():
     keys = [key for key, _label in OpsIntent.AVAILABLE_ACTIVITIES]
-    assert keys == ["club_single", "club_two", "guest", "private"]
+    assert keys == [
+        "club_single",
+        "club_two",
+        "guest",
+        "private",
+        "faa_practical_test",
+    ]
 
 
 @pytest.mark.django_db

--- a/duty_roster/tests/test_ops_intent_toggle.py
+++ b/duty_roster/tests/test_ops_intent_toggle.py
@@ -1,0 +1,162 @@
+from datetime import date, timedelta
+
+import pytest
+from django.core import mail
+from django.test import override_settings
+from django.urls import reverse
+
+from duty_roster.models import DutyAssignment, InstructionSlot, OpsIntent
+
+
+def _create_member(django_user_model, username, email, **extra):
+    defaults = {
+        "first_name": username.capitalize(),
+        "last_name": "Member",
+        "membership_status": "Full Member",
+    }
+    defaults.update(extra)
+    return django_user_model.objects.create_user(
+        username=username,
+        email=email,
+        password="testpass123",
+        **defaults,
+    )
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DEFAULT_FROM_EMAIL="noreply@testclub.com",
+    EMAIL_DEV_MODE=False,
+)
+def test_ops_intent_toggle_sends_member_flight_intent_email_for_club_single(
+    client, django_user_model
+):
+    pilot = _create_member(
+        django_user_model,
+        username="pilot1",
+        email="pilot1@example.com",
+        first_name="Pat",
+        last_name="Pilot",
+    )
+    instructor = _create_member(
+        django_user_model,
+        username="inst1",
+        email="inst1@example.com",
+        instructor=True,
+        first_name="Ivy",
+        last_name="Instructor",
+    )
+
+    ops_day = date.today() + timedelta(days=7)
+    DutyAssignment.objects.create(date=ops_day, instructor=instructor)
+
+    client.force_login(pilot)
+    mail.outbox.clear()
+
+    response = client.post(
+        reverse(
+            "duty_roster:ops_intent_toggle",
+            kwargs={"year": ops_day.year, "month": ops_day.month, "day": ops_day.day},
+        ),
+        data={"available_as": ["club_single"]},
+    )
+
+    assert response.status_code == 200
+    intent = OpsIntent.objects.get(member=pilot, date=ops_day)
+    assert intent.available_as == ["club_single"]
+
+    assert len(mail.outbox) == 1
+    email = mail.outbox[0]
+    assert "Member Flight Intent" in email.subject
+    assert instructor.email in email.to
+    assert "Fly Club Single-Seater" in email.body
+    assert pilot.full_display_name in email.body
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DEFAULT_FROM_EMAIL="noreply@testclub.com",
+    EMAIL_DEV_MODE=False,
+)
+def test_ops_intent_toggle_does_not_notify_for_private_only_intent(
+    client, django_user_model
+):
+    pilot = _create_member(
+        django_user_model,
+        username="pilot2",
+        email="pilot2@example.com",
+    )
+    instructor = _create_member(
+        django_user_model,
+        username="inst2",
+        email="inst2@example.com",
+        instructor=True,
+    )
+
+    ops_day = date.today() + timedelta(days=8)
+    DutyAssignment.objects.create(date=ops_day, instructor=instructor)
+
+    client.force_login(pilot)
+    mail.outbox.clear()
+
+    response = client.post(
+        reverse(
+            "duty_roster:ops_intent_toggle",
+            kwargs={"year": ops_day.year, "month": ops_day.month, "day": ops_day.day},
+        ),
+        data={"available_as": ["private"]},
+    )
+
+    assert response.status_code == 200
+    intent = OpsIntent.objects.get(member=pilot, date=ops_day)
+    assert intent.available_as == ["private"]
+    assert len(mail.outbox) == 0
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DEFAULT_FROM_EMAIL="noreply@testclub.com",
+    EMAIL_DEV_MODE=False,
+)
+def test_ops_intent_toggle_blocks_new_intent_when_instruction_request_exists(
+    client, django_user_model
+):
+    pilot = _create_member(
+        django_user_model,
+        username="pilot3",
+        email="pilot3@example.com",
+    )
+    instructor = _create_member(
+        django_user_model,
+        username="inst3",
+        email="inst3@example.com",
+        instructor=True,
+    )
+
+    ops_day = date.today() + timedelta(days=9)
+    assignment = DutyAssignment.objects.create(date=ops_day, instructor=instructor)
+    InstructionSlot.objects.create(
+        assignment=assignment,
+        student=pilot,
+        instruction_types=["general"],
+        status="pending",
+    )
+
+    client.force_login(pilot)
+    mail.outbox.clear()
+
+    response = client.post(
+        reverse(
+            "duty_roster:ops_intent_toggle",
+            kwargs={"year": ops_day.year, "month": ops_day.month, "day": ops_day.day},
+        ),
+        data={"available_as": ["club_single"]},
+    )
+
+    assert response.status_code == 200
+    assert OpsIntent.objects.filter(member=pilot, date=ops_day).count() == 0
+    assert "already requested instruction" in response.content.decode()
+    assert len(mail.outbox) == 0

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -469,7 +469,7 @@ def calendar_day_detail(request, year, month, day):
         if assignment
         else 0
     )
-    tow_intent_keys = {"club", "club_single", "club_two", "private"}
+    tow_intent_keys = {"club", "club_single", "club_two", "private", "guest"}
     tow_count = sum(
         1 for i in intents if any(key in tow_intent_keys for key in i.available_as)
     )
@@ -518,7 +518,12 @@ def calendar_day_detail(request, year, month, day):
                 "Use only Request Instruction or cancel that request first."
             )
 
-    reservation_config = SiteConfiguration.objects.first()
+    site_config = cache.get("siteconfig_instance", _SITECONFIG_CACHE_SENTINEL)
+    if site_config is _SITECONFIG_CACHE_SENTINEL:
+        site_config = SiteConfiguration.objects.first()
+        cache.set("siteconfig_instance", site_config, timeout=60)
+
+    reservation_config = site_config
     reservation_enabled = bool(
         reservation_config and reservation_config.allow_glider_reservations
     )
@@ -553,22 +558,15 @@ def calendar_day_detail(request, year, month, day):
     scheduled_holes = {}
     volunteerable_holes = {}
     if assignment and day_date >= date.today():
-        # Reuse the cached SiteConfiguration to avoid an extra DB query and keep
-        # configuration reads consistent within the same request (same 60s cache
-        # as get_surge_thresholds / _check_instruction_request_window).
-        _cfg = cache.get("siteconfig_instance", _SITECONFIG_CACHE_SENTINEL)
-        if _cfg is _SITECONFIG_CACHE_SENTINEL:
-            _cfg = SiteConfiguration.objects.first()
-            cache.set("siteconfig_instance", _cfg, timeout=60)
-        if _cfg:
-            if _cfg.schedule_instructors and not assignment.instructor:
+        if site_config:
+            if site_config.schedule_instructors and not assignment.instructor:
                 scheduled_holes["instructor"] = True
-            if _cfg.schedule_tow_pilots and not assignment.tow_pilot:
+            if site_config.schedule_tow_pilots and not assignment.tow_pilot:
                 scheduled_holes["tow_pilot"] = True
-            if _cfg.schedule_duty_officers and not assignment.duty_officer:
+            if site_config.schedule_duty_officers and not assignment.duty_officer:
                 scheduled_holes["duty_officer"] = True
             if (
-                _cfg.schedule_assistant_duty_officers
+                site_config.schedule_assistant_duty_officers
                 and not assignment.assistant_duty_officer
             ):
                 scheduled_holes["assistant_duty_officer"] = True

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -50,6 +50,7 @@ from .models import (
     DutyPairing,
     DutyPreference,
     DutyRosterMessage,
+    GliderReservation,
     MemberBlackout,
     OpsIntent,
 )

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -441,6 +441,7 @@ def calendar_day_detail(request, year, month, day):
 
     # Show current user intent status
     intent_exists = False
+    intent_blocked_reason = ""
     can_submit_intent = request.user.is_authenticated and day_date >= date.today()
     if request.user.is_authenticated:
         intent_exists = OpsIntent.objects.filter(
@@ -466,8 +467,9 @@ def calendar_day_detail(request, year, month, day):
         if assignment
         else 0
     )
+    tow_intent_keys = {"club", "club_single", "club_two", "private"}
     tow_count = sum(
-        1 for i in intents if "club" in i.available_as or "private" in i.available_as
+        1 for i in intents if any(key in tow_intent_keys for key in i.available_as)
     )
 
     show_surge_alert = instruction_intent_count >= instruction_surge_threshold
@@ -507,6 +509,37 @@ def calendar_day_detail(request, year, month, day):
                 assignment=assignment, student=request.user
             )
 
+        if user_has_instruction_request and not intent_exists:
+            can_submit_intent = False
+            intent_blocked_reason = (
+                "You already requested instruction for this day. "
+                "Use only Request Instruction or cancel that request first."
+            )
+
+    reservation_config = SiteConfiguration.objects.first()
+    reservation_enabled = bool(
+        reservation_config and reservation_config.allow_glider_reservations
+    )
+    day_reservations = []
+    can_reserve_glider = False
+    reservations_remaining = None
+
+    if request.user.is_authenticated and reservation_enabled:
+        day_reservations = GliderReservation.get_reservations_for_date(day_date)
+        can_reserve_glider, _reserve_message = GliderReservation.can_member_reserve(
+            request.user,
+            year=day_date.year,
+            month=day_date.month,
+        )
+
+        max_per_year = reservation_config.max_reservations_per_year
+        if max_per_year > 0:
+            current_year_count = GliderReservation.get_member_yearly_count(
+                request.user,
+                year=day_date.year,
+            )
+            reservations_remaining = max(0, max_per_year - current_year_count)
+
     # Determine scheduled but empty roles (visible to all users as an "unfilled" indicator)
     # and the subset the current user is qualified to volunteer for (Issue #679).
     scheduled_holes = {}
@@ -545,6 +578,7 @@ def calendar_day_detail(request, year, month, day):
             "day": day_date,
             "assignment": assignment,
             "intent_exists": intent_exists,
+            "intent_blocked_reason": intent_blocked_reason,
             "can_submit_intent": can_submit_intent,
             "intents": intents,
             "show_surge_alert": show_surge_alert,
@@ -582,6 +616,10 @@ def calendar_day_detail(request, year, month, day):
                 and assignment.surge_tow_pilot_id is None
                 and request.user.id != assignment.tow_pilot_id
             ),
+            "reservation_enabled": reservation_enabled,
+            "day_reservations": day_reservations,
+            "can_reserve_glider": can_reserve_glider,
+            "reservations_remaining": reservations_remaining,
         },
     )
 
@@ -594,12 +632,36 @@ def ops_intent_toggle(request, year, month, day):
     from django.conf import settings
 
     day_date = date(year, month, day)
+    available_as = request.POST.getlist("available_as") or []
+
+    assignment = DutyAssignment.objects.filter(date=day_date).first()
+
+    if request.user.is_authenticated and assignment and available_as:
+        from .models import InstructionSlot
+
+        has_instruction_request = (
+            InstructionSlot.objects.filter(
+                assignment=assignment,
+                student=request.user,
+            )
+            .exclude(status="cancelled")
+            .exists()
+        )
+        if has_instruction_request:
+            response = format_html(
+                '<p class="text-warning">⚠️ You already requested instruction for this day. '
+                "Use one workflow at a time to avoid duplicate planning.</p>"
+                '<form hx-get="{}form/" '
+                'hx-target="#ops-intent-response" hx-swap="innerHTML">'
+                '<button type="submit" class="btn btn-sm btn-primary">'
+                "🛩️ I Plan to Fly This Day</button></form>",
+                request.path,
+            )
+            return HttpResponse(response)
 
     # remember prior intent so we only email on true cancellations
     old_intent = OpsIntent.objects.filter(member=request.user, date=day_date).first()
     old_available = old_intent.available_as if old_intent else []
-
-    available_as = request.POST.getlist("available_as") or []
 
     # enforce site-configured instruction request window (Issue #648)
     if "instruction" in available_as:
@@ -629,17 +691,12 @@ def ops_intent_toggle(request, year, month, day):
             member=request.user, date=day_date, defaults={"available_as": available_as}
         )
 
-        # who’s signed up now?
-        intents = OpsIntent.objects.filter(date=day_date)
-        students = [
-            i.member.full_display_name
-            for i in intents
-            if "instruction" in i.available_as
-        ]
-
         assignment, _ = DutyAssignment.objects.get_or_create(date=day_date)
         duty_inst = assignment.instructor
         surge_inst = assignment.surge_instructor
+
+        notify_keys = {"club_single", "club_two", "guest", "club"}
+        should_notify_instructors = any(k in notify_keys for k in available_as)
 
         # recipients: duty instructor plus (if exists) surge instructor
         recipients = []
@@ -648,16 +705,22 @@ def ops_intent_toggle(request, year, month, day):
         if surge_inst and surge_inst.email:
             recipients.append(surge_inst.email)
 
-        if recipients:
+        if recipients and should_notify_instructors:
+            intent_labels = OpsIntent(
+                member=request.user,
+                date=day_date,
+                available_as=available_as,
+            ).available_as_labels()
             # Prepare template context
             email_config = get_email_config()
 
             context = {
-                "student_name": request.user.full_display_name,
+                "member_name": request.user.full_display_name,
                 "instructor_name": (
                     duty_inst.full_display_name if duty_inst else "Instructor"
                 ),
                 "ops_date": day_date.strftime("%A, %B %d, %Y"),
+                "intent_labels": intent_labels,
                 "club_name": email_config["club_name"],
                 "club_logo_url": get_absolute_club_logo_url(email_config["config"]),
                 "roster_url": email_config["roster_url"],
@@ -672,7 +735,7 @@ def ops_intent_toggle(request, year, month, day):
             )
 
             send_mail(
-                subject=f"[{email_config['club_name']}] Student Plans to Fly - {day_date:%b %d}",
+                subject=f"[{email_config['club_name']}] Member Flight Intent - {day_date:%b %d}",
                 message=text_message,
                 from_email=email_config["from_email"],
                 recipient_list=recipients,

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -621,6 +621,7 @@ def calendar_day_detail(request, year, month, day):
             "day_reservations": day_reservations,
             "can_reserve_glider": can_reserve_glider,
             "reservations_remaining": reservations_remaining,
+            "available_activities": OpsIntent.AVAILABLE_ACTIVITIES,
         },
     )
 
@@ -649,16 +650,19 @@ def ops_intent_toggle(request, year, month, day):
             .exists()
         )
         if has_instruction_request:
-            response = format_html(
-                '<p class="text-warning">⚠️ You already requested instruction for this day. '
+            warning_html = (
+                '<p class="text-warning mb-2">⚠️ You already requested instruction for this day. '
                 "Use one workflow at a time to avoid duplicate planning.</p>"
-                '<form hx-get="{}form/" '
-                'hx-target="#ops-intent-response" hx-swap="innerHTML">'
-                '<button type="submit" class="btn btn-sm btn-primary">'
-                "🛩️ I Plan to Fly This Day</button></form>",
-                request.path,
             )
-            return HttpResponse(response)
+            form_html = render_to_string(
+                "duty_roster/ops_intent_form.html",
+                {
+                    "day": day_date,
+                    "available_activities": OpsIntent.AVAILABLE_ACTIVITIES,
+                },
+                request=request,
+            )
+            return HttpResponse(f"{warning_html}{form_html}")
 
     # remember prior intent so we only email on true cancellations
     old_intent = OpsIntent.objects.filter(member=request.user, date=day_date).first()
@@ -673,18 +677,19 @@ def ops_intent_toggle(request, year, month, day):
                 if opens_on_intent
                 else "a future date"
             )
-            response = format_html(
-                '<p class="text-danger">⏰ Instruction requests for this date do not open until {}.</p>'
-                '<form hx-get="{}form/" '
-                'hx-post="{}" '
-                'hx-target="#ops-intent-response" hx-swap="innerHTML">'
-                '<button type="submit" class="btn btn-sm btn-primary">'
-                "🛩️ I Plan to Fly This Day</button></form>",
+            warning_html = format_html(
+                '<p class="text-danger mb-2">⏰ Instruction requests for this date do not open until {}.</p>',
                 opens_str,
-                request.path,
-                request.path,
             )
-            return HttpResponse(response)
+            form_html = render_to_string(
+                "duty_roster/ops_intent_form.html",
+                {
+                    "day": day_date,
+                    "available_activities": OpsIntent.AVAILABLE_ACTIVITIES,
+                },
+                request=request,
+            )
+            return HttpResponse(f"{warning_html}{form_html}")
 
     # SIGNUP FLOW
     if available_as:
@@ -792,14 +797,18 @@ def ops_intent_toggle(request, year, month, day):
                 )
 
         OpsIntent.objects.filter(member=request.user, date=day_date).delete()
-        response = format_html(
-            '<p class="text-gray-700">❌ You\'ve removed your intent to fly.</p>'
-            '<form hx-get="{}form/" '
-            'hx-target="#ops-intent-response" hx-swap="innerHTML">'
-            '<button type="submit" class="btn btn-sm btn-primary">'
-            "🛩️ I Plan to Fly This Day</button></form>",
-            request.path,
+        info_html = (
+            '<p class="text-gray-700 mb-2">❌ You\'ve removed your intent to fly.</p>'
         )
+        form_html = render_to_string(
+            "duty_roster/ops_intent_form.html",
+            {
+                "day": day_date,
+                "available_activities": OpsIntent.AVAILABLE_ACTIVITIES,
+            },
+            request=request,
+        )
+        response = f"{info_html}{form_html}"
 
     # still check for surges across the board
     maybe_notify_surge_instructor(day_date)

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -70,6 +70,9 @@ logger = logging.getLogger("duty_roster.views")
 ALLOWED_ROLES = ["instructor", "duty_officer", "assistant_duty_officer", "towpilot"]
 MAX_PROPOSAL_RANGE_MONTHS = 12
 
+# OpsIntent activity keys that contribute to tow demand/surge calculations.
+TOW_INTENT_KEYS = {"club", "club_single", "club_two", "guest", "private"}
+
 
 def calendar_refresh_response(year, month):
     """Helper function to create HTMX response that refreshes calendar with month context"""
@@ -380,11 +383,10 @@ def duty_calendar_view(request, year=None, month=None):
         instruction_count[row["assignment__date"]] += row["_count"]
 
     # Tow surge: driven by tow-relevant OpsIntent activity flags (Issue #803).
-    tow_intent_keys = {"club", "club_single", "club_two", "guest", "private"}
     intents = OpsIntent.objects.filter(date__in=visible_dates)
     for intent in intents:
         roles = intent.available_as or []
-        if any(key in tow_intent_keys for key in roles):
+        if any(key in TOW_INTENT_KEYS for key in roles):
             tow_count[intent.date] += 1
 
     surge_needed_by_date = {}
@@ -469,9 +471,8 @@ def calendar_day_detail(request, year, month, day):
         if assignment
         else 0
     )
-    tow_intent_keys = {"club", "club_single", "club_two", "private", "guest"}
     tow_count = sum(
-        1 for i in intents if any(key in tow_intent_keys for key in i.available_as)
+        1 for i in intents if any(key in TOW_INTENT_KEYS for key in i.available_as)
     )
 
     show_surge_alert = instruction_intent_count >= instruction_surge_threshold
@@ -523,9 +524,18 @@ def calendar_day_detail(request, year, month, day):
         site_config = SiteConfiguration.objects.first()
         cache.set("siteconfig_instance", site_config, timeout=60)
 
+    active_statuses = set(get_active_membership_statuses())
+    can_access_reservations = bool(
+        request.user.is_authenticated
+        and request.user.is_active
+        and request.user.membership_status in active_statuses
+    )
+
     reservation_config = site_config
     reservation_enabled = bool(
-        reservation_config and reservation_config.allow_glider_reservations
+        reservation_config
+        and reservation_config.allow_glider_reservations
+        and can_access_reservations
     )
     day_reservations = []
     can_reserve_glider = False
@@ -538,6 +548,7 @@ def calendar_day_detail(request, year, month, day):
             request.user,
             year=day_date.year,
             month=day_date.month,
+            config=reservation_config,
         )
 
         # reservation_enabled implies reservation_config exists; keep explicit
@@ -901,7 +912,7 @@ def maybe_notify_surge_towpilot(day_date):
 
     intents = OpsIntent.objects.filter(date=day_date)
     tow_count = sum(
-        1 for i in intents if "club" in i.available_as or "private" in i.available_as
+        1 for i in intents if any(key in TOW_INTENT_KEYS for key in i.available_as)
     )
 
     if tow_count >= tow_surge_threshold:

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -535,7 +535,12 @@ def calendar_day_detail(request, year, month, day):
             month=day_date.month,
         )
 
-        max_per_year = reservation_config.max_reservations_per_year
+        # reservation_enabled implies reservation_config exists; keep explicit
+        # guard so static type-checkers can narrow away Optional.
+        if reservation_config is None:
+            max_per_year = 0
+        else:
+            max_per_year = reservation_config.max_reservations_per_year
         if max_per_year > 0:
             current_year_count = GliderReservation.get_member_yearly_count(
                 request.user,

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -379,11 +379,12 @@ def duty_calendar_view(request, year=None, month=None):
     ):
         instruction_count[row["assignment__date"]] += row["_count"]
 
-    # Tow surge: still driven by OpsIntent club/private activity flags.
+    # Tow surge: driven by tow-relevant OpsIntent activity flags (Issue #803).
+    tow_intent_keys = {"club", "club_single", "club_two", "guest", "private"}
     intents = OpsIntent.objects.filter(date__in=visible_dates)
     for intent in intents:
         roles = intent.available_as or []
-        if "private" in roles or "club" in roles:
+        if any(key in tow_intent_keys for key in roles):
             tow_count[intent.date] += 1
 
     surge_needed_by_date = {}
@@ -523,11 +524,12 @@ def calendar_day_detail(request, year, month, day):
     )
     day_reservations = []
     can_reserve_glider = False
+    reserve_message = ""
     reservations_remaining = None
 
     if request.user.is_authenticated and reservation_enabled:
         day_reservations = GliderReservation.get_reservations_for_date(day_date)
-        can_reserve_glider, _reserve_message = GliderReservation.can_member_reserve(
+        can_reserve_glider, reserve_message = GliderReservation.can_member_reserve(
             request.user,
             year=day_date.year,
             month=day_date.month,
@@ -620,6 +622,7 @@ def calendar_day_detail(request, year, month, day):
             "reservation_enabled": reservation_enabled,
             "day_reservations": day_reservations,
             "can_reserve_glider": can_reserve_glider,
+            "reserve_message": reserve_message,
             "reservations_remaining": reservations_remaining,
             "available_activities": OpsIntent.AVAILABLE_ACTIVITIES,
         },

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -532,11 +532,10 @@ def calendar_day_detail(request, year, month, day):
     )
 
     reservation_config = site_config
-    reservation_enabled = bool(
-        reservation_config
-        and reservation_config.allow_glider_reservations
-        and can_access_reservations
+    reservation_feature_enabled = bool(
+        reservation_config and reservation_config.allow_glider_reservations
     )
+    reservation_enabled = bool(reservation_feature_enabled and can_access_reservations)
     day_reservations = []
     can_reserve_glider = False
     reserve_message = ""
@@ -634,6 +633,8 @@ def calendar_day_detail(request, year, month, day):
                 and request.user.id != assignment.tow_pilot_id
             ),
             "reservation_enabled": reservation_enabled,
+            "reservation_feature_enabled": reservation_feature_enabled,
+            "can_access_reservations": can_access_reservations,
             "day_reservations": day_reservations,
             "can_reserve_glider": can_reserve_glider,
             "reserve_message": reserve_message,

--- a/e2e_tests/e2e/test_day_modal_intent_workflow.py
+++ b/e2e_tests/e2e/test_day_modal_intent_workflow.py
@@ -1,0 +1,74 @@
+"""E2E coverage for duty day modal accordion + intent workflow interactions.
+
+Validates primary modal interactions introduced in the phase-1 UX refactor:
+- key accordions render collapsed by default
+- opening "I Plan to Fly This Day" reveals the inline form
+- submitting intent updates the modal DOM via HTMX
+- cancelling intent restores the inline form path
+"""
+
+from datetime import date, timedelta
+
+from duty_roster.models import DutyAssignment
+from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+from siteconfig.models import SiteConfiguration
+
+
+class TestDayModalIntentWorkflow(DjangoPlaywrightTestCase):
+    def setUp(self):
+        super().setUp()
+        config, _ = SiteConfiguration.objects.get_or_create(
+            defaults={
+                "club_name": "Test Soaring Club",
+                "club_abbreviation": "TSC",
+                "domain_name": "test.org",
+            }
+        )
+        config.allow_glider_reservations = True
+        config.max_reservations_per_year = 3
+        config.save(
+            update_fields=["allow_glider_reservations", "max_reservations_per_year"]
+        )
+
+    def test_modal_accordions_and_intent_htmx_flow(self):
+        self.create_test_member(
+            username="modalmember",
+            email="modalmember@example.com",
+            membership_status="Full Member",
+        )
+        self.login(username="modalmember")
+
+        ops_day = date.today() + timedelta(days=7)
+        DutyAssignment.objects.create(date=ops_day)
+
+        self.page.goto(f"{self.live_server_url}/duty_roster/calendar/")
+        self.page.wait_for_selector("#calendar-body")
+
+        day_cell = self.page.locator(
+            f'td[hx-get="/duty_roster/calendar/day/{ops_day.year}/{ops_day.month}/{ops_day.day}/"]'
+        )
+        day_cell.first.click()
+
+        self.page.wait_for_selector("#modal-body")
+        self.page.wait_for_selector("#plan-to-fly-panel", state="attached")
+        self.page.wait_for_selector("#reserve-glider-panel", state="attached")
+
+        plan_panel = self.page.locator("#plan-to-fly-panel")
+        reserve_panel = self.page.locator("#reserve-glider-panel")
+
+        # Accordions start collapsed by default
+        assert "show" not in (plan_panel.get_attribute("class") or "")
+        assert "show" not in (reserve_panel.get_attribute("class") or "")
+
+        # Open plan-to-fly accordion and submit intent
+        self.page.locator('button[data-bs-target="#plan-to-fly-panel"]').click()
+        self.page.wait_for_selector('input[name="available_as"][value="club_single"]')
+        self.page.check('input[name="available_as"][value="club_single"]')
+        self.page.click('button:has-text("Submit Intent")')
+
+        self.page.wait_for_selector("text=planning to fly this day")
+
+        # Cancel intent and verify form path is restored
+        self.page.click('button:has-text("Cancel Intent")')
+        self.page.wait_for_selector("text=removed your intent to fly")
+        self.page.wait_for_selector('input[name="available_as"][value="club_single"]')

--- a/e2e_tests/e2e/test_day_modal_intent_workflow.py
+++ b/e2e_tests/e2e/test_day_modal_intent_workflow.py
@@ -7,7 +7,7 @@ Validates primary modal interactions introduced in the phase-1 UX refactor:
 - cancelling intent restores the inline form path
 """
 
-from datetime import date, timedelta
+from datetime import date
 
 from duty_roster.models import DutyAssignment
 from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase

--- a/e2e_tests/e2e/test_day_modal_intent_workflow.py
+++ b/e2e_tests/e2e/test_day_modal_intent_workflow.py
@@ -38,7 +38,8 @@ class TestDayModalIntentWorkflow(DjangoPlaywrightTestCase):
         )
         self.login(username="modalmember")
 
-        ops_day = date.today() + timedelta(days=7)
+        # Keep the target date in the currently rendered month view.
+        ops_day = date.today()
         DutyAssignment.objects.create(date=ops_day)
 
         self.page.goto(f"{self.live_server_url}/duty_roster/calendar/")

--- a/static/css/baseline.css
+++ b/static/css/baseline.css
@@ -440,6 +440,17 @@ th {
 }
 
 /* Duty Roster Calendar Enhancement - Professional Color-Coded Badges */
+.duty-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 0.75em;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+  line-height: normal;
+}
+
 .calendar-cell .duty-badge,
 .duty-assignments .duty-badge,
 table .duty-badge {
@@ -479,6 +490,31 @@ table .duty-badge {
 .duty-badge.badge-duty-officer {
   background-color: #fd7e14;
   border: 1px solid #e55a00;
+  color: white;
+}
+
+/* Context-independent legend helpers so role chips keep color outside table cells */
+.duty-badge.badge-instructor {
+  background-color: #28a745;
+  border: 1px solid #1e7e34;
+  color: white;
+}
+
+.duty-badge.badge-tow-pilot {
+  background-color: #dc3545;
+  border: 1px solid #c82333;
+  color: white;
+}
+
+.duty-badge.badge-assistant-duty-officer {
+  background-color: #6c757d;
+  border: 1px solid #545b62;
+  color: white;
+}
+
+.duty-badge.badge-surge {
+  background-color: #dc3545;
+  border: 1px solid #c82333;
   color: white;
 }
 


### PR DESCRIPTION
## Summary

This PR implements the duty-roster UX and behavior improvements for issues #803, #797, and #717, with follow-on polish from iterative in-browser review.

Primary outcomes:
- Clarified flight intent taxonomy and preserved legacy label compatibility.
- Improved day modal information architecture and action hierarchy.
- Added stronger separation between instruction workflow and general flight-intent workflow.
- Integrated glider reservation context directly into the day modal experience.
- Improved role/icon/legend consistency between calendar and agenda views.

## What Changed

### 1) Ops Intent Model + Compatibility
- Updated `OpsIntent.AVAILABLE_ACTIVITIES` to:
  - `club_single`
  - `club_two`
  - `guest`
  - `private`
- Added legacy label compatibility mapping via `LEGACY_ACTIVITY_LABELS` and merged fallback behavior in `available_as_labels()`.

Files:
- duty_roster/models.py
- duty_roster/tests/test_ops_intent.py

### 2) Day Modal View Logic and Intent Guardrails
- Added instruction-request guardrails so members cannot create a duplicate planning flow when a non-cancelled instruction request already exists.
- Added modal context for reservations:
  - `reservation_enabled`
  - `day_reservations`
  - `can_reserve_glider`
  - `reservations_remaining`
- Updated tow-intent counting logic to include new keys and legacy support.
- Updated ops-intent notifications:
  - Instructor email trigger keys now aligned to active tow-relevant intent values.
  - Subject changed to "Member Flight Intent".
  - Email context now includes `member_name` and selected intent labels.

Files:
- duty_roster/views.py

### 3) Day Modal UX Refactor (Phase 1)
- Reworked modal hierarchy to reduce cognitive overload while preserving all core actions.
- Added dedicated crew-only action grouping for assigned members.
- Request Instruction accordion styling restored to green (aligned with instructor semantics).
- Converted "I Plan to Fly This Day" into an accordion-style section with inline intent form content.
- Removed the separate launch button for plan-to-fly; form is now directly embedded where users expect it.
- Promoted reservation tools into their own accordion section:
  - "Reserve a Glider"
  - Includes requirements list and existing reservation action button.
- Set all accordion sections collapsed by default.
- Changed "Submit Intent" CTA to blue for consistent primary-action semantics.
- Kept Admin controls collapsible and secondary.

Files:
- duty_roster/templates/duty_roster/calendar_day_modal.html
- duty_roster/templates/duty_roster/ops_intent_form.html

### 4) Calendar vs Agenda Consistency Polish
- Removed legend from agenda view context by moving legend markup into calendar-only container.
- Updated agenda tow icons to match calendar/legend icon orientation and style:
  - Replaced `fas fa-plane` with `bi bi-airplane` for tow roles.
- Added global duty-badge base and context-independent badge colors so legend chips render consistently as lozenges across contexts.

Files:
- duty_roster/templates/duty_roster/_calendar_body.html
- duty_roster/templates/duty_roster/_calendar_agenda.html
- static/css/baseline.css

## Bug Fixes Included
- Fixed runtime NameError in day modal reservation context by importing `GliderReservation` in duty-roster view module.

File:
- duty_roster/views.py

## Tests Added/Updated

Added:
- duty_roster/tests/test_ops_intent_toggle.py
  - verifies instructor notification for club_single intent
  - verifies no notification for private-only intent
  - verifies blocking behavior when instruction request already exists

Updated:
- duty_roster/tests/test_ops_intent.py
  - new activity keys assertions
  - updated labels and legacy compatibility checks

## Validation Performed

Targeted runs completed during implementation:
- duty_roster/tests/test_ops_intent.py
- duty_roster/tests/test_ops_intent_toggle.py
- duty_roster/tests/test_instruction_request_emails.py
- duty_roster/tests/test_active_instruction_slots.py
- duty_roster/tests/test_instruction_request_ui.py
- duty_roster/tests/test_instruction_cancellation_emails.py
- duty_roster/tests/test_instruction_request_window.py
- duty_roster/tests/test_calendar_mobile_view.py
- duty_roster/tests/test_volunteer_fill_role.py
- duty_roster/tests/test_duty_officer_display_order.py

All targeted test slices passed in the development loop.

## Notes
- Static assets were recollected after CSS updates (`collectstatic --noinput`) to ensure legend/badge styling is reflected in served static output.
