### PR TITLE
Issue #805: Agenda quick actions with state-driven UX and mobile popovers

### DIFF
--- a/duty_roster/templates/duty_roster/_calendar_agenda.html
+++ b/duty_roster/templates/duty_roster/_calendar_agenda.html
@@ -231,7 +231,8 @@
                                   data-bs-placement="top"
                                   data-bs-container="body"
                                   data-bs-content="{{ action.disabled_reason }}"
-                                  aria-haspopup="true"
+                                  aria-haspopup="dialog"
+                                  aria-disabled="true"
                                   aria-label="{{ action.label }} unavailable: {{ action.disabled_reason }}">
                             <i class="{{ action.icon }} me-1"></i>{{ action.label }}
                           </button>

--- a/duty_roster/templates/duty_roster/_calendar_agenda.html
+++ b/duty_roster/templates/duty_roster/_calendar_agenda.html
@@ -183,14 +183,63 @@
               </div>
 
               <!-- Quick Actions -->
-              <div class="mt-3">
-                <button class="btn btn-sm btn-outline-primary"
-                        hx-get="{% url 'duty_roster:calendar_day_detail' year=day.year month=day.month day=day.day %}"
-                        hx-target="#modal-body"
-                        hx-swap="innerHTML"
-                        onclick="showModalWithLoading();">
-                  <i class="fas fa-info-circle me-1"></i>View Details
-                </button>
+              <div class="mt-3 agenda-quick-actions" aria-label="Quick actions for {{ day|date:'F j, Y' }}">
+                <div class="agenda-quick-actions-buttons">
+                  <button class="btn btn-sm btn-outline-primary"
+                          hx-get="{% url 'duty_roster:calendar_day_detail' year=day.year month=day.month day=day.day %}"
+                          hx-target="#modal-body"
+                          hx-swap="innerHTML"
+                          onclick="showModalWithLoading();">
+                    <i class="fas fa-info-circle me-1"></i>View Details
+                  </button>
+
+                  {% with quick_actions=agenda_quick_actions_by_date|dict_get:day %}
+                    {% for action in quick_actions %}
+                      {% if action.enabled %}
+                        {% if action.kind == "modal" %}
+                          <button class="btn btn-sm btn-outline-secondary"
+                                  hx-get="{{ action.url }}"
+                                  hx-target="#modal-body"
+                                  hx-swap="innerHTML"
+                                  onclick="showModalWithLoading();">
+                            <i class="{{ action.icon }} me-1"></i>{{ action.label }}
+                          </button>
+                        {% elif action.kind == "post" %}
+                          <form method="post" action="{{ action.url }}" class="d-inline">
+                            {% csrf_token %}
+                            {% if action.post_data %}
+                              {% for key, value in action.post_data.items %}
+                                <input type="hidden" name="{{ key }}" value="{{ value }}">
+                              {% endfor %}
+                            {% endif %}
+                            <button type="submit" class="btn btn-sm btn-outline-secondary">
+                              <i class="{{ action.icon }} me-1"></i>{{ action.label }}
+                            </button>
+                          </form>
+                        {% else %}
+                          <a href="{{ action.url }}" class="btn btn-sm btn-outline-secondary">
+                            <i class="{{ action.icon }} me-1"></i>{{ action.label }}
+                          </a>
+                        {% endif %}
+                      {% else %}
+                        <span class="agenda-disabled-action d-inline-block">
+                          <button type="button"
+                                  class="btn btn-sm btn-outline-secondary agenda-disabled-btn agenda-disabled-trigger"
+                                  data-agenda-disabled-popover="true"
+                                  data-bs-toggle="popover"
+                                  data-bs-trigger="focus click"
+                                  data-bs-placement="top"
+                                  data-bs-container="body"
+                                  data-bs-content="{{ action.disabled_reason }}"
+                                  aria-haspopup="true"
+                                  aria-label="{{ action.label }} unavailable: {{ action.disabled_reason }}">
+                            <i class="{{ action.icon }} me-1"></i>{{ action.label }}
+                          </button>
+                        </span>
+                      {% endif %}
+                    {% endfor %}
+                  {% endwith %}
+                </div>
               </div>
             </div>
           </div>

--- a/duty_roster/templates/duty_roster/_calendar_body.html
+++ b/duty_roster/templates/duty_roster/_calendar_body.html
@@ -93,11 +93,27 @@
         }
       }
 
