### PR TITLE
Force Duty Roster Calendar navbar entry to open Calendar view

### DIFF
--- a/e2e_tests/e2e/test_duty_roster_navigation.py
+++ b/e2e_tests/e2e/test_duty_roster_navigation.py
@@ -180,3 +180,38 @@ class TestDutyRosterNavigation(DjangoPlaywrightTestCase):
         assert (
             not agenda_content.is_visible()
         ), "Agenda view should be hidden when ?view=calendar is in URL"
+
+    def test_navbar_calendar_link_forces_calendar_view(self):
+        """Duty Roster -> Calendar navbar entry should always open calendar view."""
+        self.create_test_member(
+            username="testmember",
+            email="test@example.com",
+            membership_status="Full Member",
+        )
+        self.login(username="testmember")
+
+        self.page.goto(f"{self.live_server_url}/duty_roster/calendar/")
+        self.page.wait_for_selector("#calendar-body")
+
+        # Simulate a previously saved preference for agenda view.
+        self.page.evaluate("localStorage.setItem('duty-roster-view', 'agenda')")
+
+        # Use the navbar link path the customer reported.
+        self.page.click("#dutyrosterDropdown")
+        duty_dropdown = self.page.locator("#dutyrosterDropdown + .dropdown-menu")
+        duty_dropdown.locator("a.dropdown-item", has_text="Calendar").click()
+
+        self.page.wait_for_url(
+            f"{self.live_server_url}/duty_roster/calendar/?view=calendar"
+        )
+        self.page.wait_for_selector("#calendar-view-content", state="visible")
+
+        agenda_content = self.page.locator("#agenda-view-content")
+        calendar_content = self.page.locator("#calendar-view-content")
+
+        assert (
+            calendar_content.is_visible()
+        ), "Calendar view should remain visible when opened from navbar Calendar link"
+        assert (
+            not agenda_content.is_visible()
+        ), "Agenda view should remain hidden when navbar Calendar is selected"

--- a/e2e_tests/e2e/test_duty_roster_navigation.py
+++ b/e2e_tests/e2e/test_duty_roster_navigation.py
@@ -198,6 +198,10 @@ class TestDutyRosterNavigation(DjangoPlaywrightTestCase):
 
         # Use the navbar link path the customer reported.
         self.page.click("#dutyrosterDropdown")
+        # Wait for Bootstrap dropdown to fully open before clicking a menu item.
+        self.page.wait_for_selector(
+            "#dutyrosterDropdown + .dropdown-menu.show", state="visible"
+        )
         duty_dropdown = self.page.locator("#dutyrosterDropdown + .dropdown-menu")
         duty_dropdown.locator("a.dropdown-item", has_text="Calendar").click()
 
@@ -215,3 +219,34 @@ class TestDutyRosterNavigation(DjangoPlaywrightTestCase):
         assert (
             not agenda_content.is_visible()
         ), "Agenda view should remain hidden when navbar Calendar is selected"
+
+    def test_guest_navbar_calendar_link_forces_calendar_view(self):
+        """Guest Duty Roster -> Calendar should override saved agenda preference."""
+        self.page.goto(f"{self.live_server_url}/duty_roster/calendar/")
+        self.page.wait_for_selector("#calendar-body")
+
+        # Simulate a previously saved preference for agenda view.
+        self.page.evaluate("localStorage.setItem('duty-roster-view', 'agenda')")
+
+        # Use the guest navbar path the reviewer requested coverage for.
+        self.page.click("#guestDutyrosterDropdown")
+        self.page.wait_for_selector(
+            "#guestDutyrosterDropdown + .dropdown-menu.show", state="visible"
+        )
+        guest_dropdown = self.page.locator("#guestDutyrosterDropdown + .dropdown-menu")
+        guest_dropdown.locator("a.dropdown-item", has_text="Calendar").click()
+
+        self.page.wait_for_url(
+            f"{self.live_server_url}/duty_roster/calendar/?view=calendar"
+        )
+        self.page.wait_for_selector("#calendar-view-content", state="visible")
+
+        agenda_content = self.page.locator("#agenda-view-content")
+        calendar_content = self.page.locator("#calendar-view-content")
+
+        assert (
+            calendar_content.is_visible()
+        ), "Calendar view should remain visible when guest navbar Calendar is selected"
+        assert (
+            not agenda_content.is_visible()
+        ), "Agenda view should remain hidden when guest navbar Calendar is selected"

--- a/templates/base.html
+++ b/templates/base.html
@@ -127,7 +127,7 @@
             </a>
             <ul class="dropdown-menu" aria-labelledby="guestDutyrosterDropdown">
               <li class="nav-item">
-                <a class="dropdown-item" href="{% url 'duty_roster:duty_calendar' %}"><i class="fas fa-calendar-alt me-1"></i> Calendar</a>
+                <a class="dropdown-item" href="{% url 'duty_roster:duty_calendar' %}?view=calendar"><i class="fas fa-calendar-alt me-1"></i> Calendar</a>
               </li>
               <li class="nav-item">
                 <a class="dropdown-item" href="{% url 'duty_roster:duty_calendar' %}?view=agenda"><i class="fas fa-list me-1"></i> Roster Agenda</a>
@@ -153,7 +153,7 @@
             </a>
             <ul class="dropdown-menu" aria-labelledby="dutyrosterDropdown">
               <li class="nav-item">
-                <a class="dropdown-item" href="{% url 'duty_roster:duty_calendar' %}"><i class="fas fa-calendar-alt me-1"></i> Calendar</a>
+                <a class="dropdown-item" href="{% url 'duty_roster:duty_calendar' %}?view=calendar"><i class="fas fa-calendar-alt me-1"></i> Calendar</a>
               </li>
               <li class="nav-item">
                 <a class="dropdown-item" href="{% url 'duty_roster:duty_calendar' %}?view=agenda"><i class="fas fa-list me-1"></i> Roster Agenda</a>


### PR DESCRIPTION
## Summary
Fixes a Duty Roster UX issue where clicking the navbar Calendar entry could still switch to Agenda based on a previously saved localStorage preference.

## Problem
- Users click Duty Roster -> Calendar.
- Calendar initially loads, then flips to Agenda if last-used view was agenda.
- This made the Calendar navbar entry feel unreliable unless users manually toggled back.

## Changes
- Force both navbar Calendar links (guest and authenticated) to include `?view=calendar`.
- Added E2E regression coverage for the exact user path:
  - set localStorage preference to agenda
  - click navbar Duty Roster -> Calendar
  - verify URL includes `?view=calendar`
  - verify calendar remains visible and agenda remains hidden

## Validation
- `pytest e2e_tests/e2e/test_duty_roster_navigation.py::TestDutyRosterNavigation::test_view_param_overrides_localstorage -v`
- `pytest e2e_tests/e2e/test_duty_roster_navigation.py::TestDutyRosterNavigation::test_navbar_calendar_link_forces_calendar_view -v`

## Files changed
- `templates/base.html`
- `e2e_tests/e2e/test_duty_roster_navigation.py`
