### PR TITLE
Issue #762: Logbook all-time glider breakouts and rated dual logging

### DIFF
--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -38,6 +38,7 @@ The `DjangoPlaywrightTestCase` base class sets the `DJANGO_ALLOW_ASYNC_UNSAFE` e
 - `test_tinymce.py`: TinyMCE editor tests (initialization, YouTube embedding, media dialog)
 - `test_duty_percentage_validation.py`: Duty roster percentage validation tests
 - `test_duty_swap_auto_accept.py`: Duty swap offer flow tests (cover auto-accept and swap pending workflow)
+- `test_logbook_time_breakouts.py`: Logbook dual/PIC and all-time summary breakout tests
 - `test_kiosk_authentication.py`: Kiosk authentication mode tests
 - `test_logsheet_altitude_buttons.py`: Logsheet altitude button interaction tests
 - `test_maintenance_deadline_update.py`: Maintenance deadline update tests
@@ -83,3 +84,4 @@ pytest e2e_tests/e2e/ --cov=. --cov-report=term-missing -v
 - Issue #547: Site Style Enhancements (navbar, banners)
 - Issue #558: E2E tests for navbar active highlighting and banner brightness detection
 - Issue #810: Duty swap cover auto-accept and pending swap workflow
+- Issue #762: Logbook all-time glider time breakouts and rated dual/PIC behavior

--- a/e2e_tests/e2e/test_logbook_time_breakouts.py
+++ b/e2e_tests/e2e/test_logbook_time_breakouts.py
@@ -1,0 +1,133 @@
+"""Focused E2E tests for logbook time breakout behavior (Issue #762)."""
+
+from datetime import date, time, timedelta
+
+from django.urls import reverse
+
+from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+from logsheet.models import Airfield, Flight, Glider, Logsheet
+
+
+class TestLogbookTimeBreakouts(DjangoPlaywrightTestCase):
+    def _create_common_members(self, pilot_username):
+        pilot = self.create_test_member(
+            username=pilot_username,
+            glider_rating="rated",
+        )
+        pilot.private_glider_checkride_date = date(2020, 1, 1)
+        pilot.save(update_fields=["private_glider_checkride_date"])
+
+        instructor = self.create_test_member(
+            username=f"{pilot_username}_instructor",
+            instructor=True,
+            glider_rating="rated",
+        )
+        return pilot, instructor
+
+    def test_rated_pilot_dual_row_shows_dual_and_pic(self):
+        """Rated pilot with instructor logs both Dual Received and PIC on logbook row."""
+        pilot, instructor = self._create_common_members("e2e_logbook_rated")
+
+        airfield = Airfield.objects.create(name="Front Royal", identifier="KFRR")
+        glider = Glider.objects.create(
+            n_number="N762E2E1",
+            make="Schleicher",
+            model="ASK-21",
+            club_owned=True,
+            is_active=True,
+        )
+        logsheet = Logsheet.objects.create(
+            log_date=date(2024, 6, 1),
+            airfield=airfield,
+            created_by=pilot,
+        )
+        Flight.objects.create(
+            logsheet=logsheet,
+            pilot=pilot,
+            instructor=instructor,
+            glider=glider,
+            launch_method="tow",
+            launch_time=time(10, 0),
+            landing_time=time(10, 25),
+        )
+
+        self.login(username=pilot.username)
+        self.page.goto(
+            f"{self.live_server_url}{reverse('instructors:member_logbook')}?show_all_years=1"
+        )
+        self.page.wait_for_selector("text=Logbook for")
+
+        row = self.page.locator("table.table tbody tr", has_text="2024-06-01").first
+        dual = row.locator("td").nth(11).inner_text().strip()
+        pic = row.locator("td").nth(13).inner_text().strip()
+        total = row.locator("td").nth(15).inner_text().strip()
+
+        assert dual == "0:25"
+        assert pic == "0:25"
+        assert total == "0:25"
+
+    def test_default_view_hides_old_rows_but_summary_is_all_time(self):
+        """Default logbook view still shows all-time totals in the glider summary table."""
+        pilot, instructor = self._create_common_members("e2e_logbook_alltime")
+
+        airfield = Airfield.objects.create(name="Summit Point", identifier="KSUM")
+        glider = Glider.objects.create(
+            n_number="N762E2E2",
+            make="Schleicher",
+            model="ASK-21",
+            club_owned=True,
+            is_active=True,
+        )
+
+        old_date = date.today() - timedelta(days=365 * 5)
+        recent_date = date.today() - timedelta(days=7)
+
+        old_logsheet = Logsheet.objects.create(
+            log_date=old_date,
+            airfield=airfield,
+            created_by=pilot,
+        )
+        Flight.objects.create(
+            logsheet=old_logsheet,
+            pilot=pilot,
+            instructor=instructor,
+            glider=glider,
+            launch_method="tow",
+            launch_time=time(9, 0),
+            landing_time=time(9, 30),
+        )
+
+        recent_logsheet = Logsheet.objects.create(
+            log_date=recent_date,
+            airfield=airfield,
+            created_by=pilot,
+        )
+        Flight.objects.create(
+            logsheet=recent_logsheet,
+            pilot=pilot,
+            instructor=instructor,
+            glider=glider,
+            launch_method="tow",
+            launch_time=time(10, 0),
+            landing_time=time(10, 45),
+        )
+
+        self.login(username=pilot.username)
+        self.page.goto(f"{self.live_server_url}{reverse('instructors:member_logbook')}")
+        self.page.wait_for_selector("text=Logbook for")
+
+        assert self.page.locator(f"text={old_date.isoformat()}").count() == 0
+        assert self.page.locator(f"text={recent_date.isoformat()}").count() > 0
+
+        self.page.wait_for_selector("text=All-Time Glider Time Summary")
+        summary_row = self.page.locator(
+            "table tbody tr", has_text="Schleicher ASK-21"
+        ).first
+
+        dual = summary_row.locator("td").nth(1).inner_text().strip()
+        pic_summary = summary_row.locator("td").nth(4).inner_text().strip()
+        total = summary_row.locator("td").nth(5).inner_text().strip()
+
+        assert dual == "1:15"
+        assert pic_summary == "1:15"
+        assert total == "1:15"

--- a/e2e_tests/e2e/test_logbook_time_breakouts.py
+++ b/e2e_tests/e2e/test_logbook_time_breakouts.py
@@ -9,6 +9,13 @@ from logsheet.models import Airfield, Flight, Glider, Logsheet
 
 
 class TestLogbookTimeBreakouts(DjangoPlaywrightTestCase):
+    def _header_index_map(self, table):
+        headers = [
+            table.locator("thead tr").last.locator("th").nth(i).inner_text().strip()
+            for i in range(table.locator("thead tr").last.locator("th").count())
+        ]
+        return {name: idx for idx, name in enumerate(headers)}
+
     def _create_common_members(self, pilot_username):
         pilot = self.create_test_member(
             username=pilot_username,
@@ -57,10 +64,13 @@ class TestLogbookTimeBreakouts(DjangoPlaywrightTestCase):
         )
         self.page.wait_for_selector("text=Logbook for")
 
-        row = self.page.locator("table.table tbody tr", has_text="2024-06-01").first
-        dual = row.locator("td").nth(11).inner_text().strip()
-        pic = row.locator("td").nth(13).inner_text().strip()
-        total = row.locator("td").nth(15).inner_text().strip()
+        logbook_table = self.page.locator("table.table").first
+        col = self._header_index_map(logbook_table)
+
+        row = logbook_table.locator("tbody tr", has_text="2024-06-01").first
+        dual = row.locator("td").nth(col["Dual"]).inner_text().strip()
+        pic = row.locator("td").nth(col["PIC"]).inner_text().strip()
+        total = row.locator("td").nth(col["Total"]).inner_text().strip()
 
         assert dual == "0:25"
         assert pic == "0:25"
