### PR TITLE
Issue #806: Directors read-only access to membership waitlist

### DIFF
--- a/members/templates/members/membership_application_detail.html
+++ b/members/templates/members/membership_application_detail.html
@@ -282,7 +282,7 @@
         </div>
 
         <!-- Review Form -->
-        {% if application.status != 'approved' and application.status != 'rejected' %}
+        {% if application.status != 'approved' and application.status != 'rejected' and can_modify %}
         <div class="review-section">
             <h4><i class="fas fa-gavel"></i> Review Application</h4>
             <form method="post">
@@ -328,6 +328,11 @@
                     </button>
                 </div>
             </form>
+        </div>
+        {% elif application.status != 'approved' and application.status != 'rejected' %}
+        <div class="alert alert-info">
+            <h5><i class="fas fa-eye"></i> Read-Only Director View</h5>
+            <p class="mb-0">You can review application and waitlist status, but only membership managers/webmasters can make changes.</p>
         </div>
         {% elif application.status == 'approved' %}
         <div class="alert alert-success">

--- a/members/templates/members/membership_application_detail.html
+++ b/members/templates/members/membership_application_detail.html
@@ -332,7 +332,7 @@
         {% elif application.status != 'approved' and application.status != 'rejected' %}
         <div class="alert alert-info">
             <h5><i class="fas fa-eye"></i> Read-Only Director View</h5>
-            <p class="mb-0">You can review application and waitlist status, but only membership managers/webmasters can make changes.</p>
+            <p class="mb-0">You can review the application and waitlist status, but only membership managers/webmasters can make changes.</p>
         </div>
         {% elif application.status == 'approved' %}
         <div class="alert alert-success">

--- a/members/templates/members/membership_applications_list.html
+++ b/members/templates/members/membership_applications_list.html
@@ -154,7 +154,7 @@
                                                    class="btn btn-sm btn-outline-primary" title="View Details">
                                                     <i class="fas fa-eye"></i>
                                                 </a>
-                                                {% if app.status == 'pending' or app.status == 'under_review' %}
+                                                {% if can_modify and app.status == 'pending' or can_modify and app.status == 'under_review' %}
                                                     <a href="{% url 'members:membership_application_detail' app.application_id %}"
                                                        class="btn btn-sm btn-outline-success" title="Review">
                                                         <i class="fas fa-check"></i>

--- a/members/templates/members/membership_applications_list.html
+++ b/members/templates/members/membership_applications_list.html
@@ -154,11 +154,13 @@
                                                    class="btn btn-sm btn-outline-primary" title="View Details">
                                                     <i class="fas fa-eye"></i>
                                                 </a>
-                                                {% if can_modify and app.status == 'pending' or can_modify and app.status == 'under_review' %}
-                                                    <a href="{% url 'members:membership_application_detail' app.application_id %}"
-                                                       class="btn btn-sm btn-outline-success" title="Review">
-                                                        <i class="fas fa-check"></i>
-                                                    </a>
+                                                {% if can_modify %}
+                                                    {% if app.status == 'pending' or app.status == 'under_review' %}
+                                                        <a href="{% url 'members:membership_application_detail' app.application_id %}"
+                                                           class="btn btn-sm btn-outline-success" title="Review">
+                                                            <i class="fas fa-check"></i>
+                                                        </a>
+                                                    {% endif %}
                                                 {% endif %}
                                             </div>
                                         </td>

--- a/members/templates/members/membership_waitlist.html
+++ b/members/templates/members/membership_waitlist.html
@@ -33,7 +33,11 @@
                     <h4>Current Waitlist</h4>
                     <p class="mb-0 text-muted">
                         {{ applications|length }} applicant{{ applications|length|pluralize }} currently waiting for membership.
+                        {% if can_modify %}
                         Use the arrow buttons to reorder the list as needed.
+                        {% else %}
+                        Directors have read-only access to waitlist status.
+                        {% endif %}
                     </p>
                 </div>
 
@@ -82,6 +86,7 @@
                                     <i class="fas fa-eye"></i>
                                 </a>
 
+                                {% if can_modify %}
                                 {% if app.waitlist_position > 1 %}
                                 <form method="post" style="display: inline;">
                                     {% csrf_token %}
@@ -122,6 +127,7 @@
                                         <i class="fas fa-angle-double-down"></i>
                                     </button>
                                 </form>
+                                {% endif %}
                                 {% endif %}
                             </div>
                         </div>

--- a/members/tests/test_membership_applications.py
+++ b/members/tests/test_membership_applications.py
@@ -337,6 +337,18 @@ class MembershipApplicationViewTests(TestCase):
         self.client.force_login(manager)
         return manager
 
