### PR TITLE
Issue #799: Add expired maintenance deadline warnings

### DIFF
--- a/duty_roster/management/commands/send_duty_preop_emails.py
+++ b/duty_roster/management/commands/send_duty_preop_emails.py
@@ -266,6 +266,15 @@ class Command(BaseCommand):
             towplane__isnull=False, grounded=True, resolved=False
         ).select_related("towplane")
 
+        # Get expired maintenance deadlines (already past due on target date)
+        expired_deadlines = (
+            MaintenanceDeadline.objects.filter(
+                due_date__lt=target_date,
+            )
+            .select_related("glider", "towplane")
+            .order_by("due_date")
+        )
+
         # Get upcoming maintenance deadlines (next 30 days from target date)
         upcoming_deadlines = (
             MaintenanceDeadline.objects.filter(
@@ -327,6 +336,7 @@ class Command(BaseCommand):
             # Maintenance
             "grounded_gliders": grounded_gliders,
             "grounded_towplanes": grounded_towplanes,
+            "expired_deadlines": expired_deadlines,
             "upcoming_deadlines": upcoming_deadlines,
         }
 

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -520,6 +520,7 @@
         <li>You must be an active member in good standing.</li>
         <li>You must have reservations remaining for the year.</li>
         <li>Glider availability and existing reservations still apply.</li>
+        <li>Aircraft may have overdue maintenance deadlines; review warnings before flying.</li>
       </ul>
 
       {% if reservation_enabled %}

--- a/duty_roster/templates/duty_roster/emails/preop_email.html
+++ b/duty_roster/templates/duty_roster/emails/preop_email.html
@@ -213,6 +213,35 @@
                     </tr>
                     {% endif %}
 
+                    {% if expired_deadlines %}
+                    <!-- Expired maintenance deadlines -->
+                    <tr>
+                        <td style="padding: 0 24px 16px 24px;">
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #fff5f5; border-radius: 6px; border-left: 6px solid #c53030;">
+                                <tr>
+                                    <td style="padding: 16px;">
+                                        <h2 style="margin: 0 0 12px 0; color: #9b2c2c; font-size: 18px; font-weight: 700;">
+                                            EXPIRED MAINTENANCE DEADLINES
+                                        </h2>
+                                        <p style="margin: 0 0 8px 0; color: #742a2a; font-size: 14px; font-weight: 600;">
+                                            The following aircraft have maintenance deadlines that are already past due:
+                                        </p>
+                                        <ul style="margin: 0; padding-left: 20px; color: #2d3748; font-size: 14px; line-height: 1.6;">
+                                            {% for deadline in expired_deadlines %}
+                                            <li>
+                                                <strong>{% firstof deadline.glider deadline.towplane "Unknown" %}</strong>
+                                                - {{ deadline.description_label }}
+                                                <span style="color: #9b2c2c; font-weight: 600;">(OVERDUE since {{ deadline.due_date|date:"M j, Y" }})</span>
+                                            </li>
+                                            {% endfor %}
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    {% endif %}
+
                     {% if upcoming_deadlines %}
                     <!-- Upcoming maintenance deadlines -->
                     <tr>
@@ -240,7 +269,7 @@
                     {% endif %}
 
                     <!-- No issues notice -->
-                    {% if not grounded_gliders and not grounded_towplanes and not upcoming_deadlines %}
+                    {% if not grounded_gliders and not grounded_towplanes and not expired_deadlines and not upcoming_deadlines %}
                     <tr>
                         <td style="padding: 0 24px 16px 24px;">
                             <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f0fff4; border-radius: 6px;">

--- a/duty_roster/templates/duty_roster/emails/preop_email.txt
+++ b/duty_roster/templates/duty_roster/emails/preop_email.txt
@@ -41,6 +41,11 @@ GROUNDED AIRCRAFT
 {% endfor %}{% endif %}{% else %}
 No grounded aircraft. All systems go!
 {% endif %}
+{% if expired_deadlines %}
+EXPIRED MAINTENANCE DEADLINES
+-----------------------------
+{% for deadline in expired_deadlines %}- {% firstof deadline.glider deadline.towplane "Unknown" %}: {{ deadline.description_label }} (OVERDUE since {{ deadline.due_date|date:"M j, Y" }})
+{% endfor %}{% endif %}
 {% if upcoming_deadlines %}
 MAINTENANCE DEADLINES (NEXT 30 DAYS)
 ------------------------------------

--- a/duty_roster/templates/duty_roster/emails/preop_email.txt
+++ b/duty_roster/templates/duty_roster/emails/preop_email.txt
@@ -39,7 +39,7 @@ GROUNDED AIRCRAFT
 {% endfor %}{% endif %}{% if grounded_towplanes %}Towplanes:
 {% for issue in grounded_towplanes %}- {{ issue.towplane }}: {{ issue.description }}
 {% endfor %}{% endif %}{% else %}
-No grounded aircraft. All systems go!
+{% if not expired_deadlines and not upcoming_deadlines %}No grounded aircraft. All systems go!{% else %}No grounded aircraft.{% endif %}
 {% endif %}
 {% if expired_deadlines %}
 EXPIRED MAINTENANCE DEADLINES

--- a/duty_roster/templates/duty_roster/reservations/create.html
+++ b/duty_roster/templates/duty_roster/reservations/create.html
@@ -33,6 +33,20 @@
               </div>
             {% endif %}
 
+            {% if selected_glider_expired_deadlines %}
+              <div class="alert alert-warning" role="alert">
+                <strong>Maintenance warning:</strong>
+                <span>
+                  {{ selected_glider }} has expired maintenance deadlines.
+                </span>
+                <ul class="mb-0 mt-2">
+                  {% for deadline in selected_glider_expired_deadlines %}
+                    <li>{{ deadline.description_label }} (overdue since {{ deadline.due_date|date:"M j, Y" }})</li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% endif %}
+
             <div class="mb-3">
               <label for="id_date" class="form-label">Date <span class="text-danger">*</span></label>
               {{ form.date }}
