### PR TITLE
Issue #801: Allow surge volunteers to retract offers

### DIFF
--- a/duty_roster/templates/duty_roster/_calendar_month_nav.html
+++ b/duty_roster/templates/duty_roster/_calendar_month_nav.html
@@ -3,6 +3,7 @@
 <div class="d-flex justify-content-between align-items-center {{ margin_class|default:'mb-4' }}">
   <button
     hx-get="{% url 'duty_roster:duty_calendar_month' year=prev_year month=prev_month %}"
+    hx-vals='js:{"view": localStorage.getItem("duty-roster-view") || "calendar"}'
     hx-target="#calendar-body"
     hx-swap="innerHTML"
     class="btn btn-sm btn-outline-primary"
@@ -48,6 +49,7 @@
 
   <button
     hx-get="{% url 'duty_roster:duty_calendar_month' year=next_year month=next_month %}"
+    hx-vals='js:{"view": localStorage.getItem("duty-roster-view") || "calendar"}'
     hx-target="#calendar-body"
     hx-swap="innerHTML"
     class="btn btn-sm btn-outline-primary"

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -123,6 +123,12 @@
               <small class="text-muted d-block">{{ config.surge_instructor_title|default:'Surge Instructor' }}</small>
               {% if assignment.surge_instructor %}
                 <span class="fw-medium">{{ assignment.surge_instructor.full_display_name }}</span>
+                {% if user == assignment.surge_instructor and day >= today %}
+                <a href="{% url 'duty_roster:retract_surge_instructor' assignment_id=assignment.id %}"
+                   class="btn btn-outline-warning btn-sm mt-1 d-block" style="font-size:0.7rem;padding:2px 6px;">
+                  ↩ Retract surge offer
+                </a>
+                {% endif %}
               {% elif can_volunteer_surge_instructor %}
                 <a href="{% url 'duty_roster:volunteer_surge_instructor' assignment_id=assignment.id %}"
                    class="btn btn-success btn-sm mt-1 d-block" style="font-size:0.7rem;padding:2px 6px;">
@@ -142,6 +148,12 @@
               <small class="text-muted d-block">{{ config.surge_towpilot_title|default:'Surge Tow Pilot' }}</small>
               {% if assignment.surge_tow_pilot %}
                 <span class="fw-medium">{{ assignment.surge_tow_pilot.full_display_name }}</span>
+                {% if user == assignment.surge_tow_pilot and day >= today %}
+                <a href="{% url 'duty_roster:retract_surge_tow_pilot' assignment_id=assignment.id %}"
+                   class="btn btn-outline-warning btn-sm mt-1 d-block" style="font-size:0.7rem;padding:2px 6px;">
+                  ↩ Retract surge offer
+                </a>
+                {% endif %}
               {% elif can_volunteer_surge_tow_pilot %}
                 <a href="{% url 'duty_roster:volunteer_surge_tow_pilot' assignment_id=assignment.id %}"
                    class="btn btn-danger btn-sm mt-1 d-block" style="font-size:0.7rem;padding:2px 6px;">

--- a/duty_roster/templates/duty_roster/emails/surge_instructor_withdrawn.html
+++ b/duty_roster/templates/duty_roster/emails/surge_instructor_withdrawn.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Surge Instructor Withdrawn</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #f4f4f4;">
+        <tr>
+            <td align="center" style="padding: 20px 0;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                    <tr>
+                        <td align="center" style="background-color: #fd7e14; background: linear-gradient(135deg, #fd7e14 0%, #ffc107 100%); padding: 30px 20px;">
+                            {% if club_logo_url %}
+                            <img src="{{ club_logo_url }}" alt="{{ club_name }} Logo" style="max-height: 60px; max-width: 200px; height: auto; margin-bottom: 15px;">
+                            {% endif %}
+                            <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: bold;">⚠️ Surge Instructor Withdrawn</h1>
+                            <p style="margin: 10px 0 0 0; color: #ffffff; font-size: 14px;">{{ ops_date }}</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 30px 20px;">
+                            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #fff3cd; border: 1px solid #ffeeba; border-radius: 4px; margin-bottom: 20px;">
+                                <tr>
+                                    <td style="padding: 15px; color: #856404;">
+                                        <strong>A surge instructor offer has been withdrawn.</strong>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="margin: 0 0 20px 0; color: #333333; font-size: 16px; line-height: 1.6;">
+                                Hi {{ primary_instructor.first_name|default:primary_instructor.username }},
+                            </p>
+
+                            <p style="margin: 0 0 20px 0; color: #333333; font-size: 16px; line-height: 1.6;">
+                                <strong>{{ withdrawn_instructor.get_full_name|default:withdrawn_instructor.username }}</strong>
+                                has withdrawn their surge instructor offer for
+                                <strong>{{ ops_date }}</strong>.
+                            </p>
+
+                            <p style="margin: 0 0 20px 0; color: #666666; font-size: 14px; line-height: 1.6;">
+                                You can review the duty roster for current coverage and make adjustments if needed.
+                            </p>
+
+                            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                                <tr>
+                                    <td align="center" style="padding: 10px 0;">
+                                        <a href="{{ roster_url }}" style="display: inline-block; background-color: #fd7e14; color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="background-color: #f8f9fa; padding: 20px; text-align: center; border-top: 1px solid #dee2e6;">
+                            <p style="margin: 0 0 10px 0; color: #6c757d; font-size: 12px;">
+                                This is an automated notification from Manage2Soar
+                            </p>
+                            <p style="margin: 0; color: #6c757d; font-size: 12px;">
+                                {{ club_name }}
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/duty_roster/templates/duty_roster/emails/surge_instructor_withdrawn.txt
+++ b/duty_roster/templates/duty_roster/emails/surge_instructor_withdrawn.txt
@@ -1,0 +1,13 @@
+⚠️ Surge Instructor Withdrawn - {{ ops_date }}
+================================================================================
+
+Hi {{ primary_instructor.first_name|default:primary_instructor.username }},
+
+{{ withdrawn_instructor.get_full_name|default:withdrawn_instructor.username }}
+has withdrawn their surge instructor offer for {{ ops_date }}.
+
+You can view the current duty roster here:
+  {{ roster_url }}
+
+- Manage2Soar Automated Notification
+  {{ club_name }}