+      function initAgendaDisabledPopovers() {
+        if (typeof bootstrap === 'undefined' || !bootstrap.Popover) {
+          return;
+        }
+
+        document.querySelectorAll('[data-agenda-disabled-popover="true"]').forEach((el) => {
+          if (!bootstrap.Popover.getInstance(el)) {
+            new bootstrap.Popover(el);
+          }
+        });
+      }
+
       // Restore state when page loads or HTMX updates content
-      document.addEventListener('DOMContentLoaded', restoreViewState);
+      document.addEventListener('DOMContentLoaded', function() {
+        restoreViewState();
+        initAgendaDisabledPopovers();
+      });
       document.addEventListener('htmx:afterSettle', function(event) {
         if (event.detail.target.id === 'calendar-body') {
           restoreViewState();
+          initAgendaDisabledPopovers();
         }
       });
     </script>

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -608,3 +608,29 @@
   </div>
 </div>
 {% endif %}
+
+<script>
+  (function() {
+    const openPanel = "{{ open_panel|default:'' }}";
+    if (!openPanel || typeof bootstrap === "undefined") {
+      return;
+    }
+
+    const panelMap = {
+      plan_to_fly: "plan-to-fly-panel",
+      request_instruction: "instruction-request-form",
+    };
+
+    const targetId = panelMap[openPanel];
+    const panelEl = targetId ? document.getElementById(targetId) : null;
+    if (!panelEl) {
+      return;
+    }
+
+    const collapse = bootstrap.Collapse.getOrCreateInstance(panelEl, { toggle: false });
+    collapse.show();
+    setTimeout(() => {
+      panelEl.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 120);
+  })();
+</script>

--- a/duty_roster/tests/test_calendar_mobile_view.py
+++ b/duty_roster/tests/test_calendar_mobile_view.py
@@ -111,3 +111,123 @@ def test_calendar_renders_compact_surge_alert_icon_markup(client):
     content = response.content.decode("utf-8")
     assert "calendar-alert-icon" in content
     assert "High demand alert" in content
+
+
+@pytest.mark.django_db
+def test_agenda_quick_actions_show_disabled_plan_to_fly_when_instruction_exists(client):
+    day = date.today() + timedelta(days=6)
+
+    SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="test.org",
+        club_abbreviation="TC",
+    )
+
+    viewer = Member.objects.create_user(
+        username="agenda_viewer",
+        email="agenda_viewer@example.com",
+        password="password",
+        membership_status="Full Member",
+    )
+    instructor = Member.objects.create_user(
+        username="agenda_inst",
+        email="agenda_inst@example.com",
+        password="password",
+        membership_status="Full Member",
+        instructor=True,
+    )
+
+    assignment = DutyAssignment.objects.create(date=day, instructor=instructor)
+    InstructionSlot.objects.create(assignment=assignment, student=viewer)
+
+    client.force_login(viewer)
+    response = client.get(
+        reverse(
+            "duty_roster:duty_calendar_month",
+            kwargs={"year": day.year, "month": day.month},
+        )
+        + "?view=agenda"
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "Plan to Fly" in content
+    assert "You already requested instruction for this day." in content
+    assert "Review Student Requests" not in content
+
+
+@pytest.mark.django_db
+def test_agenda_quick_actions_show_reservation_disabled_reason_when_feature_off(client):
+    day = date.today() + timedelta(days=8)
+
+    SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="test.org",
+        club_abbreviation="TC",
+        allow_glider_reservations=False,
+    )
+
+    viewer = Member.objects.create_user(
+        username="reserve_viewer",
+        email="reserve_viewer@example.com",
+        password="password",
+        membership_status="Full Member",
+    )
+
+    DutyAssignment.objects.create(date=day)
+
+    client.force_login(viewer)
+    response = client.get(
+        reverse(
+            "duty_roster:duty_calendar_month",
+            kwargs={"year": day.year, "month": day.month},
+        )
+        + "?view=agenda"
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "Reserve a Glider" in content
+    assert "Glider reservations are currently disabled." in content
+
+
+@pytest.mark.django_db
+def test_agenda_quick_actions_open_modal_panel_urls(client):
+    day = date.today() + timedelta(days=5)
+
+    SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="test.org",
+        club_abbreviation="TC",
+        allow_glider_reservations=False,
+    )
+
+    viewer = Member.objects.create_user(
+        username="agenda_modal_viewer",
+        email="agenda_modal_viewer@example.com",
+        password="password",
+        membership_status="Full Member",
+    )
+    instructor = Member.objects.create_user(
+        username="agenda_modal_inst",
+        email="agenda_modal_inst@example.com",
+        password="password",
+        membership_status="Full Member",
+        instructor=True,
+    )
+
+    DutyAssignment.objects.create(date=day, instructor=instructor)
+
+    client.force_login(viewer)
+    response = client.get(
+        reverse(
+            "duty_roster:duty_calendar_month",
+            kwargs={"year": day.year, "month": day.month},
+        )
+        + "?view=agenda"
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "open_panel=plan_to_fly" in content
+    assert "open_panel=request_instruction" in content

--- a/duty_roster/tests/test_calendar_mobile_view.py
+++ b/duty_roster/tests/test_calendar_mobile_view.py
@@ -231,3 +231,43 @@ def test_agenda_quick_actions_open_modal_panel_urls(client):
     content = response.content.decode("utf-8")
     assert "open_panel=plan_to_fly" in content
     assert "open_panel=request_instruction" in content
+
+
+@pytest.mark.django_db
+def test_agenda_review_student_requests_disabled_for_inactive_instructor(client):
+    day = date.today() + timedelta(days=5)
+
+    SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="test.org",
+        club_abbreviation="TC",
+    )
+
+    inactive_instructor = Member.objects.create_user(
+        username="inactive_instructor",
+        email="inactive_instructor@example.com",
+        password="password",
+        membership_status="Full Member",
+        instructor=True,
+    )
+    Member.objects.filter(pk=inactive_instructor.pk).update(
+        membership_status="Inactive",
+        is_active=True,
+    )
+    inactive_instructor.refresh_from_db()
+
+    DutyAssignment.objects.create(date=day)
+
+    client.force_login(inactive_instructor)
+    response = client.get(
+        reverse(
+            "duty_roster:duty_calendar_month",
+            kwargs={"year": day.year, "month": day.month},
+        )
+        + "?view=agenda"
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "Review Student Requests" in content
+    assert "Active membership is required." in content

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -50,6 +50,7 @@ from .models import (
     DutyPairing,
     DutyPreference,
     DutyRosterMessage,
+    DutySwapRequest,
     GliderReservation,
     MemberBlackout,
     OpsIntent,
@@ -342,6 +343,241 @@ def _check_instruction_request_window(day_date):
     return False, None
 
 
+def _build_agenda_quick_actions(
+    request,
+    day_date,
+    assignment,
+    site_config,
+    active_statuses,
+    intent_dates,
+    instruction_dates,
+    open_swap_keys,
+):
+    """Build quick actions for an agenda day card based on user/day state."""
+    actions = []
+    is_authenticated = request.user.is_authenticated
+    is_active_member = bool(
+        is_authenticated
+        and request.user.is_active
+        and request.user.membership_status in active_statuses
+    )
+    is_past = day_date < date.today()
+    has_intent = day_date in intent_dates
+    has_instruction_request = day_date in instruction_dates
+
+    # Plan to Fly
+    if has_intent:
+        actions.append(
+            {
+                "key": "plan_to_fly_edit",
+                "label": "Edit Plan to Fly",
+                "enabled": True,
+                "icon": "fas fa-pen",
+                "kind": "modal",
+                "url": reverse(
+                    "duty_roster:calendar_day_detail",
+                    kwargs={
+                        "year": day_date.year,
+                        "month": day_date.month,
+                        "day": day_date.day,
+                    },
+                )
+                + "?open_panel=plan_to_fly",
+            }
+        )
+        actions.append(
+            {
+                "key": "plan_to_fly_cancel",
+                "label": "Cancel Plan to Fly",
+                "enabled": True,
+                "icon": "fas fa-ban",
+                "kind": "post",
+                "url": reverse(
+                    "duty_roster:ops_intent_toggle",
+                    kwargs={
+                        "year": day_date.year,
+                        "month": day_date.month,
+                        "day": day_date.day,
+                    },
+                ),
+            }
+        )
+    else:
+        plan_reason = ""
+        if is_past:
+            plan_reason = "Unavailable for past dates."
+        elif not is_active_member:
+            plan_reason = "Active membership is required."
+        elif has_instruction_request:
+            plan_reason = "You already requested instruction for this day."
+
+        actions.append(
+            {
+                "key": "plan_to_fly",
+                "label": "Plan to Fly",
+                "enabled": plan_reason == "",
+                "disabled_reason": plan_reason,
+                "icon": "fas fa-plane-departure",
+                "kind": "modal",
+                "url": reverse(
+                    "duty_roster:calendar_day_detail",
+                    kwargs={
+                        "year": day_date.year,
+                        "month": day_date.month,
+                        "day": day_date.day,
+                    },
+                )
+                + "?open_panel=plan_to_fly",
+            }
+        )
+
+    # Request Instruction
+    instruction_reason = ""
+    has_instructor_assigned = bool(
+        assignment and (assignment.instructor_id or assignment.surge_instructor_id)
+    )
+    too_early, opens_on = _check_instruction_request_window(day_date)
+    if is_past:
+        instruction_reason = "Unavailable for past dates."
+    elif not is_active_member:
+        instruction_reason = "Active membership is required."
+    elif has_instruction_request:
+        instruction_reason = "You already have an instruction request for this day."
+    elif not has_instructor_assigned:
+        instruction_reason = "No instructor is currently assigned for this day."
+    elif too_early:
+        opens_str = opens_on.strftime("%b %d, %Y") if opens_on else "a later date"
+        instruction_reason = f"Instruction requests open on {opens_str}."
+
+    actions.append(
+        {
+            "key": "request_instruction",
+            "label": "Request Instruction",
+            "enabled": instruction_reason == "",
+            "disabled_reason": instruction_reason,
+            "icon": "fas fa-graduation-cap",
+            "kind": "modal",
+            "url": reverse(
+                "duty_roster:calendar_day_detail",
+                kwargs={
+                    "year": day_date.year,
+                    "month": day_date.month,
+                    "day": day_date.day,
+                },
+            )
+            + "?open_panel=request_instruction",
+        }
+    )
+
+    # Reserve a Glider
+    reserve_reason = ""
+    reservation_feature_enabled = bool(
+        site_config and site_config.allow_glider_reservations
+    )
+    can_reserve_glider = False
+    if is_past:
+        reserve_reason = "Unavailable for past dates."
+    elif not is_active_member:
+        reserve_reason = "Active membership is required."
+    elif not reservation_feature_enabled:
+        reserve_reason = "Glider reservations are currently disabled."
+    else:
+        can_reserve_glider, reserve_reason = GliderReservation.can_member_reserve(
+            request.user,
+            year=day_date.year,
+            month=day_date.month,
+            config=site_config,
+        )
+
+    actions.append(
+        {
+            "key": "reserve_glider",
+            "label": "Reserve a Glider",
+            "enabled": can_reserve_glider,
+            "disabled_reason": reserve_reason,
+            "icon": "fas fa-calendar-check",
+            "kind": "link",
+            "url": reverse(
+                "duty_roster:reservation_create_for_day",
+                kwargs={
+                    "year": day_date.year,
+                    "month": day_date.month,
+                    "day": day_date.day,
+                },
+            ),
+        }
+    )
+
+    # Request Swap (only if this user is assigned to one or more scheduled roles)
+    assigned_roles = []
+    if assignment and is_authenticated:
+        if assignment.instructor_id == request.user.id:
+            assigned_roles.append(("INSTRUCTOR", get_role_title("instructor")))
+        if assignment.tow_pilot_id == request.user.id:
+            assigned_roles.append(("TOW", get_role_title("towpilot")))
+        if assignment.duty_officer_id == request.user.id:
+            assigned_roles.append(("DO", get_role_title("duty_officer")))
+        if assignment.assistant_duty_officer_id == request.user.id:
+            assigned_roles.append(("ADO", get_role_title("assistant_duty_officer")))
+
+    scheduled_map = {
+        "INSTRUCTOR": bool(site_config and site_config.schedule_instructors),
+        "TOW": bool(site_config and site_config.schedule_tow_pilots),
+        "DO": bool(site_config and site_config.schedule_duty_officers),
+        "ADO": bool(site_config and site_config.schedule_assistant_duty_officers),
+    }
+
+    for role_code, role_title in assigned_roles:
+        swap_reason = ""
+        if is_past:
+            swap_reason = "Unavailable for past dates."
+        elif not is_active_member:
+            swap_reason = "Active membership is required."
+        elif not scheduled_map.get(role_code, False):
+            swap_reason = f"{role_title} is not currently a scheduled role."
+        elif (day_date, role_code) in open_swap_keys:
+            swap_reason = "You already have an open swap request for this role."
+
+        label = "Request Swap"
+        if len(assigned_roles) > 1:
+            label = f"Request Swap ({role_title})"
+
+        actions.append(
+            {
+                "key": f"request_swap_{role_code.lower()}",
+                "label": label,
+                "enabled": swap_reason == "",
+                "disabled_reason": swap_reason,
+                "icon": "fas fa-exchange-alt",
+                "kind": "link",
+                "url": reverse(
+                    "duty_roster:create_swap_request",
+                    kwargs={
+                        "year": day_date.year,
+                        "month": day_date.month,
+                        "day": day_date.day,
+                        "role": role_code,
+                    },
+                ),
+            }
+        )
+
+    # Review Student Requests (instructor roles)
+    if is_authenticated and getattr(request.user, "instructor", False):
+        actions.append(
+            {
+                "key": "review_student_requests",
+                "label": "Review Student Requests",
+                "enabled": True,
+                "icon": "fas fa-user-check",
+                "kind": "link",
+                "url": reverse("duty_roster:instructor_requests"),
+            }
+        )
+
+    return actions
+
+
 def duty_calendar_view(request, year=None, month=None):
     today = date.today()
     year = int(year) if year else today.year
@@ -350,6 +586,11 @@ def duty_calendar_view(request, year=None, month=None):
     # Get site config for surge thresholds
     tow_surge_threshold, instruction_surge_threshold = get_surge_thresholds()
 
+    site_config = cache.get("siteconfig_instance", _SITECONFIG_CACHE_SENTINEL)
+    if site_config is _SITECONFIG_CACHE_SENTINEL:
+        site_config = SiteConfiguration.objects.first()
+        cache.set("siteconfig_instance", site_config, timeout=60)
+
     cal = calendar.Calendar(firstweekday=6)
     weeks = cal.monthdatescalendar(year, month)
     first_visible_day = weeks[0][0]
@@ -357,13 +598,58 @@ def duty_calendar_view(request, year=None, month=None):
     assignments = DutyAssignment.objects.filter(
         date__range=(first_visible_day, last_visible_day)
     ).order_by("date")
+    visible_dates = [day for week in weeks for day in week]
 
     assignments_by_date = {a.date: a for a in assignments}
 
-    prev_year, prev_month, next_year, next_month = get_adjacent_months(year, month)
+    active_statuses = set(get_active_membership_statuses())
 
-    # After building `weeks` for the calendar
-    visible_dates = [day for week in weeks for day in week]
+    intent_dates = set()
+    instruction_dates = set()
+    open_swap_keys = set()
+    if request.user.is_authenticated:
+        intent_dates = set(
+            OpsIntent.objects.filter(member=request.user, date__in=visible_dates)
+            .values_list("date", flat=True)
+            .iterator()
+        )
+
+        from .models import InstructionSlot
+
+        instruction_dates = set(
+            InstructionSlot.objects.filter(
+                assignment__date__in=visible_dates,
+                student=request.user,
+            )
+            .exclude(status="cancelled")
+            .values_list("assignment__date", flat=True)
+            .iterator()
+        )
+
+        open_swap_keys = set(
+            DutySwapRequest.objects.filter(
+                requester=request.user,
+                original_date__in=visible_dates,
+                status="open",
+            )
+            .values_list("original_date", "role")
+            .iterator()
+        )
+
+    agenda_quick_actions_by_date = {}
+    for day, assignment in assignments_by_date.items():
+        agenda_quick_actions_by_date[day] = _build_agenda_quick_actions(
+            request=request,
+            day_date=day,
+            assignment=assignment,
+            site_config=site_config,
+            active_statuses=active_statuses,
+            intent_dates=intent_dates,
+            instruction_dates=instruction_dates,
+            open_swap_keys=open_swap_keys,
+        )
+
+    prev_year, prev_month, next_year, next_month = get_adjacent_months(year, month)
 
     # Then safely run these:
     instruction_count = defaultdict(int)
@@ -426,6 +712,7 @@ def duty_calendar_view(request, year=None, month=None):
         "next_year": next_year,
         "next_month": next_month,
         "today": today,
+        "agenda_quick_actions_by_date": agenda_quick_actions_by_date,
         "surge_needed_by_date": surge_needed_by_date,
         "tow_surge_threshold": tow_surge_threshold,
         "instruction_surge_threshold": instruction_surge_threshold,
@@ -439,6 +726,9 @@ def duty_calendar_view(request, year=None, month=None):
 def calendar_day_detail(request, year, month, day):
     day_date = date(year, month, day)
     assignment = DutyAssignment.objects.filter(date=day_date).first()
+    open_panel = request.GET.get("open_panel", "")
+    if open_panel not in {"plan_to_fly", "request_instruction"}:
+        open_panel = ""
 
     # Get site config for surge thresholds
     tow_surge_threshold, instruction_surge_threshold = get_surge_thresholds()
@@ -640,6 +930,7 @@ def calendar_day_detail(request, year, month, day):
             "reserve_message": reserve_message,
             "reservations_remaining": reservations_remaining,
             "available_activities": OpsIntent.AVAILABLE_ACTIVITIES,
+            "open_panel": open_panel,
         },
     )
 

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -391,15 +391,16 @@ def _build_agenda_quick_actions(
                 "label": "Cancel Plan to Fly",
                 "enabled": True,
                 "icon": "fas fa-ban",
-                "kind": "post",
+                "kind": "modal",
                 "url": reverse(
-                    "duty_roster:ops_intent_toggle",
+                    "duty_roster:calendar_day_detail",
                     kwargs={
                         "year": day_date.year,
                         "month": day_date.month,
                         "day": day_date.day,
                     },
-                ),
+                )
+                + "?open_panel=plan_to_fly",
             }
         )
     else:

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -483,12 +483,19 @@ def _build_agenda_quick_actions(
     elif not reservation_feature_enabled:
         reserve_reason = "Glider reservations are currently disabled."
     else:
-        can_reserve_glider, reserve_reason = GliderReservation.can_member_reserve(
-            request.user,
-            year=day_date.year,
-            month=day_date.month,
-            config=site_config,
-        )
+        cache_attr = "_glider_reservation_eligibility_cache"
+        if not hasattr(request, cache_attr):
+            setattr(request, cache_attr, {})
+        eligibility_cache = getattr(request, cache_attr)
+        cache_key = (day_date.year, day_date.month)
+        if cache_key not in eligibility_cache:
+            eligibility_cache[cache_key] = GliderReservation.can_member_reserve(
+                request.user,
+                year=day_date.year,
+                month=day_date.month,
+                config=site_config,
+            )
+        can_reserve_glider, reserve_reason = eligibility_cache[cache_key]
 
     actions.append(
         {
@@ -565,11 +572,16 @@ def _build_agenda_quick_actions(
 
     # Review Student Requests (instructor roles)
     if is_authenticated and getattr(request.user, "instructor", False):
+        review_reason = ""
+        if not is_active_member:
+            review_reason = "Active membership is required."
+
         actions.append(
             {
                 "key": "review_student_requests",
                 "label": "Review Student Requests",
-                "enabled": True,
+                "enabled": review_reason == "",
+                "disabled_reason": review_reason,
                 "icon": "fas fa-user-check",
                 "kind": "link",
                 "url": reverse("duty_roster:instructor_requests"),

--- a/e2e_tests/e2e/test_agenda_quick_actions.py
+++ b/e2e_tests/e2e/test_agenda_quick_actions.py
@@ -1,0 +1,77 @@
+"""E2E coverage for agenda quick actions (Issue #805)."""
+
+from datetime import date, timedelta
+
+from duty_roster.models import DutyAssignment, InstructionSlot
+from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+from siteconfig.models import SiteConfiguration
+
+
+class TestAgendaQuickActions(DjangoPlaywrightTestCase):
+    def setUp(self):
+        super().setUp()
+        SiteConfiguration.objects.get_or_create(
+            defaults={
+                "club_name": "Test Soaring Club",
+                "club_abbreviation": "TSC",
+                "domain_name": "test.org",
+                "schedule_duty_officers": True,
+                "allow_glider_reservations": False,
+            }
+        )
+
+    def test_request_swap_visible_for_assigned_crew_and_navigates(self):
+        crew = self.create_test_member(
+            username="agenda_do",
+            duty_officer=True,
+            membership_status="Full Member",
+        )
+        target_day = date.today() + timedelta(days=6)
+        DutyAssignment.objects.create(date=target_day, duty_officer=crew)
+
+        self.login(username="agenda_do")
+        self.page.goto(f"{self.live_server_url}/duty_roster/calendar/?view=agenda")
+        self.page.wait_for_selector("#agenda-view-content", state="visible")
+
+        swap_link = self.page.locator("a:has-text('Request Swap')").first
+        assert swap_link.is_visible()
+        reserve_disabled = self.page.locator(
+            "#agenda-view-content .agenda-disabled-trigger[data-bs-content*='Glider reservations are currently disabled.']"
+        ).first
+        assert reserve_disabled.is_visible()
+        reserve_disabled.click()
+        self.page.wait_for_selector(
+            ".popover .popover-body:has-text('Glider reservations are currently disabled.')"
+        )
+
+        swap_link.click()
+        self.page.wait_for_url("**/duty_roster/swap/request/create/**")
+
+    def test_plan_to_fly_disabled_when_instruction_request_exists(self):
+        student = self.create_test_member(
+            username="agenda_student",
+            membership_status="Full Member",
+        )
+        instructor = self.create_test_member(
+            username="agenda_instructor",
+            instructor=True,
+            membership_status="Full Member",
+        )
+        target_day = date.today() + timedelta(days=6)
+        assignment = DutyAssignment.objects.create(
+            date=target_day, instructor=instructor
+        )
+        InstructionSlot.objects.create(assignment=assignment, student=student)
+
+        self.login(username="agenda_student")
+        self.page.goto(f"{self.live_server_url}/duty_roster/calendar/?view=agenda")
+        self.page.wait_for_selector("#agenda-view-content", state="visible")
+
+        disabled_trigger = self.page.locator(
+            "#agenda-view-content .agenda-disabled-trigger[data-bs-content*='already requested instruction']"
+        ).first
+        assert disabled_trigger.is_visible()
+        disabled_trigger.click()
+        self.page.wait_for_selector(
+            ".popover .popover-body:has-text('already requested instruction')"
+        )

--- a/e2e_tests/e2e/test_agenda_quick_actions.py
+++ b/e2e_tests/e2e/test_agenda_quick_actions.py
@@ -74,3 +74,32 @@ class TestAgendaQuickActions(DjangoPlaywrightTestCase):
         self.page.wait_for_selector(
             ".popover .popover-body:has-text('already requested instruction')"
         )
+
+    def test_agenda_quick_actions_auto_expand_modal_panels(self):
+        member = self.create_test_member(
+            username="agenda_panel_user",
+            membership_status="Full Member",
+        )
+        instructor = self.create_test_member(
+            username="agenda_panel_instructor",
+            instructor=True,
+            membership_status="Full Member",
+        )
+
+        target_day = date.today() + timedelta(days=6)
+        DutyAssignment.objects.create(date=target_day, instructor=instructor)
+
+        self.login(username="agenda_panel_user")
+        self.page.goto(f"{self.live_server_url}/duty_roster/calendar/?view=agenda")
+        self.page.wait_for_selector("#agenda-view-content", state="visible")
+
+        self.page.locator("button:has-text('Plan to Fly')").first.click()
+        self.page.wait_for_selector("#calendarModal.show", state="visible")
+        self.page.wait_for_selector("#modal-body #plan-to-fly-panel.show")
+
+        self.page.locator("#calendarModal .btn-close").click()
+        self.page.wait_for_selector("#calendarModal.show", state="hidden")
+
+        self.page.locator("button:has-text('Request Instruction')").first.click()
+        self.page.wait_for_selector("#calendarModal.show", state="visible")
+        self.page.wait_for_selector("#modal-body #instruction-request-form.show")

--- a/e2e_tests/e2e/test_agenda_quick_actions.py
+++ b/e2e_tests/e2e/test_agenda_quick_actions.py
@@ -10,14 +10,13 @@ from siteconfig.models import SiteConfiguration
 class TestAgendaQuickActions(DjangoPlaywrightTestCase):
     def setUp(self):
         super().setUp()
-        SiteConfiguration.objects.get_or_create(
-            defaults={
-                "club_name": "Test Soaring Club",
-                "club_abbreviation": "TSC",
-                "domain_name": "test.org",
-                "schedule_duty_officers": True,
-                "allow_glider_reservations": False,
-            }
+        SiteConfiguration.objects.all().delete()
+        SiteConfiguration.objects.create(
+            club_name="Test Soaring Club",
+            club_abbreviation="TSC",
+            domain_name="test.org",
+            schedule_duty_officers=True,
+            allow_glider_reservations=False,
         )
 
     def test_request_swap_visible_for_assigned_crew_and_navigates(self):

--- a/e2e_tests/e2e/test_agenda_quick_actions.py
+++ b/e2e_tests/e2e/test_agenda_quick_actions.py
@@ -29,7 +29,9 @@ class TestAgendaQuickActions(DjangoPlaywrightTestCase):
         DutyAssignment.objects.create(date=target_day, duty_officer=crew)
 
         self.login(username="agenda_do")
-        self.page.goto(f"{self.live_server_url}/duty_roster/calendar/?view=agenda")
+        self.page.goto(
+            f"{self.live_server_url}/duty_roster/calendar/{target_day.year}/{target_day.month}/?view=agenda"
+        )
         self.page.wait_for_selector("#agenda-view-content", state="visible")
 
         swap_link = self.page.locator("a:has-text('Request Swap')").first
@@ -38,7 +40,7 @@ class TestAgendaQuickActions(DjangoPlaywrightTestCase):
             "#agenda-view-content .agenda-disabled-trigger[data-bs-content*='Glider reservations are currently disabled.']"
         ).first
         assert reserve_disabled.is_visible()
-        reserve_disabled.click()
+        reserve_disabled.click(force=True)
         self.page.wait_for_selector(
             ".popover .popover-body:has-text('Glider reservations are currently disabled.')"
         )
@@ -63,14 +65,16 @@ class TestAgendaQuickActions(DjangoPlaywrightTestCase):
         InstructionSlot.objects.create(assignment=assignment, student=student)
 
         self.login(username="agenda_student")
-        self.page.goto(f"{self.live_server_url}/duty_roster/calendar/?view=agenda")
+        self.page.goto(
+            f"{self.live_server_url}/duty_roster/calendar/{target_day.year}/{target_day.month}/?view=agenda"
+        )
         self.page.wait_for_selector("#agenda-view-content", state="visible")
 
         disabled_trigger = self.page.locator(
             "#agenda-view-content .agenda-disabled-trigger[data-bs-content*='already requested instruction']"
         ).first
         assert disabled_trigger.is_visible()
-        disabled_trigger.click()
+        disabled_trigger.click(force=True)
         self.page.wait_for_selector(
             ".popover .popover-body:has-text('already requested instruction')"
         )
@@ -90,7 +94,9 @@ class TestAgendaQuickActions(DjangoPlaywrightTestCase):
         DutyAssignment.objects.create(date=target_day, instructor=instructor)
 
         self.login(username="agenda_panel_user")
-        self.page.goto(f"{self.live_server_url}/duty_roster/calendar/?view=agenda")
+        self.page.goto(
+            f"{self.live_server_url}/duty_roster/calendar/{target_day.year}/{target_day.month}/?view=agenda"
+        )
         self.page.wait_for_selector("#agenda-view-content", state="visible")
 
         self.page.locator("button:has-text('Plan to Fly')").first.click()

--- a/static/css/baseline.css
+++ b/static/css/baseline.css
@@ -791,6 +791,52 @@ table .duty-badge.badge-warning {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
+.agenda-quick-actions-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.agenda-disabled-action {
+  max-width: 16rem;
+}
+
+.agenda-disabled-btn,
+.agenda-disabled-btn:disabled {
+  background: repeating-linear-gradient(-45deg,
+      #e8ebef,
+      #e8ebef 8px,
+      #dde2e8 8px,
+      #dde2e8 16px) !important;
+  border-color: #a0a8b3 !important;
+  border-style: dashed !important;
+  color: #6c7480 !important;
+  cursor: help !important;
+  opacity: 1 !important;
+  box-shadow: none !important;
+}
+
+.agenda-disabled-action:hover .agenda-disabled-btn {
+  transform: none !important;
+}
+
+@media (max-width: 576px) {
+  .agenda-quick-actions-buttons {
+    gap: 0.4rem;
+  }
+
+  .agenda-quick-actions-buttons .btn {
+    width: 100%;
+  }
+
+  .agenda-disabled-action {
+    display: block;
+    max-width: 100%;
+    width: 100%;
+  }
+}
+
 /* View toggle styling */
 .btn-check:checked+.btn-outline-secondary {
   background-color: #6c757d;


### PR DESCRIPTION
## Summary
Implements issue #805 Phase 2 agenda quick actions with state-driven visibility and behavior, while keeping calendar grid behavior modal-first.

### What changed
- Added agenda quick action state assembly in duty roster calendar context.
- Added/expanded agenda quick action UI for:
  - View Details
  - Plan to Fly
  - Request Instruction
  - Reserve a Glider
  - Request Swap (crew role-gated)
  - Review Student Requests (instructor-gated)
- Added disabled-action guidance via Bootstrap popovers (tap/click friendly on mobile).
- Routed Plan to Fly and Request Instruction quick actions to open the day modal with focused panel expansion.
- Added regression tests for quick-action modal panel URL hints.
- Added Playwright E2E coverage for agenda quick actions, including disabled popover behavior.

## Files
- duty_roster/views.py
- duty_roster/templates/duty_roster/_calendar_agenda.html
- duty_roster/templates/duty_roster/_calendar_body.html
- duty_roster/templates/duty_roster/calendar_day_modal.html
- static/css/baseline.css
- duty_roster/tests/test_calendar_mobile_view.py
- e2e_tests/e2e/test_agenda_quick_actions.py

## Validation
- pytest duty_roster/tests/test_calendar_mobile_view.py -q
- pytest e2e_tests/e2e/test_agenda_quick_actions.py -q
