### PR TITLE
Fix Issue #561 pairing preference persistence and visibility

### DIFF
--- a/duty_roster/forms.py
+++ b/duty_roster/forms.py
@@ -56,6 +56,21 @@ class MemberBlackoutForm(forms.ModelForm):
 
 
 class DutyPreferenceForm(forms.ModelForm):
+    pair_with = forms.ModelMultipleChoiceField(
+        queryset=Member.objects.none(),
+        required=False,
+        widget=forms.SelectMultiple(
+            attrs={"class": "form-select multi-select-responsive"}
+        ),
+    )
+    avoid_with = forms.ModelMultipleChoiceField(
+        queryset=Member.objects.none(),
+        required=False,
+        widget=forms.SelectMultiple(
+            attrs={"class": "form-select multi-select-responsive"}
+        ),
+    )
+
     max_assignments_per_month = forms.DecimalField(
         min_value=0,
         max_value=12,
@@ -108,6 +123,15 @@ class DutyPreferenceForm(forms.ModelForm):
     def __init__(self, *args, member=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.member = member
+
+        if member:
+            selectable_members = (
+                Member.objects.filter(is_active=True)
+                .exclude(id=member.id)
+                .order_by("last_name", "first_name")
+            )
+            self.fields["pair_with"].queryset = selectable_members
+            self.fields["avoid_with"].queryset = selectable_members
 
         # Make percentage fields not required if user doesn't have those roles
         # and set appropriate defaults

--- a/duty_roster/templates/duty_roster/blackout_calendar.html
+++ b/duty_roster/templates/duty_roster/blackout_calendar.html
@@ -409,14 +409,14 @@
                         {% for group_name, members in member_optgroups %}
                           <optgroup label="{{ group_name }}">
                             {% for m in members %}
-                              <option value="{{ m.id }}" {% if m in pair_with %}selected{% endif %}>{{ m.full_display_name }}</option>
+                              <option value="{{ m.id }}" {% if m.id in pair_with_ids %}selected{% endif %}>{{ m.full_display_name }}</option>
                             {% endfor %}
                           </optgroup>
                         {% endfor %}
                       </select>
                       <div class="form-text">
                         <i class="fas fa-info-circle me-1"></i>
-                        Hold <kbd aria-label="Control">Ctrl</kbd> (Windows) or <kbd aria-label="Command">⌘</kbd> (Mac) to select multiple members
+                        Hold <kbd aria-label="Control">Ctrl</kbd> (Windows) or <kbd aria-label="Command">⌘</kbd> (Mac) to select multiple members. Saved selections stay highlighted.
                       </div>
                     </div>
                   </div>
@@ -443,7 +443,7 @@
                         {% for group_name, members in member_optgroups %}
                           <optgroup label="{{ group_name }}">
                             {% for m in members %}
-                              <option value="{{ m.id }}" {% if m in avoid_with %}selected{% endif %}>{{ m.full_display_name }}</option>
+                              <option value="{{ m.id }}" {% if m.id in avoid_with_ids %}selected{% endif %}>{{ m.full_display_name }}</option>
                             {% endfor %}
                           </optgroup>
                         {% endfor %}

--- a/duty_roster/tests.py
+++ b/duty_roster/tests.py
@@ -1540,3 +1540,53 @@ class PairingPreferencesDisplayTests(TestCase):
         # Should have both badge styles
         self.assertContains(response, "bg-success-subtle")
         self.assertContains(response, "bg-warning-subtle")
+
+    def test_post_saves_pairing_preferences_and_rehydrates_selected_options(self):
+        """Saving pairing preferences should persist badges and selected options."""
+        from duty_roster.models import DutyAvoidance, DutyPairing
+
+        self.client.login(username="testmember", password="testpass123")
+        url = reverse("duty_roster:blackout_manage")
+
+        form_data = {
+            "preferred_day": "",
+            "dont_schedule": "",
+            "scheduling_suspended": "",
+            "suspended_reason": "",
+            "comment": "",
+            "instructor_percent": "0",
+            "duty_officer_percent": "0",
+            "ado_percent": "0",
+            "towpilot_percent": "0",
+            "max_assignments_per_month": "2.00",
+            "allow_weekend_double": "",
+            "pair_with": [str(self.pair_member1.id), str(self.pair_member2.id)],
+            "avoid_with": [str(self.avoid_member.id)],
+        }
+
+        response = self.client.post(url, data=form_data, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+
+        pair_ids = set(
+            DutyPairing.objects.filter(member=self.member).values_list(
+                "pair_with_id", flat=True
+            )
+        )
+        avoid_ids = set(
+            DutyAvoidance.objects.filter(member=self.member).values_list(
+                "avoid_with_id", flat=True
+            )
+        )
+
+        self.assertEqual(pair_ids, {self.pair_member1.id, self.pair_member2.id})
+        self.assertEqual(avoid_ids, {self.avoid_member.id})
+
+        self.assertContains(response, "Duty preferences saved successfully")
+        self.assertContains(response, "Alice Partner")
+        self.assertContains(response, "Bob Buddy")
+        self.assertContains(response, "Charlie Conflict")
+
+        self.assertContains(response, f'value="{self.pair_member1.id}" selected')
+        self.assertContains(response, f'value="{self.pair_member2.id}" selected')
+        self.assertContains(response, f'value="{self.avoid_member.id}" selected')

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -157,7 +157,7 @@ def blackout_manage(request):
 
     # Active members (excluding current user)
     active_members = (
-        Member.objects.filter(membership_status__in=active_statuses)
+        Member.objects.filter(membership_status__in=active_statuses, is_active=True)
         .exclude(id=member.id)
         .order_by("last_name", "first_name")
     )

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -139,8 +139,18 @@ def blackout_manage(request):
     if member.towpilot:
         role_choices.append(("towpilot", "Tow Pilot"))
 
-    pair_with = Member.objects.filter(pairing_target__member=member)
-    avoid_with = Member.objects.filter(avoid_target__member=member)
+    pair_with = list(
+        Member.objects.filter(pairing_target__member=member).order_by(
+            "last_name", "first_name"
+        )
+    )
+    avoid_with = list(
+        Member.objects.filter(avoid_target__member=member).order_by(
+            "last_name", "first_name"
+        )
+    )
+    pair_with_ids = {m.id for m in pair_with}
+    avoid_with_ids = {m.id for m in avoid_with}
 
     # Create optgroups for member pairing fields (similar to logsheet forms)
     active_statuses = get_active_membership_statuses()
@@ -244,8 +254,8 @@ def blackout_manage(request):
             "max_assignments_per_month": preference.max_assignments_per_month,
             "allow_weekend_double": preference.allow_weekend_double,
             "comment": preference.comment,
-            "pair_with": pair_with,
-            "avoid_with": avoid_with,
+            "pair_with": list(pair_with_ids),
+            "avoid_with": list(avoid_with_ids),
         }
         form = DutyPreferenceForm(initial=initial, member=member)
 
@@ -261,6 +271,8 @@ def blackout_manage(request):
             "preference": preference,
             "pair_with": pair_with,
             "avoid_with": avoid_with,
+            "pair_with_ids": pair_with_ids,
+            "avoid_with_ids": avoid_with_ids,
             "all_other_members": all_other,
             "member_optgroups": member_optgroups,
             "form": form,

--- a/e2e_tests/e2e/test_blackout_pairing_preferences.py
+++ b/e2e_tests/e2e/test_blackout_pairing_preferences.py
@@ -1,0 +1,66 @@
+"""E2E coverage for Duty Blackout pairing preference persistence (Issue #561)."""
+
+from .conftest import DjangoPlaywrightTestCase
+
+
+class TestBlackoutPairingPreferences(DjangoPlaywrightTestCase):
+    """Verify saved pairing preferences remain visibly persisted after reload."""
+
+    def test_pairing_preferences_remain_selected_after_save(self):
+        self.create_test_member(
+            username="pair_owner",
+            email="pair_owner@example.com",
+            first_name="Owner",
+            last_name="Member",
+        )
+        partner_one = self.create_test_member(
+            username="pair_partner_one",
+            email="pair_partner_one@example.com",
+            first_name="Alice",
+            last_name="Partner",
+        )
+        partner_two = self.create_test_member(
+            username="pair_partner_two",
+            email="pair_partner_two@example.com",
+            first_name="Bob",
+            last_name="Buddy",
+        )
+        avoid_member = self.create_test_member(
+            username="pair_avoid_one",
+            email="pair_avoid_one@example.com",
+            first_name="Charlie",
+            last_name="Conflict",
+        )
+
+        self.login(username="pair_owner")
+        self.page.goto(f"{self.live_server_url}/duty_roster/blackout/")
+
+        self.page.locator("#pairWith").select_option(
+            [str(partner_one.id), str(partner_two.id)]
+        )
+        self.page.locator("#avoidWith").select_option(str(avoid_member.id))
+
+        self.page.locator('button[type="submit"].btn-success').click()
+        self.page.wait_for_load_state("networkidle")
+
+        # Badge summary should show persisted selections.
+        page_text = self.page.text_content("body") or ""
+        assert "Currently selected:" in page_text
+        assert "Alice Partner" in page_text
+        assert "Bob Buddy" in page_text
+        assert "Charlie Conflict" in page_text
+
+        # Selected options should remain highlighted in both controls.
+        pair_one_selected = self.page.locator(
+            f'#pairWith option[value="{partner_one.id}"]'
+        ).evaluate("el => el.selected")
+        pair_two_selected = self.page.locator(
+            f'#pairWith option[value="{partner_two.id}"]'
+        ).evaluate("el => el.selected")
+        avoid_selected = self.page.locator(
+            f'#avoidWith option[value="{avoid_member.id}"]'
+        ).evaluate("el => el.selected")
+
+        assert pair_one_selected is True
+        assert pair_two_selected is True
+        assert avoid_selected is True


### PR DESCRIPTION
## Summary
Fixes reopened Issue #561 by making Duty Blackout pairing preferences actually persist on save and visibly rehydrate after redirect.

## Problem
Customers reported no meaningful visual confirmation after saving pairing preferences. The issue was reopened because behavior still appeared unchanged.

## Root cause
`blackout_manage` attempted to read `pair_with`/`avoid_with` from `DutyPreferenceForm.cleaned_data`, but those fields were not defined on the form. As a result, selected members were not reliably persisted from the page submission flow.

## Changes
- Added `pair_with` and `avoid_with` as `ModelMultipleChoiceField`s on `DutyPreferenceForm` with member-scoped querysets.
- Updated blackout view hydration to use stable selected ID sets for template rendering and form initial values.
- Updated template option selection logic to use selected ID sets so saved selections remain highlighted in the multi-select controls.
- Kept and reinforced the existing "Currently selected" badge summaries.
- Added server-side regression test for POST save + rehydrated selected options.
- Added Playwright E2E test for end-to-end save/reload behavior.

## Validation
- `pytest duty_roster/tests.py -k PairingPreferencesDisplayTests -v`
- `pytest e2e_tests/e2e/test_blackout_pairing_preferences.py -v`

## Files changed
- `duty_roster/forms.py`
- `duty_roster/views.py`
- `duty_roster/templates/duty_roster/blackout_calendar.html`
- `duty_roster/tests.py`
- `e2e_tests/e2e/test_blackout_pairing_preferences.py`