--- a/duty_roster/templates/duty_roster/emails/surge_tow_pilot_withdrawn.html
+++ b/duty_roster/templates/duty_roster/emails/surge_tow_pilot_withdrawn.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Surge Tow Pilot Withdrawn</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #f4f4f4;">
+        <tr>
+            <td align="center" style="padding: 20px 0;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                    <tr>
+                        <td align="center" style="background-color: #fd7e14; background: linear-gradient(135deg, #fd7e14 0%, #ffc107 100%); padding: 30px 20px;">
+                            {% if club_logo_url %}
+                            <img src="{{ club_logo_url }}" alt="{{ club_name }} Logo" style="max-height: 60px; max-width: 200px; height: auto; margin-bottom: 15px;">
+                            {% endif %}
+                            <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: bold;">⚠️ Surge Tow Pilot Withdrawn</h1>
+                            <p style="margin: 10px 0 0 0; color: #ffffff; font-size: 14px;">{{ ops_date }}</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 30px 20px;">
+                            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #fff3cd; border: 1px solid #ffeeba; border-radius: 4px; margin-bottom: 20px;">
+                                <tr>
+                                    <td style="padding: 15px; color: #856404;">
+                                        <strong>A surge tow pilot offer has been withdrawn.</strong>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="margin: 0 0 20px 0; color: #333333; font-size: 16px; line-height: 1.6;">
+                                Hi {{ primary_tow_pilot.first_name|default:primary_tow_pilot.username }},
+                            </p>
+
+                            <p style="margin: 0 0 20px 0; color: #333333; font-size: 16px; line-height: 1.6;">
+                                <strong>{{ withdrawn_tow_pilot.get_full_name|default:withdrawn_tow_pilot.username }}</strong>
+                                has withdrawn their surge tow pilot offer for
+                                <strong>{{ ops_date }}</strong>.
+                            </p>
+
+                            <p style="margin: 0 0 20px 0; color: #666666; font-size: 14px; line-height: 1.6;">
+                                You can review the duty roster for current coverage and make adjustments if needed.
+                            </p>
+
+                            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                                <tr>
+                                    <td align="center" style="padding: 10px 0;">
+                                        <a href="{{ roster_url }}" style="display: inline-block; background-color: #fd7e14; color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 4px; font-weight: bold; font-size: 16px;">View Duty Roster</a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="background-color: #f8f9fa; padding: 20px; text-align: center; border-top: 1px solid #dee2e6;">
+                            <p style="margin: 0 0 10px 0; color: #6c757d; font-size: 12px;">
+                                This is an automated notification from Manage2Soar
+                            </p>
+                            <p style="margin: 0; color: #6c757d; font-size: 12px;">
+                                {{ club_name }}
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/duty_roster/templates/duty_roster/emails/surge_tow_pilot_withdrawn.txt
+++ b/duty_roster/templates/duty_roster/emails/surge_tow_pilot_withdrawn.txt
@@ -1,0 +1,13 @@
+⚠️ Surge Tow Pilot Withdrawn - {{ ops_date }}
+================================================================================
+
+Hi {{ primary_tow_pilot.first_name|default:primary_tow_pilot.username }},
+
+{{ withdrawn_tow_pilot.get_full_name|default:withdrawn_tow_pilot.username }}
+has withdrawn their surge tow pilot offer for {{ ops_date }}.
+
+You can view the current duty roster here:
+  {{ roster_url }}
+
+- Manage2Soar Automated Notification
+  {{ club_name }}