@@ -143,6 +157,9 @@
                   {% if glider.id in grounded_glider_ids %}
                     <span class="badge bg-danger">Grounded</span>
                   {% endif %}
+                  {% if glider.id in expired_deadline_glider_ids %}
+                    <span class="badge bg-warning text-dark">Deadline Overdue</span>
+                  {% endif %}
                 </li>
               {% endfor %}
             </ul>
@@ -162,6 +179,7 @@
             <li>Reservations are for fun flying only (solo, badge flights, guest flying).</li>
             <li>Maximum of <strong>{{ max_per_year }}</strong> reservations per year{% if max_per_year == 0 %} (unlimited){% endif %}.</li>
             <li>Grounded aircraft cannot be reserved.</li>
+            <li>Expired maintenance deadlines may still allow reservation but require operations review.</li>
             <li>Please cancel promptly if your plans change.</li>
             <li>The duty officer may contact you on the day of your reservation.</li>
           </ul>

--- a/duty_roster/tests/test_glider_reservations.py
+++ b/duty_roster/tests/test_glider_reservations.py
@@ -19,7 +19,7 @@ from django.utils import timezone
 
 from duty_roster.forms import GliderReservationForm
 from duty_roster.models import GliderReservation
-from logsheet.models import Glider, MaintenanceIssue
+from logsheet.models import Glider, MaintenanceDeadline, MaintenanceIssue
 from siteconfig.models import SiteConfiguration
 
 
@@ -484,6 +484,27 @@ class TestGliderReservationValidation:
             reservation.clean()
         assert "reserved for the full day" in str(exc_info.value).lower()
 
+    def test_allows_reservation_with_expired_maintenance_deadline_warning_only(
+        self, site_config, member, glider, future_date
+    ):
+        """Expired deadlines should not hard-block reservations."""
+        MaintenanceDeadline.objects.create(
+            glider=glider,
+            description="annual",
+            due_date=timezone.now().date() - timedelta(days=1),
+        )
+
+        reservation = GliderReservation(
+            member=member,
+            glider=glider,
+            date=future_date,
+            reservation_type="solo",
+            time_preference="morning",
+        )
+
+        # Should not raise; policy is warning-only.
+        reservation.clean()
+
 
 class TestGliderReservationForm:
     """Tests for the reservation form."""