@@ -120,8 +130,11 @@ class TestLogbookTimeBreakouts(DjangoPlaywrightTestCase):
         assert self.page.locator(f"text={recent_date.isoformat()}").count() > 0
 
         self.page.wait_for_selector("text=All-Time Glider Time Summary")
-        summary_row = self.page.locator(
-            "table tbody tr", has_text="Schleicher ASK-21"
+        summary_table = self.page.locator(
+            "h3:has-text('All-Time Glider Time Summary') + p + div table"
+        ).first
+        summary_row = summary_table.locator(
+            "tbody tr", has_text="Schleicher ASK-21"
         ).first
 
         dual = summary_row.locator("td").nth(1).inner_text().strip()

--- a/e2e_tests/e2e/test_logbook_time_breakouts.py
+++ b/e2e_tests/e2e/test_logbook_time_breakouts.py
@@ -9,12 +9,44 @@ from logsheet.models import Airfield, Flight, Glider, Logsheet
 
 
 class TestLogbookTimeBreakouts(DjangoPlaywrightTestCase):
+    def _normalize_header_text(self, text):
+        return " ".join(text.split())
+
     def _header_index_map(self, table):
         headers = [
             table.locator("thead tr").last.locator("th").nth(i).inner_text().strip()
             for i in range(table.locator("thead tr").last.locator("th").count())
         ]
         return {name: idx for idx, name in enumerate(headers)}
+
+    def _summary_header_index_map(self, table):
+        first_row = table.locator("thead tr").nth(0).locator("th")
+        second_row = table.locator("thead tr").nth(1).locator("th")
+
+        index_map = {}
+        current_column = 0
+        second_row_index = 0
+
+        for idx in range(first_row.count()):
+            cell = first_row.nth(idx)
+            group_label = self._normalize_header_text(cell.inner_text())
+            colspan = int(cell.get_attribute("colspan") or "1")
+            rowspan = int(cell.get_attribute("rowspan") or "1")
+
+            if rowspan >= 2:
+                index_map[group_label] = current_column
+                current_column += colspan
+                continue
+
+            for _ in range(colspan):
+                sub_label = self._normalize_header_text(
+                    second_row.nth(second_row_index).inner_text()
+                )
+                index_map[f"{group_label} {sub_label}"] = current_column
+                current_column += 1
+                second_row_index += 1
+
+        return index_map
 
     def _create_common_members(self, pilot_username):
         pilot = self.create_test_member(
@@ -139,14 +171,41 @@ class TestLogbookTimeBreakouts(DjangoPlaywrightTestCase):
             "tbody tr", has_text="Schleicher ASK-21"
         ).first
 
-        dual_count = summary_row.locator("td").nth(1).inner_text().strip()
-        dual = summary_row.locator("td").nth(2).inner_text().strip()
-        instruction_count = summary_row.locator("td").nth(5).inner_text().strip()
-        instruction_time = summary_row.locator("td").nth(6).inner_text().strip()
-        pic_summary_count = summary_row.locator("td").nth(7).inner_text().strip()
-        pic_summary = summary_row.locator("td").nth(8).inner_text().strip()
-        total_count = summary_row.locator("td").nth(9).inner_text().strip()
-        total = summary_row.locator("td").nth(10).inner_text().strip()
+        col = self._summary_header_index_map(summary_table)
+
+        dual_count = (
+            summary_row.locator("td").nth(col["Dual Received #"]).inner_text().strip()
+        )
+        dual = (
+            summary_row.locator("td")
+            .nth(col["Dual Received Time"])
+            .inner_text()
+            .strip()
+        )
+        instruction_count = (
+            summary_row.locator("td")
+            .nth(col["Instruction Given #"])
+            .inner_text()
+            .strip()
+        )
+        instruction_time = (
+            summary_row.locator("td")
+            .nth(col["Instruction Given Time"])
+            .inner_text()
+            .strip()
+        )
+        pic_summary_count = (
+            summary_row.locator("td").nth(col["PIC Summary #"]).inner_text().strip()
+        )
+        pic_summary = (
+            summary_row.locator("td").nth(col["PIC Summary Time"]).inner_text().strip()
+        )
+        total_count = (
+            summary_row.locator("td").nth(col["Total Time #"]).inner_text().strip()
+        )
+        total = (
+            summary_row.locator("td").nth(col["Total Time Time"]).inner_text().strip()
+        )
 
         assert dual_count == "2"
         assert dual == "1:15"

--- a/e2e_tests/e2e/test_logbook_time_breakouts.py
+++ b/e2e_tests/e2e/test_logbook_time_breakouts.py
@@ -64,7 +64,9 @@ class TestLogbookTimeBreakouts(DjangoPlaywrightTestCase):
         )
         self.page.wait_for_selector("text=Logbook for")
 
-        logbook_table = self.page.locator("table.table").first
+        logbook_table = self.page.locator(
+            "table.table", has=self.page.locator("thead th:text-is('Date')")
+        ).first
         col = self._header_index_map(logbook_table)
 
         row = logbook_table.locator("tbody tr", has_text="2024-06-01").first
@@ -137,10 +139,20 @@ class TestLogbookTimeBreakouts(DjangoPlaywrightTestCase):
             "tbody tr", has_text="Schleicher ASK-21"
         ).first
 
-        dual = summary_row.locator("td").nth(1).inner_text().strip()
-        pic_summary = summary_row.locator("td").nth(4).inner_text().strip()
-        total = summary_row.locator("td").nth(5).inner_text().strip()
+        dual_count = summary_row.locator("td").nth(1).inner_text().strip()
+        dual = summary_row.locator("td").nth(2).inner_text().strip()
+        instruction_count = summary_row.locator("td").nth(5).inner_text().strip()
+        instruction_time = summary_row.locator("td").nth(6).inner_text().strip()
+        pic_summary_count = summary_row.locator("td").nth(7).inner_text().strip()
+        pic_summary = summary_row.locator("td").nth(8).inner_text().strip()
+        total_count = summary_row.locator("td").nth(9).inner_text().strip()
+        total = summary_row.locator("td").nth(10).inner_text().strip()
 
+        assert dual_count == "2"
         assert dual == "1:15"
+        assert instruction_count == "0"
+        assert instruction_time == "0:00"
+        assert pic_summary_count == "2"
         assert pic_summary == "1:15"
+        assert total_count == "2"
         assert total == "1:15"

--- a/instructors/templates/instructors/logbook.html
+++ b/instructors/templates/instructors/logbook.html
@@ -168,6 +168,37 @@
 {% endif %}
 {% endfor %}
 