--- a/duty_roster/templates/duty_roster/surge_retract_confirm.html
+++ b/duty_roster/templates/duty_roster/surge_retract_confirm.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Retract Surge Instructor Offer{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+  {% include "duty_roster/_messages.html" %}
+
+  <div class="row justify-content-center">
+    <div class="col-lg-6 col-md-8">
+      <div class="card shadow-sm border-0">
+        <div class="card-header text-white" style="background: linear-gradient(135deg, #fd7e14 0%, #ffc107 100%);">
+          <h4 class="mb-0">
+            <i class="bi bi-arrow-counterclockwise me-2"></i>
+            Retract Surge Instructor Offer
+          </h4>
+        </div>
+
+        <div class="card-body p-4">
+          <div class="alert alert-warning d-flex align-items-start mb-4" role="alert">
+            <i class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2 mt-1"></i>
+            <div>
+              <strong>You are about to retract your surge instructor offer.</strong>
+              <div class="text-muted small mt-1">
+                {{ assignment.date|date:"l, F j, Y" }}
+              </div>
+            </div>
+          </div>
+
+          {% if assignment.instructor %}
+          <p class="text-muted mb-4">
+            The primary instructor is
+            <strong>{{ assignment.instructor.get_full_name|default:assignment.instructor.username }}</strong>.
+            They will be notified after you confirm.
+          </p>
+          {% endif %}
+
+          <form method="post">
+            {% csrf_token %}
+            <div class="d-flex gap-2 flex-wrap">
+              <button type="submit" class="btn btn-warning px-4">
+                <i class="bi bi-check-circle-fill me-2"></i>Yes, Retract Offer
+              </button>
+              <a href="{% url 'duty_roster:duty_calendar' %}" class="btn btn-outline-secondary px-4">
+                <i class="bi bi-x-circle me-2"></i>Cancel
+              </a>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/duty_roster/templates/duty_roster/surge_tow_retract_confirm.html
+++ b/duty_roster/templates/duty_roster/surge_tow_retract_confirm.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Retract Surge Tow Pilot Offer{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+  {% include "duty_roster/_messages.html" %}
+
+  <div class="row justify-content-center">
+    <div class="col-lg-6 col-md-8">
+      <div class="card shadow-sm border-0">
+        <div class="card-header text-white" style="background: linear-gradient(135deg, #fd7e14 0%, #ffc107 100%);">
+          <h4 class="mb-0">
+            <i class="bi bi-arrow-counterclockwise me-2"></i>
+            Retract Surge Tow Pilot Offer
+          </h4>
+        </div>
+
+        <div class="card-body p-4">
+          <div class="alert alert-warning d-flex align-items-start mb-4" role="alert">
+            <i class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2 mt-1"></i>
+            <div>
+              <strong>You are about to retract your surge tow pilot offer.</strong>
+              <div class="text-muted small mt-1">
+                {{ assignment.date|date:"l, F j, Y" }}
+              </div>
+            </div>
+          </div>
+
+          {% if assignment.tow_pilot %}
+          <p class="text-muted mb-4">
+            The primary tow pilot is
+            <strong>{{ assignment.tow_pilot.get_full_name|default:assignment.tow_pilot.username }}</strong>.
+            They will be notified after you confirm.
+          </p>
+          {% endif %}
+
+          <form method="post">
+            {% csrf_token %}
+            <div class="d-flex gap-2 flex-wrap">
+              <button type="submit" class="btn btn-warning px-4">
+                <i class="bi bi-check-circle-fill me-2"></i>Yes, Retract Offer
+              </button>
+              <a href="{% url 'duty_roster:duty_calendar' %}" class="btn btn-outline-secondary px-4">
+                <i class="bi bi-x-circle me-2"></i>Cancel
+              </a>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/duty_roster/tests/test_volunteer_surge_instructor.py
+++ b/duty_roster/tests/test_volunteer_surge_instructor.py
@@ -21,6 +21,7 @@ from django.urls import reverse
 from duty_roster.models import DutyAssignment, InstructionSlot
 from duty_roster.views import (
     _notify_primary_instructor_surge_filled,
+    _notify_primary_instructor_surge_withdrawn,
     _notify_surge_instructor_needed,
 )
 from siteconfig.models import SiteConfiguration
@@ -389,6 +390,102 @@ def test_post_already_assigned_does_not_overwrite(client, django_user_model):
 
 
 # ---------------------------------------------------------------------------
+# Retraction flow (Issue #801)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_retract_get_shows_confirmation_page(client, django_user_model):
+    """Assigned surge instructor GETs retraction confirmation page."""
+    primary = _make_member(django_user_model, "ret_get_primary", instructor=True)
+    surge = _make_member(django_user_model, "ret_get_surge", instructor=True)
+    assignment = _make_assignment(primary, date_offset=40)
+    assignment.surge_instructor = surge
+    assignment.save(update_fields=["surge_instructor"])
+
+    client.force_login(surge)
+    url = reverse(
+        "duty_roster:retract_surge_instructor",
+        kwargs={"assignment_id": assignment.id},
+    )
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert "Retract" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_retract_post_clears_surge_instructor(client, django_user_model):
+    """Assigned surge instructor can retract their own offer."""
+    _make_site_config()
+    primary = _make_member(
+        django_user_model, "ret_post_primary", instructor=True, email="rp@sky.org"
+    )
+    surge = _make_member(django_user_model, "ret_post_surge", instructor=True)
+    assignment = _make_assignment(primary, date_offset=41)
+    assignment.surge_instructor = surge
+    assignment.save(update_fields=["surge_instructor"])
+
+    client.force_login(surge)
+    url = reverse(
+        "duty_roster:retract_surge_instructor",
+        kwargs={"assignment_id": assignment.id},
+    )
+    with patch("duty_roster.views.send_mail") as mock_send:
+        mock_send.return_value = 1
+        response = client.post(url)
+
+    assert response.status_code == 302
+    assignment.refresh_from_db()
+    assert assignment.surge_instructor is None
+
+
+@pytest.mark.django_db
+def test_retract_post_forbidden_for_non_owner(client, django_user_model):
+    """Only the current surge instructor can retract the offer."""
+    primary = _make_member(django_user_model, "ret_forbid_primary", instructor=True)
+    surge = _make_member(django_user_model, "ret_forbid_surge", instructor=True)
+    other = _make_member(django_user_model, "ret_forbid_other", instructor=True)
+    assignment = _make_assignment(primary, date_offset=42)
+    assignment.surge_instructor = surge
+    assignment.save(update_fields=["surge_instructor"])
+
+    client.force_login(other)
+    url = reverse(
+        "duty_roster:retract_surge_instructor",
+        kwargs={"assignment_id": assignment.id},
+    )
+    response = client.post(url)
+
+    assert response.status_code == 403
+    assignment.refresh_from_db()
+    assert assignment.surge_instructor == surge
+
+
+@pytest.mark.django_db
+def test_retract_post_rejected_for_past_day(client, django_user_model):
+    """Cannot retract a surge offer for a past day."""
+    primary = _make_member(django_user_model, "ret_past_primary", instructor=True)
+    surge = _make_member(django_user_model, "ret_past_surge", instructor=True)
+    assignment = DutyAssignment.objects.create(
+        date=date.today() - timedelta(days=1),
+        instructor=primary,
+        surge_instructor=surge,
+    )
+
+    client.force_login(surge)
+    url = reverse(
+        "duty_roster:retract_surge_instructor",
+        kwargs={"assignment_id": assignment.id},
+    )
+    response = client.post(url)
+
+    assert response.status_code == 302
+    assignment.refresh_from_db()
+    assert assignment.surge_instructor == surge
+
+
+# ---------------------------------------------------------------------------
 # Auth guards
 # ---------------------------------------------------------------------------
 
@@ -568,3 +665,24 @@ def test_alert_email_context_includes_volunteer_url(django_user_model):
     # The HTML body should also contain the volunteer URL path
     html_body = mock_send.call_args.kwargs.get("html_message", "")
     assert "volunteer-surge" in html_body
+
+
+@pytest.mark.django_db
+def test_notify_primary_withdrawn_returns_true_on_success(django_user_model):
+    """Withdrawn-helper sends email to primary instructor and returns True."""
+    _make_site_config()
+    primary = _make_member(
+        django_user_model,
+        "nfw_primary",
+        instructor=True,
+        email="nfw_primary@sky.org",
+    )
+    withdrawn = _make_member(django_user_model, "nfw_withdrawn", instructor=True)
+    assignment = _make_assignment(primary, date_offset=95)
+
+    with patch("duty_roster.views.send_mail") as mock_send:
+        mock_send.return_value = 1
+        result = _notify_primary_instructor_surge_withdrawn(assignment, withdrawn)
+
+    assert result is True
+    mock_send.assert_called_once()

--- a/duty_roster/tests/test_volunteer_surge_tow_pilot.py
+++ b/duty_roster/tests/test_volunteer_surge_tow_pilot.py
@@ -20,7 +20,10 @@ import pytest
 from django.urls import reverse
 
 from duty_roster.models import DutyAssignment
-from duty_roster.views import _notify_primary_tow_pilot_surge_filled
+from duty_roster.views import (
+    _notify_primary_tow_pilot_surge_filled,
+    _notify_primary_tow_pilot_surge_withdrawn,
+)
 from siteconfig.models import SiteConfiguration
 
 # ---------------------------------------------------------------------------
@@ -353,6 +356,105 @@ def test_post_race_condition_guard(client, django_user_model):
 
 
 # ---------------------------------------------------------------------------
+# Retraction flow (Issue #801)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_retract_get_shows_confirmation_page(client, django_user_model):
+    """Assigned surge tow pilot GETs retraction confirmation page."""
+    primary = _make_member(django_user_model, "tp_ret_get_primary", towpilot=True)
+    surge = _make_member(django_user_model, "tp_ret_get_surge", towpilot=True)
+    assignment = _make_assignment(primary, date_offset=40)
+    assignment.surge_tow_pilot = surge
+    assignment.save(update_fields=["surge_tow_pilot"])
+
+    client.force_login(surge)
+    url = reverse(
+        "duty_roster:retract_surge_tow_pilot",
+        kwargs={"assignment_id": assignment.id},
+    )
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert "Retract" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_retract_post_clears_surge_tow_pilot(client, django_user_model):
+    """Assigned surge tow pilot can retract their own offer."""
+    _make_site_config()
+    primary = _make_member(
+        django_user_model,
+        "tp_ret_post_primary",
+        towpilot=True,
+        email="tp_ret_primary@sky.org",
+    )
+    surge = _make_member(django_user_model, "tp_ret_post_surge", towpilot=True)
+    assignment = _make_assignment(primary, date_offset=41)
+    assignment.surge_tow_pilot = surge
+    assignment.save(update_fields=["surge_tow_pilot"])
+
+    client.force_login(surge)
+    url = reverse(
+        "duty_roster:retract_surge_tow_pilot",
+        kwargs={"assignment_id": assignment.id},
+    )
+    with patch("duty_roster.views.send_mail") as mock_send:
+        mock_send.return_value = 1
+        response = client.post(url)
+
+    assert response.status_code == 302
+    assignment.refresh_from_db()
+    assert assignment.surge_tow_pilot is None
+
+
+@pytest.mark.django_db
+def test_retract_post_forbidden_for_non_owner(client, django_user_model):
+    """Only the assigned surge tow pilot can retract the offer."""
+    primary = _make_member(django_user_model, "tp_ret_forbid_primary", towpilot=True)
+    surge = _make_member(django_user_model, "tp_ret_forbid_surge", towpilot=True)
+    other = _make_member(django_user_model, "tp_ret_forbid_other", towpilot=True)
+    assignment = _make_assignment(primary, date_offset=42)
+    assignment.surge_tow_pilot = surge
+    assignment.save(update_fields=["surge_tow_pilot"])
+
+    client.force_login(other)
+    url = reverse(
+        "duty_roster:retract_surge_tow_pilot",
+        kwargs={"assignment_id": assignment.id},
+    )
+    response = client.post(url)
+
+    assert response.status_code == 403
+    assignment.refresh_from_db()
+    assert assignment.surge_tow_pilot == surge
+
+
+@pytest.mark.django_db
+def test_retract_post_rejected_for_past_day(client, django_user_model):
+    """Cannot retract a surge tow pilot offer for a past day."""
+    primary = _make_member(django_user_model, "tp_ret_past_primary", towpilot=True)
+    surge = _make_member(django_user_model, "tp_ret_past_surge", towpilot=True)
+    assignment = DutyAssignment.objects.create(
+        date=date.today() - timedelta(days=1),
+        tow_pilot=primary,
+        surge_tow_pilot=surge,
+    )
+
+    client.force_login(surge)
+    url = reverse(
+        "duty_roster:retract_surge_tow_pilot",
+        kwargs={"assignment_id": assignment.id},
+    )
+    response = client.post(url)
+
+    assert response.status_code == 302
+    assignment.refresh_from_db()
+    assert assignment.surge_tow_pilot == surge
+
+
+# ---------------------------------------------------------------------------
 # Authentication / 404
 # ---------------------------------------------------------------------------
 
@@ -463,3 +565,24 @@ def test_notify_helper_returns_false_when_surge_not_set(django_user_model):
 
     assert result is False
     mock_send.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_notify_withdrawn_helper_returns_true_on_success(django_user_model):
+    """Withdrawn-helper sends email to primary tow pilot and returns True."""
+    _make_site_config()
+    primary = _make_member(
+        django_user_model,
+        "tp_nw_primary",
+        towpilot=True,
+        email="tp_nw_primary@sky.org",
+    )
+    withdrawn = _make_member(django_user_model, "tp_nw_withdrawn", towpilot=True)
+    assignment = _make_assignment(primary, date_offset=75)
+
+    with patch("duty_roster.views.send_mail") as mock_send:
+        mock_send.return_value = 1
+        result = _notify_primary_tow_pilot_surge_withdrawn(assignment, withdrawn)
+
+    assert result is True
+    mock_send.assert_called_once()

--- a/duty_roster/urls.py
+++ b/duty_roster/urls.py
@@ -189,9 +189,19 @@ urlpatterns = [
         name="volunteer_surge_instructor",
     ),
     path(
+        "instruction/retract-surge/<int:assignment_id>/",
+        views.retract_surge_instructor,
+        name="retract_surge_instructor",
+    ),
+    path(
         "tow/volunteer-surge/<int:assignment_id>/",
         views.volunteer_as_surge_tow_pilot,
         name="volunteer_surge_tow_pilot",
+    ),
+    path(
+        "tow/retract-surge/<int:assignment_id>/",
+        views.retract_surge_tow_pilot,
+        name="retract_surge_tow_pilot",
     ),
     path(
         "volunteer-fill/<int:assignment_id>/<str:role>/",

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -3670,6 +3670,162 @@ def volunteer_as_surge_tow_pilot(request, assignment_id):
 
 
 @active_member_required
+@never_cache
+def retract_surge_instructor(request, assignment_id):
+    """Allow the assigned surge instructor to retract their own offer (Issue #801)."""
+    assignment = get_object_or_404(DutyAssignment, id=assignment_id)
+    member = request.user
+
+    if not member.instructor:
+        messages.error(
+            request,
+            "Only qualified instructors can retract a surge instructor offer.",
+        )
+        return redirect("duty_roster:duty_calendar")
+
+    if assignment.date < date.today():
+        messages.error(
+            request,
+            "Cannot retract a surge instructor offer for a past duty day.",
+        )
+        return redirect("duty_roster:duty_calendar")
+
+    if not assignment.surge_instructor_id:
+        messages.info(
+            request,
+            "There is no surge instructor assignment to retract for this day.",
+        )
+        return redirect("duty_roster:duty_calendar")
+
+    if assignment.surge_instructor_id != member.id:
+        return HttpResponseForbidden(
+            "Only the assigned surge instructor can retract this offer."
+        )
+
+    if request.method == "POST":
+        with transaction.atomic():
+            locked = DutyAssignment.objects.select_for_update().get(id=assignment_id)
+
+            if not locked.surge_instructor_id:
+                messages.info(
+                    request,
+                    "This surge instructor offer was already retracted.",
+                )
+                return redirect("duty_roster:duty_calendar")
+
+            if locked.surge_instructor_id != member.id:
+                return HttpResponseForbidden(
+                    "Only the assigned surge instructor can retract this offer."
+                )
+
+            withdrawn_instructor = locked.surge_instructor
+            locked.surge_instructor = None
+            locked.save(update_fields=["surge_instructor"])
+
+        notified = _notify_primary_instructor_surge_withdrawn(
+            locked, withdrawn_instructor
+        )
+        base_msg = (
+            f"You have retracted your surge instructor offer for "
+            f"{assignment.date.strftime('%B %d, %Y')}."
+        )
+        messages.success(
+            request,
+            (
+                base_msg + " The primary instructor has been notified."
+                if notified
+                else base_msg
+                + " The primary instructor could not be notified automatically."
+            ),
+        )
+        return redirect("duty_roster:duty_calendar")
+
+    return render(
+        request,
+        "duty_roster/surge_retract_confirm.html",
+        {"assignment": assignment},
+    )
+
+
+@active_member_required
+@never_cache
+def retract_surge_tow_pilot(request, assignment_id):
+    """Allow the assigned surge tow pilot to retract their own offer (Issue #801)."""
+    assignment = get_object_or_404(DutyAssignment, id=assignment_id)
+    member = request.user
+
+    if not getattr(member, "towpilot", False):
+        messages.error(
+            request,
+            "Only qualified tow pilots can retract a surge tow pilot offer.",
+        )
+        return redirect("duty_roster:duty_calendar")
+
+    if assignment.date < date.today():
+        messages.error(
+            request,
+            "Cannot retract a surge tow pilot offer for a past duty day.",
+        )
+        return redirect("duty_roster:duty_calendar")
+
+    if not assignment.surge_tow_pilot_id:
+        messages.info(
+            request,
+            "There is no surge tow pilot assignment to retract for this day.",
+        )
+        return redirect("duty_roster:duty_calendar")
+
+    if assignment.surge_tow_pilot_id != member.id:
+        return HttpResponseForbidden(
+            "Only the assigned surge tow pilot can retract this offer."
+        )
+
+    if request.method == "POST":
+        with transaction.atomic():
+            locked = DutyAssignment.objects.select_for_update().get(id=assignment_id)
+
+            if not locked.surge_tow_pilot_id:
+                messages.info(
+                    request,
+                    "This surge tow pilot offer was already retracted.",
+                )
+                return redirect("duty_roster:duty_calendar")
+
+            if locked.surge_tow_pilot_id != member.id:
+                return HttpResponseForbidden(
+                    "Only the assigned surge tow pilot can retract this offer."
+                )
+
+            withdrawn_tow_pilot = locked.surge_tow_pilot
+            locked.surge_tow_pilot = None
+            locked.save(update_fields=["surge_tow_pilot"])
+
+        notified = _notify_primary_tow_pilot_surge_withdrawn(
+            locked, withdrawn_tow_pilot
+        )
+        base_msg = (
+            f"You have retracted your surge tow pilot offer for "
+            f"{assignment.date.strftime('%B %d, %Y')}."
+        )
+        messages.success(
+            request,
+            (
+                base_msg + " The primary tow pilot has been notified."
+                if notified
+                else base_msg
+                + " The primary tow pilot could not be notified automatically."
+            ),
+        )
+        return redirect("duty_roster:duty_calendar")
+
+    return render(
+        request,
+        "duty_roster/surge_tow_retract_confirm.html",
+        {"assignment": assignment},
+    )
+
+
+@active_member_required
 @require_POST
 def assign_student_to_instructor(request, slot_id):
     """
@@ -4015,6 +4171,114 @@ def _notify_primary_tow_pilot_surge_filled(assignment):
     except Exception:
         logger.exception(
             "Failed to send surge-filled notification to primary tow pilot"
+        )
+        return False
+
+
+def _notify_primary_instructor_surge_withdrawn(assignment, withdrawn_instructor):
+    """Notify the primary instructor that the surge instructor has withdrawn."""
+    try:
+        primary = assignment.instructor
+        if not primary or not primary.email:
+            logger.warning(
+                "Primary instructor for assignment %s has no email; "
+                "surge-withdrawn notification suppressed",
+                assignment.id,
+            )
+            return False
+
+        if not withdrawn_instructor:
+            return False
+
+        email_config = get_email_config()
+        config = email_config["config"]
+
+        ops_date = assignment.date.strftime("%A, %B %d, %Y")
+        subject = (
+            f"Surge Instructor Withdrawn - {assignment.date.strftime('%B %d, %Y')}"
+        )
+
+        context = {
+            "ops_date": ops_date,
+            "primary_instructor": primary,
+            "withdrawn_instructor": withdrawn_instructor,
+            "roster_url": email_config["roster_url"],
+            "club_name": email_config["club_name"],
+            "club_logo_url": get_absolute_club_logo_url(config),
+        }
+
+        html_message = render_to_string(
+            "duty_roster/emails/surge_instructor_withdrawn.html", context
+        )
+        text_message = render_to_string(
+            "duty_roster/emails/surge_instructor_withdrawn.txt", context
+        )
+
+        sent_count = send_mail(
+            subject,
+            text_message,
+            email_config["from_email"],
+            [primary.email],
+            fail_silently=False,
+            html_message=html_message,
+        )
+        return sent_count > 0
+    except Exception:
+        logger.exception(
+            "Failed to send surge-withdrawn notification to primary instructor"
+        )
+        return False
+
+
+def _notify_primary_tow_pilot_surge_withdrawn(assignment, withdrawn_tow_pilot):
+    """Notify the primary tow pilot that the surge tow pilot has withdrawn."""
+    try:
+        primary = assignment.tow_pilot
+        if not primary or not primary.email:
+            logger.warning(
+                "Primary tow pilot for assignment %s has no email; "
+                "surge-withdrawn notification suppressed",
+                assignment.id,
+            )
+            return False
+
+        if not withdrawn_tow_pilot:
+            return False
+
+        email_config = get_email_config()
+        config = email_config["config"]
+
+        ops_date = assignment.date.strftime("%A, %B %d, %Y")
+        subject = f"Surge Tow Pilot Withdrawn - {assignment.date.strftime('%B %d, %Y')}"
+
+        context = {
+            "ops_date": ops_date,
+            "primary_tow_pilot": primary,
+            "withdrawn_tow_pilot": withdrawn_tow_pilot,
+            "roster_url": email_config["roster_url"],
+            "club_name": email_config["club_name"],
+            "club_logo_url": get_absolute_club_logo_url(config),
+        }
+
+        html_message = render_to_string(
+            "duty_roster/emails/surge_tow_pilot_withdrawn.html", context
+        )
+        text_message = render_to_string(
+            "duty_roster/emails/surge_tow_pilot_withdrawn.txt", context
+        )
+
+        sent_count = send_mail(
+            subject,
+            text_message,
+            email_config["from_email"],
+            [primary.email],
+            fail_silently=False,
+            html_message=html_message,
+        )
+        return sent_count > 0
+    except Exception:
+        logger.exception(
+            "Failed to send surge-withdrawn notification to primary tow pilot"
         )
         return False
 

--- a/e2e_tests/e2e/test_duty_roster_navigation.py
+++ b/e2e_tests/e2e/test_duty_roster_navigation.py
@@ -250,3 +250,43 @@ class TestDutyRosterNavigation(DjangoPlaywrightTestCase):
         assert (
             not agenda_content.is_visible()
         ), "Agenda view should remain hidden when guest navbar Calendar is selected"
+
+    def test_month_navigation_preserves_selected_view_mode(self):
+        """Next/previous month navigation should keep the currently selected view mode."""
+        self.create_test_member(
+            username="navpreserve",
+            email="navpreserve@example.com",
+            membership_status="Full Member",
+        )
+        self.login(username="navpreserve")
+
+        self.page.goto(f"{self.live_server_url}/duty_roster/calendar/")
+        self.page.wait_for_selector("#calendar-body")
+
+        # Switch to agenda and navigate forward one month.
+        self.page.locator('label[for="agenda-view"]').click()
+        self.page.wait_for_selector("#agenda-view-content", state="visible")
+        self.page.locator('button[title^="Go to"]').last.click()
+        self.page.wait_for_selector("#calendar-body")
+
+        agenda_content = self.page.locator("#agenda-view-content")
+        calendar_content = self.page.locator("#calendar-view-content")
+        assert (
+            agenda_content.is_visible()
+        ), "Agenda view should remain visible after month navigation"
+        assert (
+            not calendar_content.is_visible()
+        ), "Calendar view should remain hidden when agenda mode was selected"
+
+        # Switch back to calendar and navigate again; calendar must remain visible.
+        self.page.locator('label[for="calendar-view"]').click()
+        self.page.wait_for_selector("#calendar-view-content", state="visible")
+        self.page.locator('button[title^="Go to"]').last.click()
+        self.page.wait_for_selector("#calendar-body")
+
+        assert (
+            calendar_content.is_visible()
+        ), "Calendar view should remain visible after month navigation"
+        assert (
+            not agenda_content.is_visible()
+        ), "Agenda view should remain hidden when calendar mode was selected"

--- a/e2e_tests/e2e/test_surge_retraction.py
+++ b/e2e_tests/e2e/test_surge_retraction.py
@@ -1,0 +1,117 @@
+from datetime import date, timedelta
+
+from duty_roster.models import DutyAssignment
+from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+from siteconfig.models import SiteConfiguration
+
+
+class TestSurgeRetraction(DjangoPlaywrightTestCase):
+    def setUp(self):
+        super().setUp()
+        SiteConfiguration.objects.get_or_create(
+            defaults={
+                "club_name": "Test Soaring Club",
+                "club_abbreviation": "TSC",
+                "domain_name": "test.org",
+                "schedule_instructors": True,
+                "schedule_tow_pilots": True,
+            }
+        )
+
+    def test_modal_allows_surge_instructor_to_retract_offer(self):
+        primary = self.create_test_member(
+            username="surge_primary",
+            instructor=True,
+            membership_status="Full Member",
+        )
+        surge = self.create_test_member(
+            username="surge_volunteer",
+            instructor=True,
+            membership_status="Full Member",
+        )
+
+        target_day = date.today() + timedelta(days=10)
+        assignment = DutyAssignment.objects.create(
+            date=target_day,
+            instructor=primary,
+            surge_instructor=surge,
+        )
+
+        self.login(username="surge_volunteer")
+        self.page.goto(
+            f"{self.live_server_url}/duty_roster/calendar/{target_day.year}/{target_day.month}/"
+        )
+        self.page.wait_for_selector("#calendar-body")
+
+        day_cell = self.page.locator(
+            f'td[hx-get="/duty_roster/calendar/day/{target_day.year}/{target_day.month}/{target_day.day}/"]'
+        )
+        day_cell.first.click()
+
+        self.page.wait_for_selector("#modal-body")
+        retract_link = self.page.locator(
+            f'a[href="/duty_roster/instruction/retract-surge/{assignment.id}/"]'
+        )
+        assert retract_link.is_visible()
+
+        retract_link.click()
+        self.page.wait_for_url(
+            f"{self.live_server_url}/duty_roster/instruction/retract-surge/{assignment.id}/"
+        )
+        self.page.wait_for_selector("text=Retract Surge Instructor Offer")
+
+        self.page.get_by_role("button", name="Yes, Retract Offer").click()
+        self.page.wait_for_url(f"{self.live_server_url}/duty_roster/calendar/")
+        self.page.wait_for_selector("text=retracted your surge instructor offer")
+
+        assignment.refresh_from_db()
+        assert assignment.surge_instructor is None
+
+    def test_modal_allows_surge_tow_pilot_to_retract_offer(self):
+        primary = self.create_test_member(
+            username="surge_tow_primary",
+            towpilot=True,
+            membership_status="Full Member",
+        )
+        surge = self.create_test_member(
+            username="surge_tow_volunteer",
+            towpilot=True,
+            membership_status="Full Member",
+        )
+
+        target_day = date.today() + timedelta(days=11)
+        assignment = DutyAssignment.objects.create(
+            date=target_day,
+            tow_pilot=primary,
+            surge_tow_pilot=surge,
+        )
+
+        self.login(username="surge_tow_volunteer")
+        self.page.goto(
+            f"{self.live_server_url}/duty_roster/calendar/{target_day.year}/{target_day.month}/"
+        )
+        self.page.wait_for_selector("#calendar-body")
+
+        day_cell = self.page.locator(
+            f'td[hx-get="/duty_roster/calendar/day/{target_day.year}/{target_day.month}/{target_day.day}/"]'
+        )
+        day_cell.first.click()
+
+        self.page.wait_for_selector("#modal-body")
+        retract_link = self.page.locator(
+            f'a[href="/duty_roster/tow/retract-surge/{assignment.id}/"]'
+        )
+        assert retract_link.is_visible()
+
+        retract_link.click()
+        self.page.wait_for_url(
+            f"{self.live_server_url}/duty_roster/tow/retract-surge/{assignment.id}/"
+        )
+        self.page.wait_for_selector("text=Retract Surge Tow Pilot Offer")
+
+        self.page.get_by_role("button", name="Yes, Retract Offer").click()
+        self.page.wait_for_url(f"{self.live_server_url}/duty_roster/calendar/")
+        self.page.wait_for_selector("text=retracted your surge tow pilot offer")
+
+        assignment.refresh_from_db()
+        assert assignment.surge_tow_pilot is None


### PR DESCRIPTION
## Summary
- add self-service retraction for surge instructor and surge tow pilot offers (Issue #801)
- add guarded retraction endpoints with permission/date checks and atomic row locking
- add retract links in the calendar day modal for the assigned surge volunteer
- add dedicated retraction confirmation pages for instructor and tow pilot flows
- add email notifications to primary instructor/tow pilot when a surge volunteer retracts
- add regression tests for both retraction backends plus Playwright E2E modal flows

## What Changed
- Views and helpers:
  - `retract_surge_instructor`
  - `retract_surge_tow_pilot`
  - `_notify_primary_instructor_surge_withdrawn`
  - `_notify_primary_tow_pilot_surge_withdrawn`
- URLs:
  - `instruction/retract-surge/<int:assignment_id>/`
  - `tow/retract-surge/<int:assignment_id>/`
- Templates:
  - modal retract actions in `calendar_day_modal.html`
  - new confirm pages for instructor/tow retraction
  - new withdrawn email templates (html + txt)
- Tests:
  - expanded instructor/tow volunteer test modules with retraction coverage
  - new E2E: `e2e_tests/e2e/test_surge_retraction.py`

## Validation
- `pytest duty_roster/tests/test_volunteer_surge_instructor.py duty_roster/tests/test_volunteer_surge_tow_pilot.py e2e_tests/e2e/test_surge_retraction.py -q`
- Result: `52 passed`