+    def _create_director(self, username="director", email="director@example.com"):
+        """Create and return a director user (read-only for applications)."""
+        director = Member.objects.create_user(
+            username=username,
+            email=email,
+            password="testpass",
+            director=True,
+            membership_status="Full Member",
+        )
+        self.client.force_login(director)
+        return director
+
     def _create_waitlisted_app(self, first_name, email):
         """Create and return a waitlisted application."""
         application = MembershipApplication.objects.create(
@@ -559,6 +571,89 @@ class MembershipApplicationViewTests(TestCase):
         self.assertContains(response, "Person0 Test")
         self.assertContains(response, "Person1 Test")
         self.assertContains(response, "Person2 Test")
+
+    def test_director_can_view_applications_list(self):
+        """Directors can view membership applications list in read-only mode."""
+        self._create_director()
+        response = self.client.get(
+            reverse("members:membership_applications_list"), follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Membership Applications")
+
+    def test_director_can_view_application_detail(self):
+        """Directors can view membership application details in read-only mode."""
+        self._create_director()
+        application = self._create_waitlisted_app(
+            "DirectorView", "directorview@example.com"
+        )
+        response = self.client.get(
+            reverse(
+                "members:membership_application_detail",
+                args=[application.application_id],
+            ),
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Application Review")
+        self.assertContains(response, "Read-Only Director View")
+
+    def test_director_can_view_waitlist(self):
+        """Directors can view waitlist status in read-only mode."""
+        self._create_director()
+        self._create_waitlisted_app("WaitlistRead", "waitlistread@example.com")
+        response = self.client.get(reverse("members:membership_waitlist"), follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Membership Waitlist")
+        self.assertContains(response, "read-only access")
+
+    def test_director_cannot_modify_application_review(self):
+        """Directors cannot submit review actions on applications."""
+        self._create_director()
+        application = self._create_waitlisted_app("NoModify", "nomodify@example.com")
+        response = self.client.post(
+            reverse(
+                "members:membership_application_detail",
+                args=[application.application_id],
+            ),
+            {
+                "review_action": "reject",
+                "admin_notes": "Should be blocked",
+            },
+        )
+        self.assertEqual(response.status_code, 403)
+
+        application.refresh_from_db()
+        self.assertEqual(application.status, "waitlisted")
+
+    def test_director_cannot_reorder_waitlist(self):
+        """Directors cannot submit waitlist reorder actions."""
+        self._create_director()
+        app1 = self._create_waitlisted_app("First", "firstro@example.com")
+        app2 = self._create_waitlisted_app("Second", "secondro@example.com")
+        response = self.client.post(
+            reverse("members:membership_waitlist"),
+            {"action": "move_to_top", "application_id": app2.application_id},
+        )
+        self.assertEqual(response.status_code, 403)
+
+        app1.refresh_from_db()
+        app2.refresh_from_db()
+        self.assertEqual(app1.waitlist_position, 1)
+        self.assertEqual(app2.waitlist_position, 2)
+
+    def test_regular_member_cannot_view_membership_applications(self):
+        """Active members without elevated roles cannot view membership applications."""
+        regular_member = Member.objects.create_user(
+            username="regular",
+            email="regular@example.com",
+            password="testpass",
+            membership_status="Full Member",
+        )
+        self.client.force_login(regular_member)
+
+        response = self.client.get(reverse("members:membership_applications_list"))
+        self.assertEqual(response.status_code, 403)
 
     def test_waitlist_move_to_top(self):
         """Test moving an applicant to the top of the waitlist."""

--- a/members/tests/test_membership_applications.py
+++ b/members/tests/test_membership_applications.py
@@ -575,11 +575,29 @@ class MembershipApplicationViewTests(TestCase):
     def test_director_can_view_applications_list(self):
         """Directors can view membership applications list in read-only mode."""
         self._create_director()
+        MembershipApplication.objects.create(
+            first_name="ListView",
+            last_name="Test",
+            email="listview@example.com",
+            phone="555-123-4567",
+            address_line1="123 Main St",
+            city="Anytown",
+            state="CA",
+            zip_code="12345",
+            emergency_contact_name="Contact Person",
+            emergency_contact_relationship="Friend",
+            emergency_contact_phone="555-987-6543",
+            soaring_goals="Test",
+            agrees_to_terms=True,
+            agrees_to_safety_rules=True,
+            agrees_to_financial_obligations=True,
+        )
         response = self.client.get(
             reverse("members:membership_applications_list"), follow=True
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Membership Applications")
+        self.assertNotContains(response, 'title="Review"')
 
     def test_director_can_view_application_detail(self):
         """Directors can view membership application details in read-only mode."""

--- a/members/views_applications.py
+++ b/members/views_applications.py
@@ -21,6 +21,18 @@ from .models_applications import MembershipApplication
 logger = logging.getLogger(__name__)
 
 
+def _can_view_membership_applications(user):
+    """Return True when the user may view membership applications/waitlist."""
+    return bool(
+        user.director or user.member_manager or user.webmaster or user.is_superuser
+    )
+
+
+def _can_modify_membership_applications(user):
+    """Return True when the user may modify membership applications/waitlist."""
+    return bool(user.member_manager or user.webmaster or user.is_superuser)
+
+
 @ensure_csrf_cookie
 @require_http_methods(["GET", "POST"])
 def membership_application(request):
@@ -135,16 +147,12 @@ def membership_application(request):
 @active_member_required
 def membership_applications_list(request):
     """
-    List of all membership applications for membership managers.
-    Only accessible to members with member_manager role.
+    List of membership applications for authorized club roles.
+    Directors have read-only visibility.
     """
 
-    # Check if user has permission to manage memberships
-    if not (
-        request.user.member_manager
-        or request.user.webmaster
-        or request.user.is_superuser
-    ):
+    # Check if user has permission to view memberships
+    if not _can_view_membership_applications(request.user):
         raise PermissionDenied(
             "You do not have permission to view membership applications."
         )
@@ -204,6 +212,7 @@ def membership_applications_list(request):
             "search_query": search_query,
             "status_counts": status_counts_dict,
             "status_choices": MembershipApplication.STATUS_CHOICES,
+            "can_modify": _can_modify_membership_applications(request.user),
         },
     )
 
@@ -211,19 +220,17 @@ def membership_applications_list(request):
 @active_member_required
 def membership_application_detail(request, application_id):
     """
-    Detailed view of a membership application with review capabilities.
-    Only accessible to membership managers.
+    Detailed view of a membership application.
+    Directors have read-only visibility.
     """
 
-    # Check permissions
-    if not (
-        request.user.member_manager
-        or request.user.webmaster
-        or request.user.is_superuser
-    ):
+    # Check read permissions
+    if not _can_view_membership_applications(request.user):
         raise PermissionDenied(
             "You do not have permission to view membership applications."
         )
+
+    can_modify = _can_modify_membership_applications(request.user)
 
     # Get the application
     application = get_object_or_404(
@@ -231,6 +238,11 @@ def membership_application_detail(request, application_id):
     )
 
     if request.method == "POST":
+        if not can_modify:
+            raise PermissionDenied(
+                "Directors have read-only access to membership applications."
+            )
+
         review_form = MembershipApplicationReviewForm(
             request.POST, instance=application
         )
@@ -375,6 +387,7 @@ def membership_application_detail(request, application_id):
         {
             "application": application,
             "review_form": review_form,
+            "can_modify": can_modify,
         },
     )
 
@@ -382,21 +395,24 @@ def membership_application_detail(request, application_id):
 @active_member_required
 def membership_waitlist(request):
     """
-    Manage the membership waiting list - allows reordering of applications.
-    Only accessible to membership managers.
+    View/manage the membership waiting list.
+    Directors have read-only visibility.
     """
 
-    # Check permissions
-    if not (
-        request.user.member_manager
-        or request.user.webmaster
-        or request.user.is_superuser
-    ):
+    # Check read permissions
+    if not _can_view_membership_applications(request.user):
         raise PermissionDenied(
             "You do not have permission to manage the membership waiting list."
         )
 
+    can_modify = _can_modify_membership_applications(request.user)
+
     if request.method == "POST":
+        if not can_modify:
+            raise PermissionDenied(
+                "Directors have read-only access to membership waitlist status."
+            )
+
         # Handle waitlist reordering
         action = request.POST.get("action")
         application_id = request.POST.get("application_id")
@@ -534,6 +550,7 @@ def membership_waitlist(request):
         "members/membership_waitlist.html",
         {
             "applications": waitlisted_applications,
+            "can_modify": can_modify,
         },
     )
 

--- a/members/views_applications.py
+++ b/members/views_applications.py
@@ -402,7 +402,7 @@ def membership_waitlist(request):
     # Check read permissions
     if not _can_view_membership_applications(request.user):
         raise PermissionDenied(
-            "You do not have permission to manage the membership waiting list."
+            "You do not have permission to view the membership waiting list."
         )
 
     can_modify = _can_modify_membership_applications(request.user)

--- a/templates/base.html
+++ b/templates/base.html
@@ -110,7 +110,7 @@
             <ul class="dropdown-menu" aria-labelledby="membersDropdown">
               <li><a class="dropdown-item" href="{% url 'members:member_list' %}"><i class="fas fa-address-book me-1"></i> Member List</a></li>
               {% if user.is_authenticated %}
-                {% if user.member_manager or user.webmaster or user.is_superuser %}
+                {% if user.director or user.member_manager or user.webmaster or user.is_superuser %}
               <li><a class="dropdown-item" href="{% url 'members:membership_applications_list' %}"><i class="fas fa-user-plus"></i> Membership Applications</a></li>
                 {% endif %}
               {% endif %}


### PR DESCRIPTION
## Summary
- allow active director users to view membership applications and waitlist pages
- keep application review and waitlist reorder actions restricted to member managers, webmasters, and superusers
- add read-only messaging and hide write controls in membership application templates
- expose Membership Applications navigation item to directors
- add tests for director read access and blocked write attempts

## Validation
- /home/piet/Projects/skylinesoaring/Manage2Soar/.venv/bin/python -m pytest members/tests/test_membership_applications.py -q
  - 22 passed

Closes #806