### PR TITLE
Fix mobile Resources webcam visibility and add E2E regression

### DIFF
--- a/e2e_tests/e2e/test_navbar_resources_drawer.py
+++ b/e2e_tests/e2e/test_navbar_resources_drawer.py
@@ -1,7 +1,10 @@
 """E2E coverage for Issue #746 navbar information architecture updates."""
 
+from django.core.cache import cache
+
 from cms.models import HomePageContent
 from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+from siteconfig.models import SiteConfiguration
 
 
 class TestNavbarResourcesDrawer(DjangoPlaywrightTestCase):
@@ -77,3 +80,33 @@ class TestNavbarResourcesDrawer(DjangoPlaywrightTestCase):
             offcanvas.locator("a.nav-link", has_text="Membership Application").count()
             == 0
         )
+
+    def test_mobile_resources_drawer_includes_clickable_webcam_entry(self):
+        """Active members should see and be able to open Webcam from mobile Resources."""
+        siteconfig = SiteConfiguration.objects.first()
+        if siteconfig:
+            siteconfig.webcam_snapshot_url = "https://example.com/webcam.jpg"
+            siteconfig.save(update_fields=["webcam_snapshot_url"])
+        else:
+            SiteConfiguration.objects.create(
+                club_name="E2E Test Club",
+                domain_name="e2e.test",
+                club_abbreviation="E2E",
+                webcam_snapshot_url="https://example.com/webcam.jpg",
+            )
+        cache.delete("siteconfig_webcam_enabled")
+
+        self.create_test_member(username="nav_webcam_member")
+        self.login(username="nav_webcam_member")
+        self._open_mobile_menu()
+
+        self.page.click("#resourcesDropdown")
+        self.page.wait_for_selector("#resourcesDropdown + .dropdown-menu.show")
+        resources_menu = self.page.locator("#resourcesDropdown + .dropdown-menu")
+        webcam_link = resources_menu.locator("a.dropdown-item", has_text="Webcam")
+        assert webcam_link.count() == 1
+
+        webcam_link.first.scroll_into_view_if_needed()
+        webcam_link.first.click()
+
+        self.page.wait_for_url(f"{self.live_server_url}/webcam/")

--- a/e2e_tests/e2e/test_navbar_resources_drawer.py
+++ b/e2e_tests/e2e/test_navbar_resources_drawer.py
@@ -10,6 +10,8 @@ from siteconfig.models import SiteConfiguration
 class TestNavbarResourcesDrawer(DjangoPlaywrightTestCase):
     """Verify guest/member navbar structures and Resources drawer behavior."""
 
+    _TEST_WEBCAM_URL = "file:///nonexistent/webcam.jpg"
+
     def setUp(self):
         super().setUp()
         HomePageContent.objects.get_or_create(
@@ -85,14 +87,14 @@ class TestNavbarResourcesDrawer(DjangoPlaywrightTestCase):
         """Active members should see and be able to open Webcam from mobile Resources."""
         siteconfig = SiteConfiguration.objects.first()
         if siteconfig:
-            siteconfig.webcam_snapshot_url = "https://example.com/webcam.jpg"
+            siteconfig.webcam_snapshot_url = self._TEST_WEBCAM_URL
             siteconfig.save(update_fields=["webcam_snapshot_url"])
         else:
             SiteConfiguration.objects.create(
                 club_name="E2E Test Club",
                 domain_name="e2e.test",
                 club_abbreviation="E2E",
-                webcam_snapshot_url="https://example.com/webcam.jpg",
+                webcam_snapshot_url=self._TEST_WEBCAM_URL,
             )
         cache.delete("siteconfig_webcam_enabled")
 

--- a/static/css/navbar-enhanced.css
+++ b/static/css/navbar-enhanced.css
@@ -240,10 +240,10 @@
 /* Keep login/logout auth buttons vertically centered across browsers (Safari).
     Using inline-flex avoids baseline alignment differences on anchor vs button. */
 .navbar-auth-btn {
-     display: inline-flex;
-     align-items: center;
-     justify-content: center;
-     line-height: 1.2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1.2;
 }
 
 /* ==========================================================================

--- a/static/css/navbar-enhanced.css
+++ b/static/css/navbar-enhanced.css
@@ -328,6 +328,8 @@
     }
 
     .navbar-offcanvas .dropdown-menu.show {
-        max-height: 500px;
+        /* Avoid clipping long menus (e.g., Resources) on small screens. */
+        max-height: 80vh;
+        overflow-y: auto;
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes a mobile navigation issue where long Resources dropdown content could be clipped, causing lower items such as Webcam to appear missing on mobile while still visible on desktop.

## What Changed
- Updated mobile offcanvas dropdown expanded behavior to use viewport-based height and vertical scrolling.
- Added a Playwright E2E regression test that validates Webcam appears in the mobile Resources drawer for an active member and is clickable.
- Included a small CSS formatting normalization in the same navbar stylesheet.

## Why
On smaller screens, the previous fixed expanded dropdown height could hide trailing menu items. Using a viewport-relative max height with scroll keeps all resources reachable.

## Validation
- pytest e2e_tests/e2e/test_navbar_resources_drawer.py -v
  - 3 passed

## Files Changed
- static/css/navbar-enhanced.css
- e2e_tests/e2e/test_navbar_resources_drawer.py
