### PR TITLE
Issue #828: Improve written test assignment visibility

### DIFF
--- a/knowledgetest/templates/written_test/emails/written_test_assigned.html
+++ b/knowledgetest/templates/written_test/emails/written_test_assigned.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Written Test Assigned</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f4;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        <tr>
+            <td align="center" style="padding: 20px 0;">
+                <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; overflow: hidden;">
+                    <tr>
+                        <td style="background-color: #667eea; padding: 30px 40px; text-align: center;">
+                            {% if club_logo_url %}
+                            <img src="{{ club_logo_url }}" alt="{{ club_name }}" style="max-height: 60px; max-width: 200px; height: auto; margin-bottom: 15px;">
+                            {% endif %}
+                            <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: bold;">📝 New Written Test Assigned</h1>
+                            <p style="margin: 10px 0 0 0; color: #e0e0e0; font-size: 15px;">{{ club_name }}</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 32px 40px; color: #4a5568; font-size: 16px; line-height: 1.6;">
+                            <p style="margin-top: 0;">Hi {{ student_name }},</p>
+                            <p>You have been assigned a written test by {{ assigned_by }}.</p>
+                            <p style="margin-bottom: 6px;"><strong>Test:</strong> {{ test_name }}</p>
+                            {% if test_description %}
+                            <p style="margin-top: 0;"><strong>Description:</strong> {{ test_description }}</p>
+                            {% endif %}
+                            <p style="margin: 24px 0; text-align: center;">
+                                <a href="{{ pending_tests_url }}" style="display: inline-block; background-color: #667eea; color: #ffffff; text-decoration: none; padding: 12px 28px; border-radius: 4px; font-weight: bold;">Open Pending Tests</a>
+                            </p>
+                            <p style="margin-bottom: 0;">Please complete the test when you are ready.</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="background-color: #f4f4f4; padding: 20px; text-align: center;">
+                            <p style="margin: 0; color: #666666; font-size: 12px;">This is an automated message from {{ club_name }}.</p>
+                            <p style="margin: 6px 0 0 0; color: #666666; font-size: 12px;">{{ site_url }}</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/knowledgetest/templates/written_test/emails/written_test_assigned.txt
+++ b/knowledgetest/templates/written_test/emails/written_test_assigned.txt
@@ -1,0 +1,15 @@
+{{ club_name }} - New Written Test Assigned
+
+Hi {{ student_name }},
+
+You have been assigned a written test by {{ assigned_by }}.
+
+Test: {{ test_name }}
+{% if test_description %}Description: {{ test_description }}
+{% endif %}Open your pending tests here:
+{{ pending_tests_url }}
+
+Please complete the test when you are ready.
+
+This is an automated message from {{ club_name }}.
+{{ site_url }}

--- a/knowledgetest/templates/written_test/instructor_recent.html
+++ b/knowledgetest/templates/written_test/instructor_recent.html
@@ -15,7 +15,7 @@
 
   <!-- Summary Stats -->
   <div class="row mb-4">
-    <div class="col-md-4">
+    <div class="col-md-3">
       <div class="card bg-info text-white">
         <div class="card-body text-center">
           <h3 class="mb-0">{{ total_recent }}</h3>
@@ -23,7 +23,7 @@
         </div>
       </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
       <div class="card bg-success text-white">
         <div class="card-body text-center">
           <h3 class="mb-0">{{ recent_passed }}</h3>
@@ -31,7 +31,7 @@
         </div>
       </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
       <div class="card bg-danger text-white">
         <div class="card-body text-center">
           <h3 class="mb-0">{{ recent_failed }}</h3>
@@ -39,6 +39,96 @@
         </div>
       </div>
     </div>
