### PR TITLE
Fix Issue #661 year-link anchor landing in equipment logbook

### DIFF
--- a/logsheet/templates/logsheet/equipment_logbook.html
+++ b/logsheet/templates/logsheet/equipment_logbook.html
@@ -136,6 +136,29 @@
                 </table>
                 </div>
                 <script>
+                    function updateLogbookYearAnchorOffset() {
+                        var root = document.documentElement;
+                        var fixedNavbar = document.querySelector('.navbar.fixed-top, .navbar.sticky-top');
+                        var yearNav = document.querySelector('.year-navigation');
+                        var offset = 16;
+
+                        if (fixedNavbar) {
+                            offset += fixedNavbar.getBoundingClientRect().height;
+                        }
+
+                        if (yearNav) {
+                            var yearNavStyle = window.getComputedStyle(yearNav);
+                            if (yearNavStyle.position === 'sticky' || yearNavStyle.position === 'fixed') {
+                                offset += yearNav.getBoundingClientRect().height;
+                            }
+                        }
+
+                        root.style.setProperty('--logbook-year-anchor-offset', Math.ceil(offset) + 'px');
+                    }
+
+                    window.addEventListener('resize', updateLogbookYearAnchorOffset);
+                    document.addEventListener('DOMContentLoaded', updateLogbookYearAnchorOffset);
+
                     // After shared tablesort initializer runs, force initial descending sort on Date column
                     document.addEventListener('tablesort:ready', function () {
                         var table = document.getElementById('equipmentLogbookTable');

--- a/logsheet/templates/logsheet/equipment_logbook.html
+++ b/logsheet/templates/logsheet/equipment_logbook.html
@@ -52,8 +52,13 @@
             <tbody>
                 {% for row in daily %}
                 {% with d=row.day %}
-                <tr id="{% if row.year_anchor %}{{ row.year_anchor }}{% endif %}">
-                    <td style="white-space:nowrap;" data-sort="{{ d|date:'Y-m-d' }}">{{ d|date:'M. j, Y' }}</td>
+                <tr>
+                    <td style="white-space:nowrap;" data-sort="{{ d|date:'Y-m-d' }}">
+                        {% if row.year_anchor %}
+                        <span id="{{ row.year_anchor }}" class="year-anchor-target" aria-hidden="true"></span>
+                        {% endif %}
+                        {{ d|date:'M. j, Y' }}
+                    </td>
                     <td class="text-end">{{ row.glider_tows }}</td>
 
                     {# Decimal hours #}

--- a/logsheet/templates/logsheet/equipment_logbook.html
+++ b/logsheet/templates/logsheet/equipment_logbook.html
@@ -156,8 +156,10 @@
                         root.style.setProperty('--logbook-year-anchor-offset', Math.ceil(offset) + 'px');
                     }
 
+                    updateLogbookYearAnchorOffset();
                     window.addEventListener('resize', updateLogbookYearAnchorOffset);
                     document.addEventListener('DOMContentLoaded', updateLogbookYearAnchorOffset);
+                    window.addEventListener('hashchange', updateLogbookYearAnchorOffset);
 
                     // After shared tablesort initializer runs, force initial descending sort on Date column
                     document.addEventListener('tablesort:ready', function () {

--- a/logsheet/tests/test_towplane_logbook_performance.py
+++ b/logsheet/tests/test_towplane_logbook_performance.py
@@ -692,6 +692,41 @@ class TowplaneLogbookMinimalTestCase(TestCase):
         self.assertEqual(day_data["day"], date.today())
         self.assertEqual(day_data["day_hours"], 1.5)
 
+    def test_year_navigation_links_have_anchor_targets(self):
+        """Year jump links should render matching in-table anchor targets."""
+        first_day = date(2025, 1, 10)
+        second_day = date(2026, 2, 15)
+
+        for d, start_tach, end_tach in (
+            (first_day, 100.0, 101.0),
+            (second_day, 101.0, 102.0),
+        ):
+            logsheet = Logsheet.objects.create(
+                log_date=d,
+                airfield=self.airfield,
+                duty_officer=self.member,
+                created_by=self.member,
+            )
+            TowplaneCloseout.objects.create(
+                logsheet=logsheet,
+                towplane=self.towplane,
+                start_tach=start_tach,
+                end_tach=end_tach,
+                tach_time=1.0,
+            )
+
+        client = Client()
+        client.force_login(self.member)
+        response = client.get(
+            reverse("logsheet:towplane_logbook", args=[self.towplane.pk])
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="#y2025"')
+        self.assertContains(response, 'href="#y2026"')
+        self.assertContains(response, 'id="y2025" class="year-anchor-target"')
+        self.assertContains(response, 'id="y2026" class="year-anchor-target"')
+
 
 class TowplaneMaintenanceOnlyDaysTestCase(TestCase):
     """

--- a/logsheet/tests/test_towplane_logbook_performance.py
+++ b/logsheet/tests/test_towplane_logbook_performance.py
@@ -724,8 +724,9 @@ class TowplaneLogbookMinimalTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'href="#y2025"')
         self.assertContains(response, 'href="#y2026"')
-        self.assertContains(response, 'id="y2025" class="year-anchor-target"')
-        self.assertContains(response, 'id="y2026" class="year-anchor-target"')
+        self.assertContains(response, 'id="y2025"')
+        self.assertContains(response, 'id="y2026"')
+        self.assertContains(response, 'class="year-anchor-target"', count=2)
 
 
 class TowplaneMaintenanceOnlyDaysTestCase(TestCase):

--- a/static/css/logbook.css
+++ b/static/css/logbook.css
@@ -108,11 +108,15 @@ td.logbook-comments {
     display: inline-block;
 }
 
+:root {
+    --logbook-year-anchor-offset: 150px;
+}
+
 /* Anchor target for year links; keep first row content visible below fixed/sticky bars. */
 .year-anchor-target {
     display: block;
     height: 0;
-    scroll-margin-top: 150px;
+    scroll-margin-top: var(--logbook-year-anchor-offset);
 }
 
 /* Smooth scrolling */

--- a/static/css/logbook.css
+++ b/static/css/logbook.css
@@ -108,6 +108,13 @@ td.logbook-comments {
     display: inline-block;
 }
 
+/* Anchor target for year links; keep first row content visible below fixed/sticky bars. */
+.year-anchor-target {
+    display: block;
+    height: 0;
+    scroll-margin-top: 150px;
+}
+
 /* Smooth scrolling */
 html {
     scroll-behavior: smooth;


### PR DESCRIPTION
## Summary
Fixes issue #661 where year-jump links in equipment/towplane logbooks could land with the top of the target entry obscured, especially when rows wrap to multiple lines.

## Root cause
Year anchors were attached directly to table rows, relying on default browser hash scrolling while the page uses fixed/sticky top UI. This made anchor landing positions inconsistent and could hide the beginning of the intended entry.

## Changes
- Moved year-jump anchor targets to explicit in-cell anchor elements at the start of the date cell for each year's first entry.
- Added `.year-anchor-target` CSS with `scroll-margin-top` to offset fixed/sticky UI during hash navigation.
- Added regression test to confirm year nav links and anchor targets render for multi-year towplane logbook data.

## Validation
- `pytest logsheet/tests/test_towplane_logbook_performance.py::TowplaneLogbookMinimalTestCase::test_year_navigation_links_have_anchor_targets -v`
- `pytest logsheet/tests/test_towplane_logbook_performance.py::TowplaneLogbookMinimalTestCase::test_single_day_logbook -v`

## Files changed
- `logsheet/templates/logsheet/equipment_logbook.html`
- `static/css/logbook.css`
- `logsheet/tests/test_towplane_logbook_performance.py`
