### PR TITLE
Issue #810: Auto-accept duty swap cover offers

### DIFF
--- a/docs/workflows/05-duty-roster-workflow.md
+++ b/docs/workflows/05-duty-roster-workflow.md
@@ -354,27 +354,36 @@ flowchart TD
     D --> F[Member Makes Offer or Declines Direct Request]
     E --> G[Member Makes Offer]
 
-    F --> H[Offer Saved as Pending]
+    F --> H{Offer Type}
     G --> H
 
-    H --> I[Notify Requester of New Offer]
-    I --> J[Requester Reviews Pending Offers]
-    J --> K{Requester Decision}
+    H -->|Cover| I[Auto-accept Offer and Fulfill Request]
+    H -->|Swap| J[Offer Saved as Pending]
 
-    K -->|Accept Offer| L[Mark Offer Accepted and Request Fulfilled]
-    K -->|Decline Offer| M[Mark Offer Declined]
+    I --> K[Auto-decline Other Pending Offers]
+    K --> L[Update Duty Assignments]
+    L --> M[Notify Requester and Offerer]
+    M --> N[Update Calendar Systems]
 
-    L --> N[Auto-decline Other Pending Offers]
-    N --> O[Update Duty Assignments]
-    O --> P[Notify Requester and Offerer]
-    P --> Q[Update Calendar Systems]
+    J --> O[Notify Requester of New Offer]
+    O --> P[Requester Reviews Pending Offers]
+    P --> Q{Requester Decision}
 
-    M --> R{More Pending Offers?}
-    R -->|Yes| J
-    R -->|No| S[Request Remains Open for New Offers]
+    Q -->|Accept Offer| R[Mark Offer Accepted and Request Fulfilled]
+    Q -->|Decline Offer| S[Mark Offer Declined]
 