+    <div class="col-md-3">
+      <div class="card bg-warning text-dark">
+        <div class="card-body text-center">
+          <h3 class="mb-0">{{ assigned_pending_recent }}</h3>
+          <small>Assigned, Not Yet Taken</small>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Assigned But Not Yet Taken -->
+  <div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <h5 class="mb-0">Assigned Tests Not Yet Taken</h5>
+      <small class="text-muted">Follow-up queue ({{ period_days }} days)</small>
+    </div>
+    <div class="card-body py-2 border-bottom bg-light">
+      <small class="text-muted d-flex flex-wrap gap-3">
+        <span><span class="badge bg-warning text-dark">⏳ 8-14 days</span> Follow up soon</span>
+        <span><span class="badge bg-danger">⚠ 15+ days</span> Needs attention now</span>
+      </small>
+    </div>
+    {% if assigned_pending_tests %}
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-hover mb-0">
+            <thead class="table-light">
+              <tr>
+                <th>Assigned Date</th>
+                <th>Student</th>
+                <th>Membership Status</th>
+                <th>Test Name</th>
+                <th>Assigned By</th>
+                <th>Days Pending</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for assignment in assigned_pending_tests %}
+                <tr class="{% if assignment.days_pending > 14 %}pending-row-urgent{% elif assignment.days_pending > 7 %}pending-row-soon{% endif %}">
+                  <td>
+                    <div class="fw-bold">{{ assignment.assigned_at|date:"M j" }}</div>
+                    <small class="text-muted">{{ assignment.assigned_at|date:"g:i A" }}</small>
+                  </td>
+                  <td>
+                    <div class="fw-bold">{{ assignment.student.full_display_name }}</div>
+                  </td>
+                  <td>
+                    <small class="text-muted">{{ assignment.student.membership_status|default:"Member" }}</small>
+                  </td>
+                  <td>
+                    <div class="fw-bold">{{ assignment.template.name }}</div>
+                    {% if assignment.template.description %}
+                      <small class="text-muted d-block">{{ assignment.template.description|truncatechars:40 }}</small>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if assignment.instructor %}
+                      {{ assignment.instructor.full_display_name }}
+                    {% else %}
+                      <em class="text-muted">Unknown</em>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if assignment.days_pending > 14 %}
+                      <span class="badge bg-danger">⚠ {{ assignment.days_pending }} days</span>
+                    {% elif assignment.days_pending > 7 %}
+                      <span class="badge bg-warning text-dark">⏳ {{ assignment.days_pending }} days</span>
+                    {% else %}
+                      <span class="badge bg-secondary">{{ assignment.days_pending }} days</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    <a href="{% url 'instructors:member_instruction_record' assignment.student.pk %}"
+                       class="btn btn-outline-secondary btn-sm"
+                       title="View student's instruction record">
+                      📘 Record
+                    </a>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    {% else %}
+      <div class="card-body">
+        <p class="mb-0 text-muted">No assigned written tests are currently pending in the last {{ period_days }} days.</p>
+      </div>
+    {% endif %}
   </div>
 
   {% if attempts %}
@@ -178,6 +268,16 @@
 .table-warning {
     --bs-table-bg: #fff3cd;
     --bs-table-striped-bg: #ffecb5;
+}
+
+.pending-row-soon {
+  --bs-table-bg: #fff7e6;
+  --bs-table-striped-bg: #ffefcf;
+}
+
+.pending-row-urgent {
+  --bs-table-bg: #fdecec;
+  --bs-table-striped-bg: #fbdede;
 }
 </style>
 {% endblock %}

--- a/knowledgetest/tests.py
+++ b/knowledgetest/tests.py
@@ -1,8 +1,11 @@
 import json
+from datetime import timedelta
 
 from django.contrib.auth import get_user_model
+from django.core import mail
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.utils import timezone
 
 from instructors.models import InstructionReport
 from knowledgetest.models import (
@@ -609,6 +612,7 @@ class TestPresetViewIntegrationTests(TestCase):
             username="integration-student",
             password="pass",
             membership_status="Full Member",
+            email="integration-student@example.com",
         )
 
     def test_get_presets_function(self):
@@ -675,6 +679,7 @@ class TestPresetViewIntegrationTests(TestCase):
 
     def test_create_self_practice_skips_assignment_and_notification(self):
         self.client.login(username="testuser", password="pass")
+        mail.outbox = []
         if Notification is not None:
             Notification.objects.all().delete()
 
