### PR TITLE
Remediate Dependabot alerts by upgrading Authlib and pyasn1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.7.0
 anyio==4.11.0
 asgiref==3.9.1
-Authlib==1.6.7
+Authlib==1.6.9
 bandit==1.8.6
 black==26.3.1
 bleach==6.3.0
@@ -80,7 +80,7 @@ proto-plus==1.26.1
 protobuf>=3.19.5,<7.0.0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,!=5.29.0,!=6.33.0,!=6.33.1,!=6.33.2,!=6.33.3,!=6.33.4
 psycopg2-binary==2.9.10
 py-serializable==2.1.0
-pyasn1==0.6.2
+pyasn1==0.6.3
 pyasn1_modules==0.4.2
 pycodestyle==2.14.0
 pycparser==2.22


### PR DESCRIPTION
## Summary
This PR remediates the currently patchable Dependabot vulnerabilities in `requirements.txt`.

## Dependabot alerts addressed
- Authlib alerts (critical/high): #29, #30, #31
  - Upgraded `Authlib` from `1.6.7` to `1.6.9` (first patched version)
- pyasn1 alert (high): #32
  - Upgraded `pyasn1` from `0.6.2` to `0.6.3` (first patched version)

## Validation
- Installed upgraded packages in project venv successfully:
  - `Authlib==1.6.9`
  - `pyasn1==0.6.3`
- Dependency consistency check:
  - `python -m pip check` → no broken requirements
- Vulnerability audit after upgrades:
  - `python -m pip_audit -r requirements.txt`
  - Remaining finding: `pygments 2.19.2` (`GHSA-5239-wwwm-4pmq`)

## Remaining blocker (unpatched upstream)
- Dependabot alert #36 (`Pygments<=2.19.2`) currently has no patched release available from PyPI.
- Latest published Pygments is still `2.19.2`, so this alert cannot be fixed by a safe version bump at this time.

## Next step recommendation
- Temporarily dismiss/triage alert #36 with rationale "no fix available upstream" and monitor for a patched Pygments release.