@@ -646,6 +667,34 @@ class TestGliderReservationViews:
         response = client.get(url)
         # Should redirect with message
         assert response.status_code == 302
+
+    def test_reservation_create_shows_warning_for_expired_deadline(
+        self, client, site_config, member, glider, future_date
+    ):
+        """Reservation succeeds but shows warning when glider has expired deadlines."""
+        MaintenanceDeadline.objects.create(
+            glider=glider,
+            description="annual",
+            due_date=timezone.now().date() - timedelta(days=3),
+        )
+
+        client.force_login(member)
+        url = reverse("duty_roster:reservation_create")
+        response = client.post(
+            url,
+            {
+                "glider": glider.pk,
+                "date": future_date.isoformat(),
+                "reservation_type": "solo",
+                "time_preference": "morning",
+            },
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        assert GliderReservation.objects.filter(member=member, glider=glider).exists()
+        content = response.content.decode("utf-8")
+        assert "expired maintenance deadlines" in content.lower()
 
     def test_reservation_form_blocks_monthly_limit(
         self, site_config, member, glider, future_date

--- a/duty_roster/tests/test_preop_emails.py
+++ b/duty_roster/tests/test_preop_emails.py
@@ -277,7 +277,7 @@ class TestSendDutyPreopEmails:
 
         assert "Members Planning to Fly" in html_content
         assert "Pete Private" in html_content
-        assert "Private glider" in html_content
+        assert "Fly Private Glider" in html_content
 
     @override_settings(
         EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
@@ -345,6 +345,39 @@ class TestSendDutyPreopEmails:
 
         assert "Maintenance Deadlines" in html_content
         assert "Annual inspection" in html_content
+
+    @override_settings(
+        EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+        EMAIL_DEV_MODE=False,
+        DEFAULT_FROM_EMAIL="noreply@test.com",
+        SITE_URL="https://test.manage2soar.com",
+    )
+    def test_includes_expired_maintenance_deadline_warning(
+        self, site_config, duty_assignment, glider, tomorrow
+    ):
+        """Expired maintenance deadlines should be highlighted separately."""
+        MaintenanceDeadline.objects.create(
+            glider=glider,
+            description="annual",
+            due_date=tomorrow - timedelta(days=40),
+        )
+
+        out = StringIO()
+        call_command(
+            "send_duty_preop_emails",
+            date=tomorrow.strftime("%Y-%m-%d"),
+            stdout=out,
+        )
+
+        email = mail.outbox[0]
+        html_content = email.alternatives[0][0]
+        text_content = email.body
+
+        assert "EXPIRED MAINTENANCE DEADLINES" in html_content
+        assert "OVERDUE since" in html_content
+        assert "Annual Inspection" in html_content
+        assert "EXPIRED MAINTENANCE DEADLINES" in text_content
+        assert "OVERDUE since" in text_content
 
     @override_settings(
         EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",

--- a/duty_roster/views_reservation.py
+++ b/duty_roster/views_reservation.py
@@ -173,7 +173,9 @@ def reservation_create(request, year=None, month=None, day=None):
         MaintenanceDeadline.objects.filter(
             glider__in=available_gliders,
             due_date__lt=timezone.now().date(),
-        ).values_list("glider_id", flat=True)
+        )
+        .values_list("glider_id", flat=True)
+        .distinct()
     )
 
     selected_glider = None

--- a/duty_roster/views_reservation.py
+++ b/duty_roster/views_reservation.py
@@ -112,6 +112,23 @@ def reservation_create(request, year=None, month=None, day=None):
             reservation = form.save()
             # Check if save was actually successful (form.save() may add errors without raising)
             if reservation.pk:
+                expired_deadlines = []
+                if reservation.glider:
+                    expired_deadlines = list(
+                        reservation.glider.get_expired_maintenance_deadlines()
+                    )
+
+                if expired_deadlines:
+                    overdue_items = ", ".join(
+                        f"{d.description_label} (due {d.due_date:%b %d, %Y})"
+                        for d in expired_deadlines
+                    )
+                    messages.warning(
+                        request,
+                        "Warning: this aircraft has expired maintenance deadlines: "
+                        f"{overdue_items}. Please confirm with operations staff before flying.",
+                    )
+
                 # Defensive programming: ensure glider exists before displaying
                 glider_display = (
                     str(reservation.glider) if reservation.glider else "Unknown glider"
@@ -141,8 +158,8 @@ def reservation_create(request, year=None, month=None, day=None):
     # Get available gliders for display (use the same queryset as the form to ensure consistency)
     available_gliders = form.fields["glider"].queryset
 
-    # Prefetch grounded status to avoid N+1 queries in template
-    from logsheet.models import MaintenanceIssue
+    # Prefetch grounded/expired status to avoid N+1 queries in template
+    from logsheet.models import MaintenanceDeadline, MaintenanceIssue
 
     grounded_glider_ids = set(
         MaintenanceIssue.objects.filter(
@@ -152,10 +169,38 @@ def reservation_create(request, year=None, month=None, day=None):
         ).values_list("glider_id", flat=True)
     )
 
+    expired_deadline_glider_ids = set(
+        MaintenanceDeadline.objects.filter(
+            glider__in=available_gliders,
+            due_date__lt=timezone.now().date(),
+        ).values_list("glider_id", flat=True)
+    )
+
+    selected_glider = None
+    selected_glider_expired_deadlines = []
+    selected_glider_id = (
+        request.POST.get("glider") if request.method == "POST" else None
+    )
+    if selected_glider_id:
+        try:
+            selected_glider = available_gliders.filter(
+                pk=int(selected_glider_id)
+            ).first()
+        except (TypeError, ValueError):
+            selected_glider = None
+
+    if selected_glider:
+        selected_glider_expired_deadlines = list(
+            selected_glider.get_expired_maintenance_deadlines()
+        )
+
     context = {
         "form": form,
         "available_gliders": available_gliders,
         "grounded_glider_ids": grounded_glider_ids,
+        "expired_deadline_glider_ids": expired_deadline_glider_ids,
+        "selected_glider": selected_glider,
+        "selected_glider_expired_deadlines": selected_glider_expired_deadlines,
         "max_per_year": config.max_reservations_per_year,
     }
 

--- a/e2e_tests/e2e/test_glider_reservation_deadline_warning.py
+++ b/e2e_tests/e2e/test_glider_reservation_deadline_warning.py
@@ -10,15 +10,22 @@ from siteconfig.models import SiteConfiguration
 class TestGliderReservationDeadlineWarning(DjangoPlaywrightTestCase):
     def setUp(self):
         super().setUp()
-        SiteConfiguration.objects.get_or_create(
+        config, _ = SiteConfiguration.objects.get_or_create(
             defaults={
                 "club_name": "Test Soaring Club",
                 "club_abbreviation": "TSC",
                 "domain_name": "test.org",
-                "allow_glider_reservations": True,
-                "allow_two_seater_reservations": True,
-                "max_reservations_per_year": 3,
             }
+        )
+        config.allow_glider_reservations = True
+        config.allow_two_seater_reservations = True
+        config.max_reservations_per_year = 3
+        config.save(
+            update_fields=[
+                "allow_glider_reservations",
+                "allow_two_seater_reservations",
+                "max_reservations_per_year",
+            ]
         )
 
     def test_reservation_succeeds_with_expired_deadline_warning(self):

--- a/e2e_tests/e2e/test_glider_reservation_deadline_warning.py
+++ b/e2e_tests/e2e/test_glider_reservation_deadline_warning.py
@@ -1,0 +1,61 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+from logsheet.models import DeadlineType, Glider, MaintenanceDeadline
+from siteconfig.models import SiteConfiguration
+
+
+class TestGliderReservationDeadlineWarning(DjangoPlaywrightTestCase):
+    def setUp(self):
+        super().setUp()
+        SiteConfiguration.objects.get_or_create(
+            defaults={
+                "club_name": "Test Soaring Club",
+                "club_abbreviation": "TSC",
+                "domain_name": "test.org",
+                "allow_glider_reservations": True,
+                "allow_two_seater_reservations": True,
+                "max_reservations_per_year": 3,
+            }
+        )
+
+    def test_reservation_succeeds_with_expired_deadline_warning(self):
+        member = self.create_test_member(
+            username="deadline_warning_user",
+            email="deadline_warning_user@example.com",
+            membership_status="Full Member",
+        )
+
+        glider = Glider.objects.create(
+            make="Schleicher",
+            model="ASK-21",
+            n_number="N99001",
+            competition_number="DW",
+            seats=2,
+            is_active=True,
+            club_owned=True,
+        )
+
+        MaintenanceDeadline.objects.create(
+            glider=glider,
+            description=DeadlineType.ANNUAL,
+            due_date=timezone.now().date() - timedelta(days=10),
+        )
+
+        target_date = timezone.now().date() + timedelta(days=7)
+
+        self.login(username=member.username)
+        self.page.goto(f"{self.live_server_url}/duty_roster/reservations/create/")
+        self.page.wait_for_selector("h5:has-text('New Reservation')")
+
+        self.page.fill('input[name="date"]', target_date.isoformat())
+        self.page.select_option('select[name="glider"]', str(glider.pk))
+        self.page.select_option('select[name="reservation_type"]', "solo")
+        self.page.select_option('select[name="time_preference"]', "morning")
+        self.page.get_by_role("button", name="Confirm Reservation").click()
+
+        self.page.wait_for_url(f"{self.live_server_url}/duty_roster/reservations/")
+        self.page.wait_for_selector("text=expired maintenance deadlines")
+        self.page.wait_for_selector(f"text={glider}")

--- a/logsheet/models.py
+++ b/logsheet/models.py
@@ -683,6 +683,21 @@ class Glider(models.Model):
             glider=self, grounded=True, resolved=False
         ).exists()
 
+    @property
+    def has_expired_maintenance_deadlines(self):
+        """Return True if this glider has any maintenance deadlines already past due."""
+        return MaintenanceDeadline.objects.filter(
+            glider=self,
+            due_date__lt=date.today(),
+        ).exists()
+
+    def get_expired_maintenance_deadlines(self):
+        """Return expired maintenance deadlines ordered oldest-first."""
+        return MaintenanceDeadline.objects.filter(
+            glider=self,
+            due_date__lt=date.today(),
+        ).order_by("due_date")
+
     def get_active_issues(self):
         return MaintenanceIssue.objects.filter(glider=self, resolved=False)
 

--- a/logsheet/models.py
+++ b/logsheet/models.py
@@ -5,6 +5,7 @@ from decimal import ROUND_HALF_UP, Decimal
 from django.conf import settings
 from django.core.validators import MinValueValidator
 from django.db import models
+from django.utils import timezone
 from tinymce.models import HTMLField
 
 from members.models import Member
@@ -688,14 +689,14 @@ class Glider(models.Model):
         """Return True if this glider has any maintenance deadlines already past due."""
         return MaintenanceDeadline.objects.filter(
             glider=self,
-            due_date__lt=date.today(),
+            due_date__lt=timezone.localdate(),
         ).exists()
 
     def get_expired_maintenance_deadlines(self):
         """Return expired maintenance deadlines ordered oldest-first."""
         return MaintenanceDeadline.objects.filter(
             glider=self,
-            due_date__lt=date.today(),
+            due_date__lt=timezone.localdate(),
         ).order_by("due_date")
 
     def get_active_issues(self):


### PR DESCRIPTION
## Summary
- surface expired maintenance deadlines in pre-ops emails with a dedicated high-visibility warning section
- preserve existing upcoming maintenance deadline reporting (next 30 days)
- implement warning-only reservation UX for gliders with expired maintenance deadlines (no hard block)
- add reservation UI cues for overdue deadlines and a day-modal requirements hint
- add regression coverage for pre-op email output, reservation behavior, and E2E warning flow

## What Changed
- pre-op command context now includes `expired_deadlines` in addition to `upcoming_deadlines`
- pre-op HTML/text templates now render an explicit expired-deadline section
- glider model now exposes helpers for expired deadline checks
- reservation create flow now warns users after successful booking when selected glider has overdue deadlines
- reservation create template shows overdue badges and inline warning details for selected glider
- calendar day modal reserve panel includes maintenance-warning guidance

## Validation
- `pytest duty_roster/tests/test_preop_emails.py duty_roster/tests/test_glider_reservations.py e2e_tests/e2e/test_glider_reservation_deadline_warning.py -q`
- Result: `68 passed`