@@ -700,9 +705,11 @@ class TestPresetViewIntegrationTests(TestCase):
         )
         if Notification is not None:
             self.assertFalse(Notification.objects.filter(user=self.user).exists())
+        self.assertEqual(len(mail.outbox), 0)
 
     def test_create_assigned_member_creates_assignment_and_notification(self):
         self.client.login(username="testuser", password="pass")
+        mail.outbox = []
         if Notification is not None:
             Notification.objects.all().delete()
 
@@ -735,3 +742,138 @@ class TestPresetViewIntegrationTests(TestCase):
                     message__icontains="assigned a new written test",
                 ).exists()
             )
+
+        self.assertEqual(len(mail.outbox), 1)
+        sent = mail.outbox[0]
+        # EMAIL_DEV_MODE can redirect recipients in staging-like test configs.
+        self.assertTrue(
+            self.other_member.email in sent.to
+            or self.other_member.email in sent.subject
+        )
+        self.assertIn("New Written Test Assigned", sent.subject)
+        self.assertIn("Open Pending Tests", sent.alternatives[0][0])
+
+
+class InstructorRecentTestsViewTests(TestCase):
+    def setUp(self):
+        self.instructor = User.objects.create_user(
+            username="recent-instructor",
+            password="pass",
+            membership_status="Full Member",
+        )
+        self.student = User.objects.create_user(
+            username="recent-student",
+            password="pass",
+            membership_status="Student Member",
+        )
+        self.other_student = User.objects.create_user(
+            username="recent-student-2",
+            password="pass",
+            membership_status="Full Member",
+        )
+
+        # Instructor access gate relies on at least one instruction report.
+        InstructionReport.objects.create(
+            student=self.student,
+            instructor=self.instructor,
+            report_date=timezone.localdate(),
+            report_text="Gate access report",
+        )
+
+        category = QuestionCategory.objects.create(code="RVT", description="Recent")
+        question = Question.objects.create(
+            qnum=9101,
+            category=category,
+            question_text="Recent test question?",
+            option_a="A",
+            option_b="B",
+            option_c="C",
+            option_d="D",
+            correct_answer="A",
+        )
+
+        self.template = WrittenTestTemplate.objects.create(
+            name="Recent Template",
+            pass_percentage=70,
+            created_by=self.instructor,
+        )
+        self.template.questions.add(question, through_defaults={"order": 1})
+
+        # One passed and one failed attempt (used by existing summary cards)
+        WrittenTestAttempt.objects.create(
+            template=self.template,
+            student=self.student,
+            instructor=self.instructor,
+            score_percentage=90,
+            passed=True,
+        )
+        WrittenTestAttempt.objects.create(
+            template=self.template,
+            student=self.other_student,
+            instructor=self.instructor,
+            score_percentage=40,
+            passed=False,
+        )
+
+        # In-window pending assignment
+        self.pending_assignment = WrittenTestAssignment.objects.create(
+            template=self.template,
+            student=self.student,
+            instructor=self.instructor,
+            completed=False,
+        )
+
+        # Completed assignment should not appear in pending table
+        WrittenTestAssignment.objects.create(
+            template=WrittenTestTemplate.objects.create(
+                name="Completed Assignment Template",
+                pass_percentage=70,
+                created_by=self.instructor,
+            ),
+            student=self.other_student,
+            instructor=self.instructor,
+            completed=True,
+        )
+
+        # Old pending assignment should be excluded by 30-day window
+        old_assignment = WrittenTestAssignment.objects.create(
+            template=WrittenTestTemplate.objects.create(
+                name="Old Assignment Template",
+                pass_percentage=70,
+                created_by=self.instructor,
+            ),
+            student=self.other_student,
+            instructor=self.instructor,
+            completed=False,
+        )
+        WrittenTestAssignment.objects.filter(pk=old_assignment.pk).update(
+            assigned_at=timezone.now() - timedelta(days=45)
+        )
+
+        self.client.login(username="recent-instructor", password="pass")
+
+    def test_instructor_recent_context_includes_pending_assignment_metrics(self):
+        response = self.client.get(reverse("knowledgetest:instructor-recent-tests"))
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.context["total_recent"], 2)
+        self.assertEqual(response.context["recent_passed"], 1)
+        self.assertEqual(response.context["recent_failed"], 1)
+        self.assertEqual(response.context["assigned_pending_recent"], 1)
+
+        pending = list(response.context["assigned_pending_tests"])
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0].pk, self.pending_assignment.pk)
+        self.assertGreaterEqual(pending[0].days_pending, 0)
+
+    def test_pending_table_renders_above_recent_completions(self):
+        response = self.client.get(reverse("knowledgetest:instructor-recent-tests"))
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode("utf-8")
+        self.assertIn("Assigned Tests Not Yet Taken", content)
+        self.assertIn("Recent Test Completions", content)
+        self.assertTrue(
+            content.index("Assigned Tests Not Yet Taken")
+            < content.index("Recent Test Completions")
+        )