+{% if glider_time_summary %}
+<h3 class="mt-4">All-Time Glider Time Summary</h3>
+<p class="text-muted">Comprehensive breakout across all logged years by glider make and model.</p>
+<div class="table-responsive">
+  <table class="table table-sm table-bordered mb-4">
+    <thead class="table-dark">
+      <tr>
+        <th>Make / Model</th>
+        <th class="text-end">Dual Received</th>
+        <th class="text-end">Solo</th>
+        <th class="text-end">Instruction Given</th>
+        <th class="text-end">PIC Summary</th>
+        <th class="text-end">Total Time</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for summary in glider_time_summary %}
+      <tr class="{% if summary.make_model == 'Totals' %}table-secondary fw-bold{% endif %}">
+        <td>{{ summary.make_model }}</td>
+        <td class="text-end">{{ summary.dual_received }}</td>
+        <td class="text-end">{{ summary.solo }}</td>
+        <td class="text-end">{{ summary.instruction_given }}</td>
+        <td class="text-end">{{ summary.pic_summary }}</td>
+        <td class="text-end">{{ summary.total }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
 <!-- Back to Top Button -->
 
 <!-- Back to Top Button -->

--- a/instructors/templates/instructors/logbook.html
+++ b/instructors/templates/instructors/logbook.html
@@ -44,6 +44,54 @@
 </div>
 {% endif %}
 
+{% if glider_time_summary %}
+<h3 class="mt-4">All-Time Glider Time Summary</h3>
+<p class="text-muted">Comprehensive breakout across all logged years by glider make and model.</p>
+<div class="table-responsive">
+  <table class="table table-sm table-bordered mb-4">
+    <thead class="table-dark">
+      <tr>
+        <th rowspan="2">Make / Model</th>
+        <th colspan="2" class="text-center">Dual Received</th>
+        <th colspan="2" class="text-center">Solo</th>
+        <th colspan="2" class="text-center">Instruction Given</th>
+        <th colspan="2" class="text-center">PIC Summary</th>
+        <th colspan="2" class="text-center">Total Time</th>
+      </tr>
+      <tr>
+        <th class="text-end">#</th>
+        <th class="text-end">Time</th>
+        <th class="text-end">#</th>
+        <th class="text-end">Time</th>
+        <th class="text-end">#</th>
+        <th class="text-end">Time</th>
+        <th class="text-end">#</th>
+        <th class="text-end">Time</th>
+        <th class="text-end">#</th>
+        <th class="text-end">Time</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for summary in glider_time_summary %}
+      <tr class="{% if summary.make_model == 'Totals' %}table-secondary fw-bold{% endif %}">
+        <td>{{ summary.make_model }}</td>
+        <td class="text-end">{{ summary.dual_received_count }}</td>
+        <td class="text-end">{{ summary.dual_received }}</td>
+        <td class="text-end">{{ summary.solo_count }}</td>
+        <td class="text-end">{{ summary.solo }}</td>
+        <td class="text-end">{{ summary.instruction_given_count }}</td>
+        <td class="text-end">{{ summary.instruction_given }}</td>
+        <td class="text-end">{{ summary.pic_summary_count }}</td>
+        <td class="text-end">{{ summary.pic_summary }}</td>
+        <td class="text-end">{{ summary.total_count }}</td>
+        <td class="text-end">{{ summary.total }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
 
 {% for page in pages %}
 
@@ -167,37 +215,6 @@
 <div class="page-break"></div>
 {% endif %}
 {% endfor %}
-
-{% if glider_time_summary %}
-<h3 class="mt-4">All-Time Glider Time Summary</h3>
-<p class="text-muted">Comprehensive breakout across all logged years by glider make and model.</p>
-<div class="table-responsive">
-  <table class="table table-sm table-bordered mb-4">
-    <thead class="table-dark">
-      <tr>
-        <th>Make / Model</th>
-        <th class="text-end">Dual Received</th>
-        <th class="text-end">Solo</th>
-        <th class="text-end">Instruction Given</th>
-        <th class="text-end">PIC Summary</th>
-        <th class="text-end">Total Time</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for summary in glider_time_summary %}
-      <tr class="{% if summary.make_model == 'Totals' %}table-secondary fw-bold{% endif %}">
-        <td>{{ summary.make_model }}</td>
-        <td class="text-end">{{ summary.dual_received }}</td>
-        <td class="text-end">{{ summary.solo }}</td>
-        <td class="text-end">{{ summary.instruction_given }}</td>
-        <td class="text-end">{{ summary.pic_summary }}</td>
-        <td class="text-end">{{ summary.total }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
-{% endif %}
 
 <!-- Back to Top Button -->
 

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -46,6 +46,154 @@ def test_member_can_view_own_logbook(client):
 
 
 @pytest.mark.django_db
+def test_rated_pilot_logs_dual_and_pic_for_instructor_flight(client):
+    _ensure_full_member_status()
+    pilot = _make_member("logbook_rated_dual", glider_rating="rated")
+    pilot.private_glider_checkride_date = date(2024, 1, 1)
+    pilot.save(update_fields=["private_glider_checkride_date"])
+
+    instructor = _make_member(
+        "logbook_rated_dual_instructor", instructor=True, glider_rating="rated"
+    )
+
+    airfield = Airfield.objects.create(name="Front Royal", identifier="KFRR")
+    glider = Glider.objects.create(
+        n_number="N762A",
+        make="Schleicher",
+        model="ASK-21",
+        club_owned=True,
+        is_active=True,
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date(2024, 6, 1),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        instructor=instructor,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(10, 0),
+        landing_time=time(10, 25),
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook") + "?show_all_years=1")
+
+    assert response.status_code == 200
+    row = response.context["pages"][0]["rows"][0]
+    assert row["dual_received_m"] == 25
+    assert row["pic_m"] == 25
+
+
+@pytest.mark.django_db
+def test_pre_rating_instructor_flight_logs_dual_not_pic(client):
+    _ensure_full_member_status()
+    pilot = _make_member("logbook_prerating_dual", glider_rating="student")
+    pilot.private_glider_checkride_date = date(2024, 7, 1)
+    pilot.save(update_fields=["private_glider_checkride_date"])
+
+    instructor = _make_member(
+        "logbook_prerating_instructor", instructor=True, glider_rating="rated"
+    )
+
+    airfield = Airfield.objects.create(name="Winchester", identifier="KWGO")
+    glider = Glider.objects.create(
+        n_number="N762B",
+        make="Schweizer",
+        model="2-33",
+        club_owned=True,
+        is_active=True,
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date(2024, 6, 1),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        instructor=instructor,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(11, 0),
+        landing_time=time(11, 30),
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook") + "?show_all_years=1")
+
+    assert response.status_code == 200
+    row = response.context["pages"][0]["rows"][0]
+    assert row["dual_received_m"] == 30
+    assert row["pic_m"] == 0
+
+
+@pytest.mark.django_db
+def test_logbook_glider_summary_is_all_time_even_on_default_view(client):
+    _ensure_full_member_status()
+    pilot = _make_member("logbook_all_time_summary")
+    instructor = _make_member(
+        "logbook_all_time_summary_instructor", instructor=True, glider_rating="rated"
+    )
+
+    airfield = Airfield.objects.create(name="Summit Point", identifier="KSUM")
+    glider = Glider.objects.create(
+        n_number="N762C",
+        make="Schleicher",
+        model="ASK-21",
+        club_owned=True,
+        is_active=True,
+    )
+
+    old_logsheet = Logsheet.objects.create(
+        log_date=date.today() - timedelta(days=365 * 5),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    Flight.objects.create(
+        logsheet=old_logsheet,
+        pilot=pilot,
+        instructor=instructor,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(9, 0),
+        landing_time=time(9, 30),
+    )
+
+    recent_logsheet = Logsheet.objects.create(
+        log_date=date.today() - timedelta(days=10),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    Flight.objects.create(
+        logsheet=recent_logsheet,
+        pilot=pilot,
+        instructor=instructor,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(10, 0),
+        landing_time=time(10, 45),
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook"))
+
+    assert response.status_code == 200
+
+    pages = response.context["pages"]
+    total_rows = sum(len(page["rows"]) for page in pages)
+    assert total_rows == 1
+
+    summary_rows = response.context["glider_time_summary"]
+    row = next(r for r in summary_rows if r["make_model"] == "Schleicher ASK-21")
+    assert row["total"] == "1:15"
+    assert row["dual_received"] == "1:15"
+
+
+@pytest.mark.django_db
 def test_instructor_can_view_student_logbook(client):
     _ensure_full_member_status()
     instructor = _make_member("logbook_instructor", instructor=True)

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import re
 from datetime import date, time, timedelta
 
@@ -390,6 +392,52 @@ def test_non_instructor_cannot_export_another_members_logbook_csv(client):
     )
 
     assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_csv_export_uses_shared_dual_and_pic_classification(client):
+    _ensure_full_member_status()
+    pilot = _make_member("logbook_csv_rated_dual", glider_rating="rated")
+    pilot.private_glider_checkride_date = date(2020, 1, 1)
+    pilot.save(update_fields=["private_glider_checkride_date"])
+
+    instructor = _make_member(
+        "logbook_csv_rated_dual_instructor", instructor=True, glider_rating="rated"
+    )
+    airfield = Airfield.objects.create(name="CSV Field", identifier="KCSV")
+    glider = Glider.objects.create(
+        n_number="N762CSV",
+        make="Schleicher",
+        model="ASK-21",
+        club_owned=True,
+        is_active=True,
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date(2024, 6, 1),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        instructor=instructor,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(10, 0),
+        landing_time=time(10, 25),
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook_export_csv"))
+
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/csv")
+
+    rows = list(csv.DictReader(io.StringIO(response.content.decode())))
+    assert len(rows) == 1
+    assert rows[0]["Dual"] == "0:25"
+    assert rows[0]["PIC"] == "0:25"
+    assert rows[0]["Total"] == "0:25"
 
 
 @pytest.mark.django_db

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -194,6 +194,50 @@ def test_logbook_glider_summary_is_all_time_even_on_default_view(client):
 
 
 @pytest.mark.django_db
+def test_guest_instructor_flight_counts_as_dual_and_rated_pic(client):
+    _ensure_full_member_status()
+    pilot = _make_member("logbook_guest_instructor", glider_rating="rated")
+    pilot.private_glider_checkride_date = date(2020, 1, 1)
+    pilot.save(update_fields=["private_glider_checkride_date"])
+
+    airfield = Airfield.objects.create(name="Guest Field", identifier="KGST")
+    glider = Glider.objects.create(
+        n_number="N762G",
+        make="DG",
+        model="DG-1000",
+        club_owned=True,
+        is_active=True,
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date(2024, 5, 1),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(9, 0),
+        landing_time=time(9, 20),
+        guest_instructor_name="Guest CFI",
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook") + "?show_all_years=1")
+
+    assert response.status_code == 200
+    row = response.context["pages"][0]["rows"][0]
+    assert row["dual_received_m"] == 20
+    assert row["pic_m"] == 20
+
+    summary_rows = response.context["glider_time_summary"]
+    summary_row = next(r for r in summary_rows if r["make_model"] == "DG DG-1000")
+    assert summary_row["dual_received"] == "0:20"
+    assert summary_row["pic_summary"] == "0:20"
+
+
+@pytest.mark.django_db
 def test_instructor_can_view_student_logbook(client):
     _ensure_full_member_status()
     instructor = _make_member("logbook_instructor", instructor=True)

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -240,6 +240,47 @@ def test_guest_instructor_flight_counts_as_dual_and_rated_pic(client):
 
 
 @pytest.mark.django_db
+def test_whitespace_guest_name_falls_back_to_legacy_instructor_name(client):
+    _ensure_full_member_status()
+    pilot = _make_member("logbook_legacy_instructor_fallback", glider_rating="rated")
+    pilot.private_glider_checkride_date = date(2020, 1, 1)
+    pilot.save(update_fields=["private_glider_checkride_date"])
+
+    airfield = Airfield.objects.create(name="Legacy Field", identifier="KLGY")
+    glider = Glider.objects.create(
+        n_number="N762L",
+        make="ASK",
+        model="21",
+        club_owned=True,
+        is_active=True,
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date(2024, 5, 2),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(9, 0),
+        landing_time=time(9, 20),
+        guest_instructor_name="   ",
+        legacy_instructor_name="Legacy CFI",
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook") + "?show_all_years=1")
+
+    assert response.status_code == 200
+    row = response.context["pages"][0]["rows"][0]
+    assert row["dual_received_m"] == 20
+    assert "instruction received" in row["comments"]
+    assert "Legacy CFI" in row["comments"]
+
+
+@pytest.mark.django_db
 def test_private_flights_are_included_in_all_time_summary(client):
     _ensure_full_member_status()
     pilot = _make_member("logbook_private_summary", glider_rating="rated")

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -230,11 +230,44 @@ def test_guest_instructor_flight_counts_as_dual_and_rated_pic(client):
     row = response.context["pages"][0]["rows"][0]
     assert row["dual_received_m"] == 20
     assert row["pic_m"] == 20
+    assert "instruction received" in row["comments"]
+    assert "Guest CFI" in row["comments"]
 
     summary_rows = response.context["glider_time_summary"]
     summary_row = next(r for r in summary_rows if r["make_model"] == "DG DG-1000")
     assert summary_row["dual_received"] == "0:20"
     assert summary_row["pic_summary"] == "0:20"
+
+
+@pytest.mark.django_db
+def test_private_flights_are_included_in_all_time_summary(client):
+    _ensure_full_member_status()
+    pilot = _make_member("logbook_private_summary", glider_rating="rated")
+    pilot.private_glider_checkride_date = date(2020, 1, 1)
+    pilot.save(update_fields=["private_glider_checkride_date"])
+
+    airfield = Airfield.objects.create(name="Private Field", identifier="KPRV")
+    logsheet = Logsheet.objects.create(
+        log_date=date(2024, 8, 1),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        launch_method="tow",
+        launch_time=time(8, 0),
+        landing_time=time(8, 25),
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook") + "?show_all_years=1")
+
+    assert response.status_code == 200
+    summary_rows = response.context["glider_time_summary"]
+    private_row = next(r for r in summary_rows if r["make_model"] == "Private")
+    assert private_row["solo"] == "0:25"
+    assert private_row["total"] == "0:25"
 
 
 @pytest.mark.django_db

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -1,10 +1,11 @@
 # instructors/utils.py
 
 import logging
+from collections import defaultdict
 from datetime import timedelta
 
 from django.conf import settings
-from django.db.models import Count, F, Max, Sum, Value
+from django.db.models import Count, F, Max, Q, Sum, Value
 from django.db.models.fields import DurationField
 from django.db.models.functions import Coalesce
 from django.template.loader import render_to_string
@@ -135,6 +136,120 @@ def get_flight_summary_for_member(member):
                 row[f"{prefix}_time"] = ""
 
     return flights_summary
+
+
+def get_logbook_glider_time_summary(member):
+    """Build an all-time, per-make/model glider time summary for logbook display."""
+
+    def format_minutes(minutes):
+        hours, mins = divmod(int(minutes), 60)
+        return f"{hours}:{mins:02d}"
+
+    rating_date = getattr(member, "private_glider_checkride_date", None)
+
+    flights = Flight.objects.filter(
+        (Q(pilot=member) | Q(instructor=member)),
+        glider__isnull=False,
+    ).select_related("glider", "logsheet")
+
+    summary_by_glider = defaultdict(
+        lambda: {
+            "dual_received_m": 0,
+            "solo_m": 0,
+            "instruction_given_m": 0,
+            "rated_dual_for_pic_m": 0,
+            "total_m": 0,
+        }
+    )
+
+    for flight in flights:
+        flight_date = flight.logsheet.log_date if flight.logsheet else None
+        duration_m = (
+            int(flight.duration.total_seconds() // 60) if flight.duration else 0
+        )
+
+        make = (flight.glider.make or "").strip()
+        model = (flight.glider.model or "").strip()
+        make_model = " ".join(part for part in (make, model) if part).strip()
+        if not make_model:
+            make_model = flight.glider.n_number or "Unknown Glider"
+
+        bucket = summary_by_glider[make_model]
+
+        is_pilot = flight.pilot_id == member.id
+        is_instructor = flight.instructor_id == member.id
+
+        if is_pilot and flight.instructor_id:
+            bucket["dual_received_m"] += duration_m
+            if rating_date and flight_date and flight_date >= rating_date:
+                bucket["rated_dual_for_pic_m"] += duration_m
+
+        if (
+            is_pilot
+            and not flight.instructor_id
+            and not flight.passenger_id
+            and not flight.passenger_name
+        ):
+            bucket["solo_m"] += duration_m
+
+        if is_instructor:
+            bucket["instruction_given_m"] += duration_m
+
+        if is_pilot or is_instructor:
+            bucket["total_m"] += duration_m
+
+    rows = []
+    totals = {
+        "make_model": "Totals",
+        "dual_received_m": 0,
+        "solo_m": 0,
+        "instruction_given_m": 0,
+        "pic_summary_m": 0,
+        "total_m": 0,
+    }
+
+    for make_model in sorted(summary_by_glider):
+        bucket = summary_by_glider[make_model]
+        pic_summary_m = (
+            bucket["solo_m"]
+            + bucket["instruction_given_m"]
+            + bucket["rated_dual_for_pic_m"]
+        )
+
+        row = {
+            "make_model": make_model,
+            "dual_received_m": bucket["dual_received_m"],
+            "solo_m": bucket["solo_m"],
+            "instruction_given_m": bucket["instruction_given_m"],
+            "pic_summary_m": pic_summary_m,
+            "total_m": bucket["total_m"],
+            "dual_received": format_minutes(bucket["dual_received_m"]),
+            "solo": format_minutes(bucket["solo_m"]),
+            "instruction_given": format_minutes(bucket["instruction_given_m"]),
+            "pic_summary": format_minutes(pic_summary_m),
+            "total": format_minutes(bucket["total_m"]),
+        }
+        rows.append(row)
+
+        totals["dual_received_m"] += row["dual_received_m"]
+        totals["solo_m"] += row["solo_m"]
+        totals["instruction_given_m"] += row["instruction_given_m"]
+        totals["pic_summary_m"] += row["pic_summary_m"]
+        totals["total_m"] += row["total_m"]
+
+    if rows:
+        totals.update(
+            {
+                "dual_received": format_minutes(totals["dual_received_m"]),
+                "solo": format_minutes(totals["solo_m"]),
+                "instruction_given": format_minutes(totals["instruction_given_m"]),
+                "pic_summary": format_minutes(totals["pic_summary_m"]),
+                "total": format_minutes(totals["total_m"]),
+            }
+        )
+        rows.append(totals)
+
+    return rows
 
 
 ####################################################

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -210,7 +210,7 @@ def get_logbook_glider_time_summary(member):
         Q(pilot=member)
         & ~instructor_present_filter
         & Q(passenger__isnull=True)
-        & (Q(passenger_name__isnull=True) | Q(passenger_name=""))
+        & Q(passenger_name="")
     )
     instruction_given_filter = Q(instructor=member)
     total_filter = Q(pilot=member) | Q(instructor=member)

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -142,6 +142,15 @@ def is_logbook_rated_dual_flight(flight_date, rating_date):
     return bool(rating_date and flight_date and flight_date >= rating_date)
 
 
+def _has_instructor_context(flight):
+    """Return True when a flight includes any instructor source (FK or imported name)."""
+    return bool(
+        flight.instructor_id
+        or (flight.guest_instructor_name and flight.guest_instructor_name.strip())
+        or (flight.legacy_instructor_name and flight.legacy_instructor_name.strip())
+    )
+
+
 def classify_logbook_flight_minutes(flight, member_id, rating_date):
     """Classify one flight's minutes into logbook buckets for a member."""
     flight_date = flight.logsheet.log_date if flight.logsheet else None
@@ -157,7 +166,7 @@ def classify_logbook_flight_minutes(flight, member_id, rating_date):
     inst_m = 0
 
     if is_pilot:
-        if flight.instructor_id:
+        if _has_instructor_context(flight):
             dual_m += duration_m
             if is_logbook_rated_dual_flight(flight_date, rating_date):
                 pic_m += duration_m
@@ -191,9 +200,17 @@ def get_logbook_glider_time_summary(member):
     rating_date = getattr(member, "private_glider_checkride_date", None)
 
     empty_duration = Value(timedelta(0), output_field=DurationField())
-    dual_filter = Q(pilot=member, instructor__isnull=False)
-    solo_filter = Q(pilot=member, instructor__isnull=True, passenger__isnull=True) & (
-        Q(passenger_name__isnull=True) | Q(passenger_name="")
+    instructor_present_filter = (
+        Q(instructor__isnull=False)
+        | (Q(guest_instructor_name__isnull=False) & ~Q(guest_instructor_name=""))
+        | (Q(legacy_instructor_name__isnull=False) & ~Q(legacy_instructor_name=""))
+    )
+    dual_filter = Q(pilot=member) & instructor_present_filter
+    solo_filter = (
+        Q(pilot=member)
+        & ~instructor_present_filter
+        & Q(passenger__isnull=True)
+        & (Q(passenger_name__isnull=True) | Q(passenger_name=""))
     )
     instruction_given_filter = Q(instructor=member)
     total_filter = Q(pilot=member) | Q(instructor=member)
@@ -203,7 +220,7 @@ def get_logbook_glider_time_summary(member):
 
     grouped = (
         Flight.objects.filter(total_filter, glider__isnull=False)
-        .values("glider__make", "glider__model", "glider__n_number")
+        .values("glider__make", "glider__model")
         .annotate(
             dual_received_duration=Coalesce(
                 Sum("duration", filter=dual_filter),
@@ -231,6 +248,7 @@ def get_logbook_glider_time_summary(member):
                 output_field=DurationField(),
             ),
         )
+        .order_by("glider__make", "glider__model")
     )
 
     rows = []
@@ -248,7 +266,7 @@ def get_logbook_glider_time_summary(member):
         model = (grouped_row.get("glider__model") or "").strip()
         make_model = " ".join(part for part in (make, model) if part).strip()
         if not make_model:
-            make_model = grouped_row.get("glider__n_number") or "Unknown Glider"
+            make_model = "Unknown Glider"
 
         dual_received_m = int(
             grouped_row["dual_received_duration"].total_seconds() // 60

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -1,7 +1,6 @@
 # instructors/utils.py
 
 import logging
-from collections import defaultdict
 from datetime import timedelta
 
 from django.conf import settings
@@ -138,6 +137,50 @@ def get_flight_summary_for_member(member):
     return flights_summary
 
 
+def is_logbook_rated_dual_flight(flight_date, rating_date):
+    """Return True when an instructor flight should also count toward PIC as rated dual."""
+    return bool(rating_date and flight_date and flight_date >= rating_date)
+
+
+def classify_logbook_flight_minutes(flight, member_id, rating_date):
+    """Classify one flight's minutes into logbook buckets for a member."""
+    flight_date = flight.logsheet.log_date if flight.logsheet else None
+    duration_m = int(flight.duration.total_seconds() // 60) if flight.duration else 0
+
+    is_pilot = flight.pilot_id == member_id
+    is_instructor = flight.instructor_id == member_id
+    is_passenger = flight.passenger_id == member_id
+
+    dual_m = 0
+    solo_m = 0
+    pic_m = 0
+    inst_m = 0
+
+    if is_pilot:
+        if flight.instructor_id:
+            dual_m += duration_m
+            if is_logbook_rated_dual_flight(flight_date, rating_date):
+                pic_m += duration_m
+        else:
+            if not flight.passenger_id and not flight.passenger_name:
+                solo_m += duration_m
+            pic_m += duration_m
+    elif is_instructor:
+        inst_m += duration_m
+        pic_m += duration_m
+
+    return {
+        "is_pilot": is_pilot,
+        "is_instructor": is_instructor,
+        "is_passenger": is_passenger,
+        "duration_m": duration_m,
+        "dual_m": dual_m,
+        "solo_m": solo_m,
+        "pic_m": pic_m,
+        "inst_m": inst_m,
+    }
+
+
 def get_logbook_glider_time_summary(member):
     """Build an all-time, per-make/model glider time summary for logbook display."""
 
@@ -147,56 +190,48 @@ def get_logbook_glider_time_summary(member):
 
     rating_date = getattr(member, "private_glider_checkride_date", None)
 
-    flights = Flight.objects.filter(
-        (Q(pilot=member) | Q(instructor=member)),
-        glider__isnull=False,
-    ).select_related("glider", "logsheet")
-
-    summary_by_glider = defaultdict(
-        lambda: {
-            "dual_received_m": 0,
-            "solo_m": 0,
-            "instruction_given_m": 0,
-            "rated_dual_for_pic_m": 0,
-            "total_m": 0,
-        }
+    empty_duration = Value(timedelta(0), output_field=DurationField())
+    dual_filter = Q(pilot=member, instructor__isnull=False)
+    solo_filter = Q(pilot=member, instructor__isnull=True, passenger__isnull=True) & (
+        Q(passenger_name__isnull=True) | Q(passenger_name="")
     )
+    instruction_given_filter = Q(instructor=member)
+    total_filter = Q(pilot=member) | Q(instructor=member)
+    rated_dual_filter = Q(pk__in=[])
+    if rating_date:
+        rated_dual_filter = dual_filter & Q(logsheet__log_date__gte=rating_date)
 
-    for flight in flights:
-        flight_date = flight.logsheet.log_date if flight.logsheet else None
-        duration_m = (
-            int(flight.duration.total_seconds() // 60) if flight.duration else 0
+    grouped = (
+        Flight.objects.filter(total_filter, glider__isnull=False)
+        .values("glider__make", "glider__model", "glider__n_number")
+        .annotate(
+            dual_received_duration=Coalesce(
+                Sum("duration", filter=dual_filter),
+                empty_duration,
+                output_field=DurationField(),
+            ),
+            solo_duration=Coalesce(
+                Sum("duration", filter=solo_filter),
+                empty_duration,
+                output_field=DurationField(),
+            ),
+            instruction_given_duration=Coalesce(
+                Sum("duration", filter=instruction_given_filter),
+                empty_duration,
+                output_field=DurationField(),
+            ),
+            rated_dual_pic_duration=Coalesce(
+                Sum("duration", filter=rated_dual_filter),
+                empty_duration,
+                output_field=DurationField(),
+            ),
+            total_duration=Coalesce(
+                Sum("duration", filter=total_filter),
+                empty_duration,
+                output_field=DurationField(),
+            ),
         )
-
-        make = (flight.glider.make or "").strip()
-        model = (flight.glider.model or "").strip()
-        make_model = " ".join(part for part in (make, model) if part).strip()
-        if not make_model:
-            make_model = flight.glider.n_number or "Unknown Glider"
-
-        bucket = summary_by_glider[make_model]
-
-        is_pilot = flight.pilot_id == member.id
-        is_instructor = flight.instructor_id == member.id
-
-        if is_pilot and flight.instructor_id:
-            bucket["dual_received_m"] += duration_m
-            if rating_date and flight_date and flight_date >= rating_date:
-                bucket["rated_dual_for_pic_m"] += duration_m
-
-        if (
-            is_pilot
-            and not flight.instructor_id
-            and not flight.passenger_id
-            and not flight.passenger_name
-        ):
-            bucket["solo_m"] += duration_m
-
-        if is_instructor:
-            bucket["instruction_given_m"] += duration_m
-
-        if is_pilot or is_instructor:
-            bucket["total_m"] += duration_m
+    )
 
     rows = []
     totals = {
@@ -208,26 +243,39 @@ def get_logbook_glider_time_summary(member):
         "total_m": 0,
     }
 
-    for make_model in sorted(summary_by_glider):
-        bucket = summary_by_glider[make_model]
-        pic_summary_m = (
-            bucket["solo_m"]
-            + bucket["instruction_given_m"]
-            + bucket["rated_dual_for_pic_m"]
+    for grouped_row in grouped:
+        make = (grouped_row.get("glider__make") or "").strip()
+        model = (grouped_row.get("glider__model") or "").strip()
+        make_model = " ".join(part for part in (make, model) if part).strip()
+        if not make_model:
+            make_model = grouped_row.get("glider__n_number") or "Unknown Glider"
+
+        dual_received_m = int(
+            grouped_row["dual_received_duration"].total_seconds() // 60
         )
+        solo_m = int(grouped_row["solo_duration"].total_seconds() // 60)
+        instruction_given_m = int(
+            grouped_row["instruction_given_duration"].total_seconds() // 60
+        )
+        rated_dual_for_pic_m = int(
+            grouped_row["rated_dual_pic_duration"].total_seconds() // 60
+        )
+        total_m = int(grouped_row["total_duration"].total_seconds() // 60)
+
+        pic_summary_m = solo_m + instruction_given_m + rated_dual_for_pic_m
 
         row = {
             "make_model": make_model,
-            "dual_received_m": bucket["dual_received_m"],
-            "solo_m": bucket["solo_m"],
-            "instruction_given_m": bucket["instruction_given_m"],
+            "dual_received_m": dual_received_m,
+            "solo_m": solo_m,
+            "instruction_given_m": instruction_given_m,
             "pic_summary_m": pic_summary_m,
-            "total_m": bucket["total_m"],
-            "dual_received": format_minutes(bucket["dual_received_m"]),
-            "solo": format_minutes(bucket["solo_m"]),
-            "instruction_given": format_minutes(bucket["instruction_given_m"]),
+            "total_m": total_m,
+            "dual_received": format_minutes(dual_received_m),
+            "solo": format_minutes(solo_m),
+            "instruction_given": format_minutes(instruction_given_m),
             "pic_summary": format_minutes(pic_summary_m),
-            "total": format_minutes(bucket["total_m"]),
+            "total": format_minutes(total_m),
         }
         rows.append(row)
 

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -222,26 +222,31 @@ def get_logbook_glider_time_summary(member):
         Flight.objects.filter(total_filter)
         .values("glider__make", "glider__model")
         .annotate(
+            dual_received_count=Count("id", filter=dual_filter),
             dual_received_duration=Coalesce(
                 Sum("duration", filter=dual_filter),
                 empty_duration,
                 output_field=DurationField(),
             ),
+            solo_count=Count("id", filter=solo_filter),
             solo_duration=Coalesce(
                 Sum("duration", filter=solo_filter),
                 empty_duration,
                 output_field=DurationField(),
             ),
+            instruction_given_count=Count("id", filter=instruction_given_filter),
             instruction_given_duration=Coalesce(
                 Sum("duration", filter=instruction_given_filter),
                 empty_duration,
                 output_field=DurationField(),
             ),
+            rated_dual_pic_count=Count("id", filter=rated_dual_filter),
             rated_dual_pic_duration=Coalesce(
                 Sum("duration", filter=rated_dual_filter),
                 empty_duration,
                 output_field=DurationField(),
             ),
+            total_count=Count("id", filter=total_filter),
             total_duration=Coalesce(
                 Sum("duration", filter=total_filter),
                 empty_duration,
@@ -254,10 +259,15 @@ def get_logbook_glider_time_summary(member):
     rows = []
     totals = {
         "make_model": "Totals",
+        "dual_received_count": 0,
         "dual_received_m": 0,
+        "solo_count": 0,
         "solo_m": 0,
+        "instruction_given_count": 0,
         "instruction_given_m": 0,
+        "pic_summary_count": 0,
         "pic_summary_m": 0,
+        "total_count": 0,
         "total_m": 0,
     }
 
@@ -268,26 +278,39 @@ def get_logbook_glider_time_summary(member):
         if not make_model:
             make_model = "Private"
 
+        dual_received_count = grouped_row["dual_received_count"]
         dual_received_m = int(
             grouped_row["dual_received_duration"].total_seconds() // 60
         )
+        solo_count = grouped_row["solo_count"]
         solo_m = int(grouped_row["solo_duration"].total_seconds() // 60)
+        instruction_given_count = grouped_row["instruction_given_count"]
         instruction_given_m = int(
             grouped_row["instruction_given_duration"].total_seconds() // 60
         )
+        rated_dual_for_pic_count = grouped_row["rated_dual_pic_count"]
         rated_dual_for_pic_m = int(
             grouped_row["rated_dual_pic_duration"].total_seconds() // 60
         )
+        total_count = grouped_row["total_count"]
         total_m = int(grouped_row["total_duration"].total_seconds() // 60)
 
+        pic_summary_count = (
+            solo_count + instruction_given_count + rated_dual_for_pic_count
+        )
         pic_summary_m = solo_m + instruction_given_m + rated_dual_for_pic_m
 
         row = {
             "make_model": make_model,
+            "dual_received_count": dual_received_count,
             "dual_received_m": dual_received_m,
+            "solo_count": solo_count,
             "solo_m": solo_m,
+            "instruction_given_count": instruction_given_count,
             "instruction_given_m": instruction_given_m,
+            "pic_summary_count": pic_summary_count,
             "pic_summary_m": pic_summary_m,
+            "total_count": total_count,
             "total_m": total_m,
             "dual_received": format_minutes(dual_received_m),
             "solo": format_minutes(solo_m),
@@ -297,10 +320,15 @@ def get_logbook_glider_time_summary(member):
         }
         rows.append(row)
 
+        totals["dual_received_count"] += row["dual_received_count"]
         totals["dual_received_m"] += row["dual_received_m"]
+        totals["solo_count"] += row["solo_count"]
         totals["solo_m"] += row["solo_m"]
+        totals["instruction_given_count"] += row["instruction_given_count"]
         totals["instruction_given_m"] += row["instruction_given_m"]
+        totals["pic_summary_count"] += row["pic_summary_count"]
         totals["pic_summary_m"] += row["pic_summary_m"]
+        totals["total_count"] += row["total_count"]
         totals["total_m"] += row["total_m"]
 
     if rows:

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -246,9 +246,9 @@ def get_logbook_glider_time_summary(member):
                 empty_duration,
                 output_field=DurationField(),
             ),
-            total_count=Count("id", filter=total_filter),
+            total_count=Count("id"),
             total_duration=Coalesce(
-                Sum("duration", filter=total_filter),
+                Sum("duration"),
                 empty_duration,
                 output_field=DurationField(),
             ),

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -142,7 +142,7 @@ def is_logbook_rated_dual_flight(flight_date, rating_date):
     return bool(rating_date and flight_date and flight_date >= rating_date)
 
 
-def _has_instructor_context(flight):
+def has_logbook_instructor_context(flight):
     """Return True when a flight includes any instructor source (FK or imported name)."""
     return bool(
         flight.instructor_id
@@ -166,7 +166,7 @@ def classify_logbook_flight_minutes(flight, member_id, rating_date):
     inst_m = 0
 
     if is_pilot:
-        if _has_instructor_context(flight):
+        if has_logbook_instructor_context(flight):
             dual_m += duration_m
             if is_logbook_rated_dual_flight(flight_date, rating_date):
                 pic_m += duration_m
@@ -219,7 +219,7 @@ def get_logbook_glider_time_summary(member):
         rated_dual_filter = dual_filter & Q(logsheet__log_date__gte=rating_date)
 
     grouped = (
-        Flight.objects.filter(total_filter, glider__isnull=False)
+        Flight.objects.filter(total_filter)
         .values("glider__make", "glider__model")
         .annotate(
             dual_received_duration=Coalesce(
@@ -266,7 +266,7 @@ def get_logbook_glider_time_summary(member):
         model = (grouped_row.get("glider__model") or "").strip()
         make_model = " ".join(part for part in (make, model) if part).strip()
         if not make_model:
-            make_model = "Unknown Glider"
+            make_model = "Private"
 
         dual_received_m = int(
             grouped_row["dual_received_duration"].total_seconds() // 60

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -1776,8 +1776,12 @@ def member_logbook(request, member_id=None):
                         )
                         report_id = rpt.id
                     else:
+                        guest_instructor_name = (f.guest_instructor_name or "").strip()
+                        legacy_instructor_name = (
+                            f.legacy_instructor_name or ""
+                        ).strip()
                         fallback_instructor_name = (
-                            f.guest_instructor_name or f.legacy_instructor_name or ""
+                            guest_instructor_name or legacy_instructor_name
                         )
                         if fallback_instructor_name:
                             comments = (

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -52,6 +52,7 @@ from instructors.models import (
     TrainingPhase,
 )
 from instructors.utils import (
+    classify_logbook_flight_minutes,
     get_flight_summary_for_member,
     get_logbook_glider_time_summary,
     send_instruction_report_email,
@@ -1730,10 +1731,15 @@ def member_logbook(request, member_id=None):
             flight_id = f.id
             date = ev["date"]
 
-            # Roles
-            is_pilot = f.pilot_id == member.id
-            is_instructor = f.instructor_id == member.id
-            is_passenger = f.passenger_id == member.id
+            classification = classify_logbook_flight_minutes(
+                f,
+                member.id,
+                rating_date,
+            )
+
+            is_pilot = classification["is_pilot"]
+            is_instructor = classification["is_instructor"]
+            is_passenger = classification["is_passenger"]
 
             # Always initialize report_id
             report_id = None
@@ -1746,18 +1752,16 @@ def member_logbook(request, member_id=None):
                 display_flight_no = ""
 
             # Raw minutes
-            dur_m = int(f.duration.total_seconds() // 60) if f.duration else 0
-            dual_m = solo_m = pic_m = inst_m = 0
+            dur_m = classification["duration_m"]
+            dual_m = classification["dual_m"]
+            solo_m = classification["solo_m"]
+            pic_m = classification["pic_m"]
+            inst_m = classification["inst_m"]
             comments = ""
 
             # 5b) Pilot logic: instruction received vs lesson codes
             if is_pilot:
                 if f.instructor:
-                    # Received dual / PIC
-                    dual_m += dur_m
-                    if rating_date and date >= rating_date:
-                        pic_m += dur_m
-
                     # Look up the instruction report from pre-fetched dict (O(1) lookup)
                     report_data = report_lookup.get((f.instructor_id, date))
 
@@ -1772,10 +1776,6 @@ def member_logbook(request, member_id=None):
                         comments = "instruction received"
                         report_id = None
                 else:
-                    # Solo flight (only if no passenger)
-                    if not f.passenger and not f.passenger_name:
-                        solo_m += dur_m
-                    pic_m += dur_m
                     if f.passenger:
                         comments = f"{f.passenger.full_display_name}"
                     elif f.passenger_name:
@@ -1787,10 +1787,8 @@ def member_logbook(request, member_id=None):
                     f"{f.pilot.full_display_name} (<i>{member.full_display_name}</i>)"
                 )
 
-            # 7) Instructor logic: inst_given + PIC
+            # 7) Instructor logic: classification already includes inst_given + PIC
             elif is_instructor:
-                inst_m += dur_m
-                pic_m += dur_m
                 student = f.pilot or f.passenger
                 if student:
                     comments = student.full_display_name

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -2498,6 +2498,17 @@ def export_member_logbook_csv(request, member_id=None):
     )
 
     rating_date = getattr(member, "private_glider_checkride_date", None)
+    instruction_reports = (
+        InstructionReport.objects.filter(student=member)
+        .select_related("instructor")
+        .prefetch_related("lesson_scores__lesson")
+    )
+    report_lookup = {}
+    for rpt in instruction_reports:
+        report_lookup[(rpt.instructor_id, rpt.report_date)] = [
+            ls.lesson.code for ls in rpt.lesson_scores.all()
+        ]
+
     events = []
     for f in flights:
         events.append(
@@ -2536,21 +2547,11 @@ def export_member_logbook_csv(request, member_id=None):
             comments = ""
             # Construct comments as in logbook.html: lesson codes for instruction, otherwise blank
             if is_pilot and has_logbook_instructor_context(f):
-                rpt = None
+                codes = []
                 if f.instructor_id:
-                    rpt = (
-                        InstructionReport.objects.filter(
-                            student=member,
-                            instructor=f.instructor,
-                            report_date=date,
-                        )
-                        .prefetch_related("lesson_scores__lesson")
-                        .first()
-                    )
-                if rpt:
-                    codes = [ls.lesson.code for ls in rpt.lesson_scores.all()]
-                    if codes:
-                        comments = ", ".join(codes)
+                    codes = report_lookup.get((f.instructor_id, date), [])
+                if codes:
+                    comments = ", ".join(codes)
                 else:
                     fallback_instructor_name = (
                         f.guest_instructor_name or ""

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -2518,23 +2518,48 @@ def export_member_logbook_csv(request, member_id=None):
         if ev["type"] == "flight":
             f = ev["obj"]
             date = ev["date"]
-            is_pilot = f.pilot_id == member.id
-            is_instructor = f.instructor_id == member.id
-            is_passenger = f.passenger_id == member.id
+            classification = classify_logbook_flight_minutes(
+                f,
+                member.id,
+                rating_date,
+            )
+            is_pilot = classification["is_pilot"]
+            is_instructor = classification["is_instructor"]
+            is_passenger = classification["is_passenger"]
             if is_pilot or is_instructor:
                 flight_no += 1
-            dur_m = int(f.duration.total_seconds() // 60) if f.duration else 0
-            dual_m = solo_m = pic_m = inst_m = 0
+            dur_m = classification["duration_m"]
+            dual_m = classification["dual_m"]
+            solo_m = classification["solo_m"]
+            pic_m = classification["pic_m"]
+            inst_m = classification["inst_m"]
             comments = ""
             # Construct comments as in logbook.html: lesson codes for instruction, otherwise blank
-            if is_pilot and f.instructor:
-                rpt = InstructionReport.objects.filter(
-                    student=member, instructor=f.instructor, report_date=date
-                ).first()
+            if is_pilot and has_logbook_instructor_context(f):
+                rpt = None
+                if f.instructor_id:
+                    rpt = (
+                        InstructionReport.objects.filter(
+                            student=member,
+                            instructor=f.instructor,
+                            report_date=date,
+                        )
+                        .prefetch_related("lesson_scores__lesson")
+                        .first()
+                    )
                 if rpt:
                     codes = [ls.lesson.code for ls in rpt.lesson_scores.all()]
                     if codes:
                         comments = ", ".join(codes)
+                else:
+                    fallback_instructor_name = (
+                        f.guest_instructor_name or ""
+                    ).strip() or (f.legacy_instructor_name or "").strip()
+                    comments = "instruction received"
+                    if fallback_instructor_name:
+                        comments = (
+                            f"instruction received /s/ {fallback_instructor_name}"
+                        )
             row = {
                 "Date": date,
                 "Flight #": flight_no if (is_pilot or is_instructor) else "",

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -55,6 +55,7 @@ from instructors.utils import (
     classify_logbook_flight_minutes,
     get_flight_summary_for_member,
     get_logbook_glider_time_summary,
+    has_logbook_instructor_context,
     send_instruction_report_email,
 )
 from knowledgetest.forms import TestBuilderForm
@@ -1761,9 +1762,11 @@ def member_logbook(request, member_id=None):
 
             # 5b) Pilot logic: instruction received vs lesson codes
             if is_pilot:
-                if f.instructor:
+                if has_logbook_instructor_context(f):
                     # Look up the instruction report from pre-fetched dict (O(1) lookup)
-                    report_data = report_lookup.get((f.instructor_id, date))
+                    report_data = None
+                    if f.instructor_id:
+                        report_data = report_lookup.get((f.instructor_id, date))
 
                     if report_data:
                         rpt = report_data["report"]
@@ -1773,7 +1776,15 @@ def member_logbook(request, member_id=None):
                         )
                         report_id = rpt.id
                     else:
-                        comments = "instruction received"
+                        fallback_instructor_name = (
+                            f.guest_instructor_name or f.legacy_instructor_name or ""
+                        )
+                        if fallback_instructor_name:
+                            comments = (
+                                f"instruction received /s/ {fallback_instructor_name}"
+                            )
+                        else:
+                            comments = "instruction received"
                         report_id = None
                 else:
                     if f.passenger:

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -53,6 +53,7 @@ from instructors.models import (
 )
 from instructors.utils import (
     get_flight_summary_for_member,
+    get_logbook_glider_time_summary,
     send_instruction_report_email,
 )
 from knowledgetest.forms import TestBuilderForm
@@ -1693,6 +1694,7 @@ def member_logbook(request, member_id=None):
 
     # 3) Use actual private_glider_checkride_date if available
     rating_date = getattr(member, "private_glider_checkride_date", None)
+    glider_time_summary = get_logbook_glider_time_summary(member)
 
     # 4) Flatten flights & grounds into a single timeline of events, capturing time
     events = []
@@ -1752,10 +1754,9 @@ def member_logbook(request, member_id=None):
             if is_pilot:
                 if f.instructor:
                     # Received dual / PIC
+                    dual_m += dur_m
                     if rating_date and date >= rating_date:
                         pic_m += dur_m
-                    else:
-                        dual_m += dur_m
 
                     # Look up the instruction report from pre-fetched dict (O(1) lookup)
                     report_data = report_lookup.get((f.instructor_id, date))
@@ -2023,6 +2024,7 @@ def member_logbook(request, member_id=None):
             "years": years,
             "year_page_map": year_page_map,
             "all_years": all_years,
+            "glider_time_summary": glider_time_summary,
         },
     )
 


### PR DESCRIPTION
## Summary
- update logbook row classification so pilot flights with an instructor always log Dual Received, and also log PIC when the member was rated on the flight date
- add all-time per-glider make/model summary on the logbook page with Dual Received, Solo, Instruction Given, PIC Summary, and Total Time
- keep instruction record quick-summary behavior unchanged; this expansion is scoped to logbook
- add focused E2E coverage for rated dual/PIC display and all-time summary visibility

## Implementation
- added get_logbook_glider_time_summary in instructors/utils.py
- wired glider_time_summary into member_logbook context in instructors/views.py
- updated rated-pilot row logic in member_logbook so instructor flights contribute to dual received and PIC (rating-date gated for PIC)
- rendered new summary table in instructors/templates/instructors/logbook.html
- added targeted tests in instructors/tests/test_member_logbook_permissions.py
- added focused Playwright tests in e2e_tests/e2e/test_logbook_time_breakouts.py

## Validation
- pytest instructors/tests/test_member_logbook_permissions.py -q
- pytest instructors/tests/test_member_logbook_performance.py -q
- pytest instructors/tests/test_flight_summary.py -q
- pytest e2e_tests/e2e/test_logbook_time_breakouts.py -q

Closes #762