-    style L fill:#e8f5e8
-    style S fill:#fff3e0
+    R --> T[Auto-decline Other Pending Offers]
+    T --> U[Update Duty Assignments]
+    U --> V[Notify Requester and Offerer]
+    V --> N
+
+    S --> W{More Pending Offers?}
+    W -->|Yes| P
+    W -->|No| X[Request Remains Open for New Offers]
+
+    style I fill:#e8f5e8
+    style R fill:#e8f5e8
+    style X fill:#fff3e0
 ```
 
 ### **Emergency Coverage Process**

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -21,6 +21,7 @@ from duty_roster.models import (
     DutySwapRequest,
     MemberBlackout,
 )
+from duty_roster.views_swap import _accept_offer_and_finalize
 from members.models import Member
 from siteconfig.models import SiteConfiguration
 
@@ -613,6 +614,30 @@ class TestOfferAcceptDecline:
 
         swap_offer.refresh_from_db()
         assert swap_offer.status == "withdrawn"
+
+    def test_accept_helper_returns_false_when_request_already_fulfilled(
+        self, swap_request, swap_offer, charlie
+    ):
+        """Concurrent/stale accept attempts do not overwrite fulfilled requests."""
+        swap_request.status = "fulfilled"
+        swap_request.accepted_offer = swap_offer
+        swap_request.save(update_fields=["status", "accepted_offer"])
+
+        stale_offer = DutySwapOffer.objects.create(
+            swap_request=swap_request,
+            offered_by=charlie,
+            offer_type="cover",
+            status="pending",
+        )
+
+        accepted = _accept_offer_and_finalize(swap_request, stale_offer)
+        stale_offer.refresh_from_db()
+        swap_request.refresh_from_db()
+
+        assert accepted is False
+        assert stale_offer.status == "auto_declined"
+        assert swap_request.status == "fulfilled"
+        assert swap_request.accepted_offer == swap_offer
 
 
 # =============================================================================

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -487,7 +487,7 @@ class TestSwapOfferWorkflow:
     def test_make_cover_offer(
         self, client, bob, swap_request, bob_duty_assignment, site_config
     ):
-        """Member can make a cover offer."""
+        """Cover offer is accepted immediately and fulfills the request."""
         client.force_login(bob)
         url = reverse("duty_roster:make_swap_offer", args=[swap_request.id])
         resp = client.post(
@@ -498,16 +498,21 @@ class TestSwapOfferWorkflow:
             },
         )
         assert resp.status_code in [200, 302]
-        assert DutySwapOffer.objects.filter(
+        offer = DutySwapOffer.objects.get(
             swap_request=swap_request,
             offered_by=bob,
             offer_type="cover",
-        ).exists()
+        )
+
+        swap_request.refresh_from_db()
+        assert offer.status == "accepted"
+        assert swap_request.status == "fulfilled"
+        assert swap_request.accepted_offer == offer
 
     def test_make_swap_offer(
         self, client, bob, swap_request, bob_duty_assignment, site_config
     ):
-        """Member can make a swap offer with proposed date."""
+        """Swap offer remains pending until requester explicitly accepts."""
         client.force_login(bob)
         url = reverse("duty_roster:make_swap_offer", args=[swap_request.id])
         resp = client.post(
@@ -519,12 +524,52 @@ class TestSwapOfferWorkflow:
             },
         )
         assert resp.status_code in [200, 302]
-        assert DutySwapOffer.objects.filter(
+        offer = DutySwapOffer.objects.get(
             swap_request=swap_request,
             offered_by=bob,
             offer_type="swap",
             proposed_swap_date=bob_duty_assignment.date,
-        ).exists()
+        )
+
+        swap_request.refresh_from_db()
+        assert offer.status == "pending"
+        assert swap_request.status == "open"
+        assert swap_request.accepted_offer is None
+
+    def test_cover_auto_accept_declines_existing_pending_offers(
+        self, client, bob, charlie, swap_request, site_config
+    ):
+        """Auto-accepting a cover offer auto-declines other pending offers."""
+        other_offer = DutySwapOffer.objects.create(
+            swap_request=swap_request,
+            offered_by=charlie,
+            offer_type="cover",
+            status="pending",
+        )
+
+        client.force_login(bob)
+        url = reverse("duty_roster:make_swap_offer", args=[swap_request.id])
+        resp = client.post(
+            url,
+            {
+                "offer_type": "cover",
+                "notes": "I can take this duty",
+            },
+        )
+        assert resp.status_code in [200, 302]
+
+        accepted_offer = DutySwapOffer.objects.get(
+            swap_request=swap_request,
+            offered_by=bob,
+            offer_type="cover",
+        )
+        other_offer.refresh_from_db()
+        swap_request.refresh_from_db()
+
+        assert accepted_offer.status == "accepted"
+        assert other_offer.status == "auto_declined"
+        assert swap_request.status == "fulfilled"
+        assert swap_request.accepted_offer == accepted_offer
 
 
 @pytest.mark.django_db
@@ -786,14 +831,12 @@ class TestSwapIntegration:
         assert swap_offer.offer_type == "cover"
         assert swap_offer.proposed_swap_date is None
 
-        # Step 3: Alice accepts Bob's offer
-        client.force_login(alice)
-        accept_url = reverse("duty_roster:accept_swap_offer", args=[swap_offer.id])
-        client.post(accept_url)
-
-        # Verify final state
+        # Verify final state (auto-accepted for cover offers)
+        swap_offer.refresh_from_db()
         swap_request.refresh_from_db()
+        assert swap_offer.status == "accepted"
         assert swap_request.status == "fulfilled"
+        assert swap_request.accepted_offer == swap_offer
 
 
 # ---------------------------------------------------------------------------

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -498,7 +498,7 @@ class TestSwapOfferWorkflow:
                 "notes": "I can cover for you",
             },
         )
-        assert resp.status_code in [200, 302]
+        assert resp.status_code == 302
         offer = DutySwapOffer.objects.get(
             swap_request=swap_request,
             offered_by=bob,
@@ -524,7 +524,7 @@ class TestSwapOfferWorkflow:
                 "notes": "Let's trade dates",
             },
         )
-        assert resp.status_code in [200, 302]
+        assert resp.status_code == 302
         offer = DutySwapOffer.objects.get(
             swap_request=swap_request,
             offered_by=bob,
@@ -557,7 +557,7 @@ class TestSwapOfferWorkflow:
                 "notes": "I can take this duty",
             },
         )
-        assert resp.status_code in [200, 302]
+        assert resp.status_code == 302
 
         accepted_offer = DutySwapOffer.objects.get(
             swap_request=swap_request,

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -510,6 +510,9 @@ class TestSwapOfferWorkflow:
         assert swap_request.status == "fulfilled"
         assert swap_request.accepted_offer == offer
 
+        updated_assignment = DutyAssignment.objects.get(date=swap_request.original_date)
+        assert updated_assignment.tow_pilot == bob
+
     def test_make_swap_offer(
         self, client, bob, swap_request, bob_duty_assignment, site_config
     ):

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -642,12 +642,19 @@ def make_offer(request, request_id):
 
             # A pure cover offer does not require requester acknowledgement.
             if offer.offer_type == "cover" and not offer.proposed_swap_date:
-                _accept_offer_and_finalize(swap_request, offer)
-                messages.success(
-                    request,
-                    "Your cover offer was accepted automatically. "
-                    "The duty assignment has been updated.",
-                )
+                accepted = _accept_offer_and_finalize(swap_request, offer)
+                if accepted:
+                    messages.success(
+                        request,
+                        "Your cover offer was accepted automatically. "
+                        "The duty assignment has been updated.",
+                    )
+                else:
+                    messages.info(
+                        request,
+                        "This request was just fulfilled by another offer. "
+                        "Your offer was not applied.",
+                    )
             else:
                 # Notify requester for offers that still need a decision.
                 send_offer_made_notification(offer)
@@ -667,37 +674,74 @@ def make_offer(request, request_id):
 
 
 def _accept_offer_and_finalize(swap_request, offer):
-    """Accept an offer, fulfill the request, and send notifications."""
+    """Accept an offer, fulfill the request, and queue notifications post-commit."""
     with transaction.atomic():
+        locked_request = DutySwapRequest.objects.select_for_update().get(
+            pk=swap_request.pk
+        )
+        locked_offer = DutySwapOffer.objects.select_for_update().get(pk=offer.pk)
         now = timezone.now()
 
+        # Abort if another transaction already fulfilled this request.
+        if (
+            locked_request.status != "open"
+            or locked_request.accepted_offer_id is not None
+            or locked_offer.status != "pending"
+        ):
+            if locked_offer.status == "pending":
+                locked_offer.status = "auto_declined"
+                locked_offer.responded_at = now
+                locked_offer.save(update_fields=["status", "responded_at"])
+            return False
+
         # Accept this offer
-        offer.status = "accepted"
-        offer.responded_at = now
-        offer.save()
+        locked_offer.status = "accepted"
+        locked_offer.responded_at = now
+        locked_offer.save(update_fields=["status", "responded_at"])
 
         # Mark request as fulfilled
-        swap_request.status = "fulfilled"
-        swap_request.accepted_offer = offer
-        swap_request.fulfilled_at = now
-        swap_request.save()
+        locked_request.status = "fulfilled"
+        locked_request.accepted_offer = locked_offer
+        locked_request.fulfilled_at = now
+        locked_request.save(update_fields=["status", "accepted_offer", "fulfilled_at"])
 
         # Auto-decline other pending offers
         other_offers = list(
-            swap_request.offers.filter(status="pending").exclude(pk=offer.pk)
+            locked_request.offers.filter(status="pending").exclude(pk=locked_offer.pk)
         )
         for other in other_offers:
             other.status = "auto_declined"
             other.responded_at = now
-            other.save()
+            other.save(update_fields=["status", "responded_at"])
 
         # Update duty assignments
-        update_duty_assignments(swap_request, offer)
+        update_duty_assignments(locked_request, locked_offer)
 
-        # Send notifications
-        send_offer_accepted_notifications(offer)
-        for other in other_offers:
-            send_offer_declined_notification(other, auto=True)
+        accepted_offer_id = locked_offer.pk
+        declined_offer_ids = [other.pk for other in other_offers]
+
+        def _send_notifications_after_commit():
+            accepted_offer = DutySwapOffer.objects.select_related(
+                "swap_request", "offered_by", "swap_request__requester"
+            ).get(pk=accepted_offer_id)
+            send_offer_accepted_notifications(accepted_offer)
+
+            for declined_offer_id in declined_offer_ids:
+                declined_offer = DutySwapOffer.objects.select_related(
+                    "swap_request", "offered_by", "swap_request__requester"
+                ).get(pk=declined_offer_id)
+                send_offer_declined_notification(declined_offer, auto=True)
+
+        transaction.on_commit(_send_notifications_after_commit)
+
+        # Keep caller instances up to date for downstream messages.
+        offer.status = locked_offer.status
+        offer.responded_at = locked_offer.responded_at
+        swap_request.status = locked_request.status
+        swap_request.accepted_offer = locked_request.accepted_offer
+        swap_request.fulfilled_at = locked_request.fulfilled_at
+
+        return True
 
 
 @active_member_required
@@ -718,7 +762,10 @@ def accept_offer(request, offer_id):
         messages.error(request, "This offer is no longer available.")
         return redirect("duty_roster:swap_request_detail", request_id=swap_request.pk)
 
-    _accept_offer_and_finalize(swap_request, offer)
+    accepted = _accept_offer_and_finalize(swap_request, offer)
+    if not accepted:
+        messages.error(request, "This offer is no longer available.")
+        return redirect("duty_roster:swap_request_detail", request_id=swap_request.pk)
 
     messages.success(
         request,

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -703,22 +703,22 @@ def _accept_offer_and_finalize(swap_request, offer):
         locked_request.status = "fulfilled"
         locked_request.accepted_offer = locked_offer
         locked_request.fulfilled_at = now
-        locked_request.save(update_fields=["status", "accepted_offer", "fulfilled_at"])
+        locked_request.save(
+            update_fields=["status", "accepted_offer", "fulfilled_at", "updated_at"]
+        )
 
         # Auto-decline other pending offers
-        other_offers = list(
-            locked_request.offers.filter(status="pending").exclude(pk=locked_offer.pk)
+        pending_other_offers = locked_request.offers.filter(status="pending").exclude(
+            pk=locked_offer.pk
         )
-        for other in other_offers:
-            other.status = "auto_declined"
-            other.responded_at = now
-            other.save(update_fields=["status", "responded_at"])
+        declined_offer_ids = list(pending_other_offers.values_list("pk", flat=True))
+        if declined_offer_ids:
+            pending_other_offers.update(status="auto_declined", responded_at=now)
 
         # Update duty assignments
         update_duty_assignments(locked_request, locked_offer)
 
         accepted_offer_id = locked_offer.pk
-        declined_offer_ids = [other.pk for other in other_offers]
 
         def _send_notifications_after_commit():
             offers = DutySwapOffer.objects.select_related(

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -640,13 +640,21 @@ def make_offer(request, request_id):
         if form.is_valid():
             offer = form.save()
 
-            # Notify requester
-            send_offer_made_notification(offer)
-
-            messages.success(
-                request,
-                f"Your offer has been sent to {swap_request.requester.first_name}!",
-            )
+            # A pure cover offer does not require requester acknowledgement.
+            if offer.offer_type == "cover" and not offer.proposed_swap_date:
+                _accept_offer_and_finalize(swap_request, offer)
+                messages.success(
+                    request,
+                    "Your cover offer was accepted automatically. "
+                    "The duty assignment has been updated.",
+                )
+            else:
+                # Notify requester for offers that still need a decision.
+                send_offer_made_notification(offer)
+                messages.success(
+                    request,
+                    f"Your offer has been sent to {swap_request.requester.first_name}!",
+                )
             return redirect("duty_roster:swap_request_detail", request_id=request_id)
     else:
         form = DutySwapOfferForm(swap_request=swap_request, offered_by=member)
@@ -656,6 +664,40 @@ def make_offer(request, request_id):
         "swap_request": swap_request,
     }
     return render(request, "duty_roster/swap/make_offer.html", context)
+
+
+def _accept_offer_and_finalize(swap_request, offer):
+    """Accept an offer, fulfill the request, and send notifications."""
+    with transaction.atomic():
+        now = timezone.now()
+
+        # Accept this offer
+        offer.status = "accepted"
+        offer.responded_at = now
+        offer.save()
+
+        # Mark request as fulfilled
+        swap_request.status = "fulfilled"
+        swap_request.accepted_offer = offer
+        swap_request.fulfilled_at = now
+        swap_request.save()
+
+        # Auto-decline other pending offers
+        other_offers = list(
+            swap_request.offers.filter(status="pending").exclude(pk=offer.pk)
+        )
+        for other in other_offers:
+            other.status = "auto_declined"
+            other.responded_at = now
+            other.save()
+
+        # Update duty assignments
+        update_duty_assignments(swap_request, offer)
+
+        # Send notifications
+        send_offer_accepted_notifications(offer)
+        for other in other_offers:
+            send_offer_declined_notification(other, auto=True)
 
 
 @active_member_required
@@ -676,33 +718,7 @@ def accept_offer(request, offer_id):
         messages.error(request, "This offer is no longer available.")
         return redirect("duty_roster:swap_request_detail", request_id=swap_request.pk)
 
-    with transaction.atomic():
-        # Accept this offer
-        offer.status = "accepted"
-        offer.responded_at = timezone.now()
-        offer.save()
-
-        # Mark request as fulfilled
-        swap_request.status = "fulfilled"
-        swap_request.accepted_offer = offer
-        swap_request.fulfilled_at = timezone.now()
-        swap_request.save()
-
-        # Auto-decline other pending offers
-        other_offers = swap_request.offers.filter(status="pending").exclude(pk=offer.pk)
-        for other in other_offers:
-            other.status = "auto_declined"
-            other.responded_at = timezone.now()
-            other.save()
-
-        # Update duty assignments
-        update_duty_assignments(swap_request, offer)
-
-        # Send notifications
-        send_offer_accepted_notifications(offer)
-
-        for other in other_offers:
-            send_offer_declined_notification(other, auto=True)
+    _accept_offer_and_finalize(swap_request, offer)
 
     messages.success(
         request,

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -721,16 +721,19 @@ def _accept_offer_and_finalize(swap_request, offer):
         declined_offer_ids = [other.pk for other in other_offers]
 
         def _send_notifications_after_commit():
-            accepted_offer = DutySwapOffer.objects.select_related(
+            offers = DutySwapOffer.objects.select_related(
                 "swap_request", "offered_by", "swap_request__requester"
-            ).get(pk=accepted_offer_id)
-            send_offer_accepted_notifications(accepted_offer)
+            ).filter(pk__in=[accepted_offer_id, *declined_offer_ids])
+            offers_by_id = {loaded_offer.pk: loaded_offer for loaded_offer in offers}
+
+            accepted_offer = offers_by_id.get(accepted_offer_id)
+            if accepted_offer is not None:
+                send_offer_accepted_notifications(accepted_offer)
 
             for declined_offer_id in declined_offer_ids:
-                declined_offer = DutySwapOffer.objects.select_related(
-                    "swap_request", "offered_by", "swap_request__requester"
-                ).get(pk=declined_offer_id)
-                send_offer_declined_notification(declined_offer, auto=True)
+                declined_offer = offers_by_id.get(declined_offer_id)
+                if declined_offer is not None:
+                    send_offer_declined_notification(declined_offer, auto=True)
 
         transaction.on_commit(_send_notifications_after_commit)
 

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -37,6 +37,7 @@ The `DjangoPlaywrightTestCase` base class sets the `DJANGO_ALLOW_ASYNC_UNSAFE` e
 - `test_banner_brightness_detection.py`: Banner auto-contrast text detection tests (Issue #558)
 - `test_tinymce.py`: TinyMCE editor tests (initialization, YouTube embedding, media dialog)
 - `test_duty_percentage_validation.py`: Duty roster percentage validation tests
+- `test_duty_swap_auto_accept.py`: Duty swap offer flow tests (cover auto-accept and swap pending workflow)
 - `test_kiosk_authentication.py`: Kiosk authentication mode tests
 - `test_logsheet_altitude_buttons.py`: Logsheet altitude button interaction tests
 - `test_maintenance_deadline_update.py`: Maintenance deadline update tests
@@ -81,3 +82,4 @@ pytest e2e_tests/e2e/ --cov=. --cov-report=term-missing -v
 - Issue #422: TinyMCE YouTube embedding bug (confirmed via xfail test)
 - Issue #547: Site Style Enhancements (navbar, banners)
 - Issue #558: E2E tests for navbar active highlighting and banner brightness detection
+- Issue #810: Duty swap cover auto-accept and pending swap workflow

--- a/e2e_tests/e2e/test_duty_swap_auto_accept.py
+++ b/e2e_tests/e2e/test_duty_swap_auto_accept.py
@@ -1,0 +1,120 @@
+"""Focused E2E coverage for duty swap offer behavior (Issue #810).
+
+Validates that:
+- Cover offers are auto-accepted immediately from the Make Offer UI.
+- Swap offers remain pending and require requester acceptance.
+"""
+
+from datetime import date, timedelta
+
+from django.urls import reverse
+
+from duty_roster.models import DutyAssignment, DutySwapOffer, DutySwapRequest
+from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+from siteconfig.models import SiteConfiguration
+
+
+class TestDutySwapAutoAccept(DjangoPlaywrightTestCase):
+    def setUp(self):
+        super().setUp()
+        SiteConfiguration.objects.get_or_create(
+            defaults={
+                "club_name": "Test Soaring Club",
+                "club_abbreviation": "TSC",
+                "domain_name": "test.org",
+                "schedule_tow_pilots": True,
+                "schedule_duty_officers": True,
+                "schedule_instructors": True,
+                "schedule_assistant_duty_officers": True,
+            }
+        )
+
+    def _create_open_tow_swap_request(self):
+        requester = self.create_test_member(
+            username="swaprequester",
+            email="swaprequester@example.com",
+            membership_status="Full Member",
+            towpilot=True,
+        )
+        offerer = self.create_test_member(
+            username="swapofferer",
+            email="swapofferer@example.com",
+            membership_status="Full Member",
+            towpilot=True,
+        )
+
+        target_date = date.today() + timedelta(days=14)
+        DutyAssignment.objects.create(date=target_date, tow_pilot=requester)
+
+        swap_request = DutySwapRequest.objects.create(
+            requester=requester,
+            original_date=target_date,
+            role="TOW",
+            request_type="general",
+            status="open",
+            notes="Need coverage",
+        )
+
+        return requester, offerer, swap_request
+
+    def test_cover_offer_auto_accepts_from_ui(self):
+        """Submitting a cover offer auto-accepts and fulfills the request."""
+        requester, offerer, swap_request = self._create_open_tow_swap_request()
+
+        self.login(username=offerer.username)
+        offer_url = reverse("duty_roster:make_swap_offer", args=[swap_request.pk])
+        self.page.goto(f"{self.live_server_url}{offer_url}")
+        self.page.wait_for_selector("text=Make an Offer")
+
+        self.page.check('input[name="offer_type"][value="cover"]')
+        self.page.fill('textarea[name="notes"]', "I can cover this duty")
+        self.page.get_by_role("button", name="Send Offer").click()
+
+        detail_url = f"{self.live_server_url}{reverse('duty_roster:swap_request_detail', args=[swap_request.pk])}"
+        self.page.wait_for_url(detail_url)
+        self.page.wait_for_selector("text=Resolved!")
+        self.page.wait_for_selector("text=ACCEPTED")
+
+        offer = DutySwapOffer.objects.get(swap_request=swap_request, offered_by=offerer)
+        assignment = DutyAssignment.objects.get(date=swap_request.original_date)
+        swap_request.refresh_from_db()
+
+        assert offer.status == "accepted"
+        assert swap_request.status == "fulfilled"
+        assert swap_request.accepted_offer_id == offer.id
+        assert assignment.tow_pilot_id == offerer.id
+
+    def test_swap_offer_stays_pending_until_requester_accepts(self):
+        """Submitting a swap offer keeps the request open and offer pending."""
+        requester, offerer, swap_request = self._create_open_tow_swap_request()
+        proposed_date = date.today() + timedelta(days=21)
+
+        self.login(username=offerer.username)
+        offer_url = reverse("duty_roster:make_swap_offer", args=[swap_request.pk])
+        self.page.goto(f"{self.live_server_url}{offer_url}")
+        self.page.wait_for_selector("text=Make an Offer")
+
+        self.page.check('input[name="offer_type"][value="swap"]')
+        self.page.wait_for_function(
+            "() => getComputedStyle(document.querySelector('#swap-date-section')).display !== 'none'"
+        )
+        self.page.fill('input[name="proposed_swap_date"]', proposed_date.isoformat())
+        self.page.fill('textarea[name="notes"]', "Can trade with my duty date")
+        self.page.get_by_role("button", name="Send Offer").click()
+
+        detail_url = f"{self.live_server_url}{reverse('duty_roster:swap_request_detail', args=[swap_request.pk])}"
+        self.page.wait_for_url(detail_url)
+        self.page.wait_for_selector("text=Swap: Will take")
+
+        offer = DutySwapOffer.objects.get(swap_request=swap_request, offered_by=offerer)
+        swap_request.refresh_from_db()
+
+        assert offer.status == "pending"
+        assert swap_request.status == "open"
+        assert swap_request.accepted_offer is None
+
+        # Requester still sees manual Accept action for pending swap offers.
+        self.context.clear_cookies()
+        self.login(username=requester.username)
+        self.page.goto(detail_url)
+        self.page.wait_for_selector('button:has-text("Accept")')


### PR DESCRIPTION
## Summary
- auto-accept pure cover duty swap offers on submission (no requester acknowledgement step)
- keep swap offers pending until requester explicitly accepts
- refactor acceptance/finalization into shared helper to keep behavior consistent
- update workflow documentation for cover vs swap branches
- add focused Playwright E2E coverage for auto-accept and pending swap paths

## Files Changed
- duty_roster/views_swap.py
- duty_roster/tests/test_duty_swap.py
- docs/workflows/05-duty-roster-workflow.md
- e2e_tests/e2e/test_duty_swap_auto_accept.py
- e2e_tests/README.md

## Validation
- pytest duty_roster/tests/test_duty_swap.py -q (48 passed)
- pytest duty_roster/tests/test_ics_generation.py -q (26 passed)
- pytest e2e_tests/e2e/test_duty_swap_auto_accept.py -q (2 passed)

Closes #810