--- a/knowledgetest/views.py
+++ b/knowledgetest/views.py
@@ -1,11 +1,14 @@
 import json
 import logging
+from datetime import timedelta
 
+from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.http import HttpResponseForbidden, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404, redirect, render
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -25,7 +28,9 @@ from knowledgetest.models import (
     WrittenTestTemplateQuestion,
 )
 from members.decorators import active_member_required
-from utils.url_helpers import build_absolute_url
+from utils.email import send_mail
+from utils.email_helpers import get_absolute_club_logo_url
+from utils.url_helpers import build_absolute_url, get_canonical_url
 
 try:
     from notifications.models import Notification
@@ -36,6 +41,61 @@ except ImportError:
     Notification = None
 
 logger = logging.getLogger(__name__)
+
+
+def _get_site_config():
+    from siteconfig.models import SiteConfiguration
+
+    return SiteConfiguration.objects.first()
+
+
+def _send_written_test_assignment_email(assignment):
+    """Send student-facing email when a written test is assigned."""
+    student_email = getattr(assignment.student, "email", None)
+    if not student_email:
+        return
+
+    config = _get_site_config()
+    site_url = get_canonical_url(config=config)
+    pending_tests_url = build_absolute_url(
+        reverse("knowledgetest:quiz-pending"), canonical=site_url
+    )
+    student_name = getattr(
+        assignment.student, "full_display_name", str(assignment.student)
+    )
+    assigned_by = (
+        getattr(assignment.instructor, "full_display_name", None)
+        if assignment.instructor
+        else "your instructor"
+    )
+    club_name = config.club_name if config else "Soaring Club"
+
+    context = {
+        "student_name": student_name,
+        "assigned_by": assigned_by,
+        "test_name": assignment.template.name,
+        "test_description": assignment.template.description,
+        "pending_tests_url": pending_tests_url,
+        "club_name": club_name,
+        "club_logo_url": get_absolute_club_logo_url(config),
+        "site_url": site_url,
+    }
+
+    html_message = render_to_string(
+        "written_test/emails/written_test_assigned.html", context
+    )
+    text_message = render_to_string(
+        "written_test/emails/written_test_assigned.txt", context
+    )
+
+    send_mail(
+        subject=f"[{club_name}] New Written Test Assigned: {assignment.template.name}",
+        message=text_message,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[student_email],
+        html_message=html_message,
+        fail_silently=False,
+    )
 
 
 def generate_test_subject_breakdown(attempt):
@@ -200,6 +260,7 @@ class CreateWrittenTestView(FormView):
                 # Now must is capped, and weights is capped
 
         # 2. Build a template
+        assignment = None
         with transaction.atomic():
             tmpl = WrittenTestTemplate.objects.create(
                 name=f"Test by {self.request.user} on {timezone.now().date()}",
@@ -209,7 +270,7 @@ class CreateWrittenTestView(FormView):
             )
             is_self_practice = data["student"] == self.request.user
             if not is_self_practice:
-                WrittenTestAssignment.objects.create(
+                assignment = WrittenTestAssignment.objects.create(
                     template=tmpl, student=data["student"], instructor=self.request.user
                 )
 
@@ -237,6 +298,16 @@ class CreateWrittenTestView(FormView):
                 logging.warning(
                     f"Failed to create notification for test assignment: {e}"
                 )
+
+            # Send assignment email to the student
+            if assignment is not None:
+                try:
+                    _send_written_test_assignment_email(assignment)
+                except Exception:
+                    logger.exception(
+                        "Failed to send written test assignment email for assignment_id=%s",
+                        assignment.pk,
+                    )
         order = 1
         # 3. First, include forced questions
         for qnum in must:
@@ -504,6 +575,7 @@ class InstructorRecentTestsView(ListView):
     template_name = "written_test/instructor_recent.html"
     context_object_name = "attempts"
     paginate_by = 50
+    period_days = 30
 
     def dispatch(self, request, *args, **kwargs):
         # Check if user is an instructor (has given instruction reports or is staff)
@@ -514,11 +586,12 @@ class InstructorRecentTestsView(ListView):
             return HttpResponseForbidden("Access restricted to instructors and staff")
         return super().dispatch(request, *args, **kwargs)
 
-    def get_queryset(self):
-        # Show tests from the last 30 days, most recent first
-        from datetime import timedelta
+    def _get_cutoff_date(self):
+        return timezone.now() - timedelta(days=self.period_days)
 
-        cutoff_date = timezone.now() - timedelta(days=30)
+    def get_queryset(self):
+        # Show tests from the last N days, most recent first
+        cutoff_date = self._get_cutoff_date()
 
         return (
             WrittenTestAttempt.objects.filter(date_taken__gte=cutoff_date)
@@ -526,16 +599,36 @@ class InstructorRecentTestsView(ListView):
             .order_by("-date_taken")
         )
 
+    def _get_pending_assignments_queryset(self):
+        cutoff_date = self._get_cutoff_date()
+        return (
+            WrittenTestAssignment.objects.filter(
+                completed=False,
+                assigned_at__gte=cutoff_date,
+            )
+            .select_related("student", "template", "instructor")
+            .order_by("-assigned_at")
+        )
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         # Add summary stats for the period
         attempts = self.get_queryset()
+        pending_assignments = self._get_pending_assignments_queryset()
+        today = timezone.localdate()
+
+        for assignment in pending_assignments:
+            assigned_date = timezone.localtime(assignment.assigned_at).date()
+            assignment.days_pending = max((today - assigned_date).days, 0)
+
         context.update(
             {
                 "total_recent": attempts.count(),
                 "recent_passed": attempts.filter(passed=True).count(),
                 "recent_failed": attempts.filter(passed=False).count(),
-                "period_days": 30,
+                "assigned_pending_recent": pending_assignments.count(),
+                "assigned_pending_tests": pending_assignments,
+                "period_days": self.period_days,
             }
         )
         return context

--- a/knowledgetest/views.py
+++ b/knowledgetest/views.py
@@ -259,8 +259,9 @@ class CreateWrittenTestView(FormView):
                     weights[q.category.code] += 1
                 # Now must is capped, and weights is capped
 
-        # 2. Build a template
+        # 2. Build template, assignment, and question rows in one transaction.
         assignment = None
+        is_self_practice = data["student"] == self.request.user
         with transaction.atomic():
             tmpl = WrittenTestTemplate.objects.create(
                 name=f"Test by {self.request.user} on {timezone.now().date()}",
@@ -268,11 +269,36 @@ class CreateWrittenTestView(FormView):
                 pass_percentage=data["pass_percentage"],
                 created_by=self.request.user,
             )
-            is_self_practice = data["student"] == self.request.user
             if not is_self_practice:
                 assignment = WrittenTestAssignment.objects.create(
                     template=tmpl, student=data["student"], instructor=self.request.user
                 )
+
+            order = 1
+            # 3. First, include forced questions.
+            for qnum in must:
+                try:
+                    q = Question.objects.get(pk=qnum)
+                    WrittenTestTemplateQuestion.objects.create(
+                        template=tmpl, question=q, order=order
+                    )
+                    order += 1
+                except Question.DoesNotExist:
+                    continue
+
+            # 4. Then, for each category, randomly choose unanswered ones.
+            import random
+
+            for code, cnt in weights.items():
+                pool = list(
+                    Question.objects.filter(category__code=code).exclude(qnum__in=must)
+                )
+                chosen = random.sample(pool, min(cnt, len(pool)))
+                for q in chosen:
+                    WrittenTestTemplateQuestion.objects.create(
+                        template=tmpl, question=q, order=order
+                    )
+                    order += 1
 
         if is_self_practice:
             practice_url = build_absolute_url(
@@ -299,7 +325,7 @@ class CreateWrittenTestView(FormView):
                     f"Failed to create notification for test assignment: {e}"
                 )
 
-            # Send assignment email to the student
+            # Send assignment email only after all test questions are created.
             if assignment is not None:
                 try:
                     _send_written_test_assignment_email(assignment)
@@ -308,32 +334,6 @@ class CreateWrittenTestView(FormView):
                         "Failed to send written test assignment email for assignment_id=%s",
                         assignment.pk,
                     )
