### PR TITLE
Harden GKE deploy exec steps with retry policy

### DIFF
--- a/infrastructure/ansible/roles/gke-deploy/defaults/main.yml
+++ b/infrastructure/ansible/roles/gke-deploy/defaults/main.yml
@@ -238,6 +238,12 @@ gke_run_migrations: false
 # The cost and time overhead is minimal (~10s); the risk of skipping is a broken site.
 gke_collect_static: true
 
+# Retry policy for kubectl exec management commands (migrate/collectstatic).
+# This helps absorb transient failures such as rc=137 when a selected pod is
+# terminated during rollout completion or rescheduling.
+gke_management_command_retries: 3
+gke_management_command_retry_delay: 10
+
 # Keep generated manifest files for debugging (default: clean up after deployment)
 gke_keep_manifests: false
 

--- a/infrastructure/ansible/roles/gke-deploy/tasks/deploy.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/deploy.yml
@@ -141,6 +141,9 @@
   run_once: true
   when: gke_run_migrations | bool
   register: migrate_result
+  retries: "{{ gke_management_command_retries | int }}"
+  delay: "{{ gke_management_command_retry_delay | int }}"
+  until: migrate_result.rc == 0
 
 - name: Display migration result
   ansible.builtin.debug:
@@ -164,6 +167,9 @@
   run_once: true
   when: gke_collect_static | bool
   register: collectstatic_result
+  retries: "{{ gke_management_command_retries | int }}"
+  delay: "{{ gke_management_command_retry_delay | int }}"
+  until: collectstatic_result.rc == 0
 
 - name: Display collectstatic result
   ansible.builtin.debug:


### PR DESCRIPTION
## Summary
- add configurable retry settings for management commands in the gke-deploy role defaults
- apply retry and delay handling to migrate and collectstatic kubectl exec steps
- keep behavior unchanged on success, but improve resilience against transient pod termination during rollout

## Why
Collectstatic failed with exit code 137 during deployment. This commonly occurs when the target pod is terminated while kubectl exec is running. Retrying the command improves deployment reliability without requiring manual reruns.

## Validation
- ansible playbook syntax check passed for playbooks/gcp-app-deploy.yml