-        order = 1
-        # 3. First, include forced questions
-        for qnum in must:
-            try:
-                q = Question.objects.get(pk=qnum)
-                WrittenTestTemplateQuestion.objects.create(
-                    template=tmpl, question=q, order=order
-                )
-                order += 1
-            except Question.DoesNotExist:
-                continue
-
-        # 4. Then, for each category, randomly choose unanswered ones
-        import random
-
-        for code, cnt in weights.items():
-            pool = list(
-                Question.objects.filter(category__code=code).exclude(qnum__in=must)
-            )
-            chosen = random.sample(pool, min(cnt, len(pool)))
-            for q in chosen:
-                WrittenTestTemplateQuestion.objects.create(
-                    template=tmpl, question=q, order=order
-                )
-                order += 1
-
         # 5. Redirect to the quiz start
         return redirect(reverse("knowledgetest:quiz-start", args=[tmpl.pk]))
 
@@ -614,7 +614,7 @@ class InstructorRecentTestsView(ListView):
         context = super().get_context_data(**kwargs)
         # Add summary stats for the period
         attempts = self.get_queryset()
-        pending_assignments = self._get_pending_assignments_queryset()
+        pending_assignments = list(self._get_pending_assignments_queryset())
         today = timezone.localdate()
 
         for assignment in pending_assignments:
@@ -626,7 +626,7 @@ class InstructorRecentTestsView(ListView):
                 "total_recent": attempts.count(),
                 "recent_passed": attempts.filter(passed=True).count(),
                 "recent_failed": attempts.filter(passed=False).count(),
-                "assigned_pending_recent": pending_assignments.count(),
+                "assigned_pending_recent": len(pending_assignments),
                 "assigned_pending_tests": pending_assignments,
                 "period_days": self.period_days,
             }


### PR DESCRIPTION
## Summary
- send a branded outbound email to students when a written test is assigned (non-self-practice flow)
- keep instructor completion notifications and improve reliability around pending-assignment follow-up context
- add pending assignment stats and a new "Assigned Tests Not Yet Taken" table on Recent Written Test Results
- place the pending-assignment table directly above the existing Recent Test Completions table
- add urgency styling and legend for 8-14 day and 15+ day pending assignments

## Details
- Added student assignment email templates:
  - knowledgetest/templates/written_test/emails/written_test_assigned.html
  - knowledgetest/templates/written_test/emails/written_test_assigned.txt
- Updated knowledgetest view logic to:
  - send assignment email after assignment creation
  - compute pending assignment count and records for the instructor recent view
  - include days-pending values for visual urgency cues
- Updated instructor recent results template to include:
  - pending summary card
  - pending follow-up table above completions table
  - urgency row highlighting and legend
- Extended tests for:
  - assignment email send/no-send behavior
  - pending-assignment metrics/context
  - pending section ordering above recent completions

## Validation
- pytest knowledgetest/tests.py knowledgetest/test_quiz_flow.py -q
- Result: 57 passed