### PR TITLE
Implement issue #732 email feedback fan-out for fulfilled requests

### DIFF
--- a/duty_roster/signals.py
+++ b/duty_roster/signals.py
@@ -313,6 +313,56 @@ def send_request_response_email(slot):
         logger.exception("Failed to create in-system notification for student")
 
 
+def send_instructor_acceptance_confirmation_email(slot):
+    """Notify assignment instructors when any instructor accepts a student request."""
+    if slot.instructor_response != "accepted":
+        return
+
+    config = SiteConfiguration.objects.first()
+    site_url = get_canonical_url()
+
+    recipients = []
+    for instructor in [slot.assignment.instructor, slot.assignment.surge_instructor]:
+        if instructor and instructor.email:
+            recipients.append(instructor.email)
+
+    recipients = list(dict.fromkeys(recipients))
+    if not recipients:
+        return
+
+    context = _get_email_context(slot, config, site_url)
+    context["accepted_by"] = slot.instructor
+    context["instructor_requests_url"] = build_absolute_url(
+        reverse("duty_roster:instructor_requests"), canonical=site_url
+    )
+
+    from_email = _get_from_email(config)
+    subject = (
+        f"Instruction Accepted: {slot.student.first_name} on {slot.assignment.date}"
+    )
+
+    html_message = render_to_string(
+        "instructors/emails/instructor_acceptance_confirmation.html", context
+    )
+    text_message = render_to_string(
+        "instructors/emails/instructor_acceptance_confirmation.txt", context
+    )
+
+    try:
+        send_mail(
+            subject=subject,
+            message=text_message,
+            from_email=from_email,
+            recipient_list=recipients,
+            html_message=html_message,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to send instructor acceptance confirmation for slot %s",
+            slot.pk,
+        )
+
+
 def send_request_reverted_to_pending_notification(
     slot, acting_instructor=None, prior_instructor_note=""
 ):
@@ -453,6 +503,8 @@ def handle_instruction_slot_save(sender, instance, created, **kwargs):
             ):
                 # Response changed - notify student
                 send_request_response_email(instance)
+                if instance.instructor_response == "accepted":
+                    send_instructor_acceptance_confirmation_email(instance)
     except Exception:
         # Log error but don't re-raise to avoid breaking the save operation
         logger.exception("handle_instruction_slot_save failed")

--- a/duty_roster/signals.py
+++ b/duty_roster/signals.py
@@ -319,7 +319,7 @@ def send_instructor_acceptance_confirmation_email(slot):
         return
 
     config = SiteConfiguration.objects.first()
-    site_url = get_canonical_url()
+    site_url = get_canonical_url(config=config)
 
     recipients = []
     for instructor in [slot.assignment.instructor, slot.assignment.surge_instructor]:

--- a/duty_roster/templates/duty_roster/emails/surge_instructor_filled_broadcast.html
+++ b/duty_roster/templates/duty_roster/emails/surge_instructor_filled_broadcast.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Surge Instructor Filled</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f4;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        <tr>
+            <td align="center" style="padding: 20px 0;">
+                <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; overflow: hidden;">
+                    <tr>
+                        <td style="background-color: #667eea; padding: 30px 40px; text-align: center;">
+                            {% if club_logo_url %}
+                            <img src="{{ club_logo_url }}" alt="{{ club_name }}" style="max-height: 60px; max-width: 200px; height: auto; margin-bottom: 15px;">
+                            {% endif %}
+                            <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: bold;">✅ Surge Instructor Filled</h1>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 32px 40px; color: #4a5568; font-size: 16px; line-height: 1.6;">
+                            <p style="margin-top: 0;">A surge instructor has accepted coverage for {{ ops_date }}.</p>
+                            <p style="margin: 0 0 8px 0;"><strong>Surge instructor:</strong> {{ surge_instructor.full_display_name|default:surge_instructor.username }}</p>
+                            {% if primary_instructor %}
+                            <p style="margin: 0 0 8px 0;"><strong>Primary instructor:</strong> {{ primary_instructor.full_display_name|default:primary_instructor.username }}</p>
+                            {% endif %}
+                            <p style="margin: 20px 0; text-align: center;">
+                                <a href="{{ roster_url }}" style="display: inline-block; background-color: #667eea; color: #ffffff; text-decoration: none; padding: 12px 28px; border-radius: 4px; font-weight: bold;">View Duty Roster</a>
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/duty_roster/templates/duty_roster/emails/surge_instructor_filled_broadcast.txt
+++ b/duty_roster/templates/duty_roster/emails/surge_instructor_filled_broadcast.txt
@@ -1,0 +1,13 @@
+Surge Instructor Filled - {{ ops_date }}
+
+A surge instructor has accepted coverage.
+
+Date: {{ ops_date }}
+Surge instructor: {{ surge_instructor.full_display_name|default:surge_instructor.username }}
+{% if primary_instructor %}Primary instructor: {{ primary_instructor.full_display_name|default:primary_instructor.username }}
+{% endif %}
+View duty roster:
+{{ roster_url }}
+
+This is an automated message from {{ club_name }}.
+{{ site_url }}

--- a/duty_roster/templates/duty_roster/emails/surge_tow_pilot_filled_broadcast.html
+++ b/duty_roster/templates/duty_roster/emails/surge_tow_pilot_filled_broadcast.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Surge Tow Pilot Filled</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f4;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        <tr>
+            <td align="center" style="padding: 20px 0;">
+                <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; overflow: hidden;">
+                    <tr>
+                        <td style="background-color: #667eea; padding: 30px 40px; text-align: center;">
+                            {% if club_logo_url %}
+                            <img src="{{ club_logo_url }}" alt="{{ club_name }}" style="max-height: 60px; max-width: 200px; height: auto; margin-bottom: 15px;">
+                            {% endif %}
+                            <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: bold;">✅ Surge Tow Pilot Filled</h1>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 32px 40px; color: #4a5568; font-size: 16px; line-height: 1.6;">
+                            <p style="margin-top: 0;">A surge tow pilot has accepted coverage for {{ ops_date }}.</p>
+                            <p style="margin: 0 0 8px 0;"><strong>Surge tow pilot:</strong> {{ surge_tow_pilot.full_display_name|default:surge_tow_pilot.username }}</p>
+                            {% if primary_tow_pilot %}
+                            <p style="margin: 0 0 8px 0;"><strong>Primary tow pilot:</strong> {{ primary_tow_pilot.full_display_name|default:primary_tow_pilot.username }}</p>
+                            {% endif %}
+                            <p style="margin: 20px 0; text-align: center;">
+                                <a href="{{ roster_url }}" style="display: inline-block; background-color: #667eea; color: #ffffff; text-decoration: none; padding: 12px 28px; border-radius: 4px; font-weight: bold;">View Duty Roster</a>
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/duty_roster/templates/duty_roster/emails/surge_tow_pilot_filled_broadcast.txt
+++ b/duty_roster/templates/duty_roster/emails/surge_tow_pilot_filled_broadcast.txt
@@ -1,0 +1,13 @@
+Surge Tow Pilot Filled - {{ ops_date }}
+
+A surge tow pilot has accepted coverage.
+
+Date: {{ ops_date }}
+Surge tow pilot: {{ surge_tow_pilot.full_display_name|default:surge_tow_pilot.username }}
+{% if primary_tow_pilot %}Primary tow pilot: {{ primary_tow_pilot.full_display_name|default:primary_tow_pilot.username }}
+{% endif %}
+View duty roster:
+{{ roster_url }}
+
+This is an automated message from {{ club_name }}.
+{{ site_url }}

--- a/duty_roster/tests/test_volunteer_surge_instructor.py
+++ b/duty_roster/tests/test_volunteer_surge_instructor.py
@@ -26,6 +26,7 @@ from duty_roster.views import (
     _notify_surge_instructor_needed,
 )
 from siteconfig.models import SiteConfiguration
+from utils.url_helpers import get_canonical_url
 
 # ---------------------------------------------------------------------------
 # Helpers (mirror test_request_surge_instructor.py for consistency)
@@ -664,7 +665,10 @@ def test_notify_instructors_broadcast_includes_site_url(django_user_model):
 
     assert result is True
     text_body = mock_send.call_args.args[1]
-    assert "https://sky.org" in text_body.splitlines()
+    non_empty_lines = [line.strip() for line in text_body.splitlines() if line.strip()]
+    assert non_empty_lines[-1] == get_canonical_url(
+        config=SiteConfiguration.objects.first()
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/duty_roster/tests/test_volunteer_surge_instructor.py
+++ b/duty_roster/tests/test_volunteer_surge_instructor.py
@@ -304,7 +304,7 @@ def test_post_redirects_to_duty_calendar(client, django_user_model):
 
 @pytest.mark.django_db
 def test_post_notifies_primary_instructor_by_email(client, django_user_model):
-    """After a successful POST, the primary instructor receives an HTML email."""
+    """After a successful POST, primary and instructors-list emails are sent."""
     _make_site_config()
     primary = _make_member(
         django_user_model,
@@ -324,18 +324,23 @@ def test_post_notifies_primary_instructor_by_email(client, django_user_model):
         mock_send.return_value = 1
         client.post(url)
 
-    mock_send.assert_called_once()
-    call_kwargs = mock_send.call_args
-    # The notification must be sent to the primary instructor's email
-    recipients = (
-        call_kwargs.args[3]
-        if len(call_kwargs.args) > 3
-        else call_kwargs.kwargs.get("recipient_list", [])
-    )
-    assert "primary3@sky.org" in recipients
-    # HTML message must be present
-    html_content = call_kwargs.kwargs.get("html_message", "")
-    assert "<html" in html_content.lower()
+    assert mock_send.call_count == 2
+
+    recipients_per_call = []
+    for call in mock_send.call_args_list:
+        recipients = (
+            call.args[3]
+            if len(call.args) > 3
+            else call.kwargs.get("recipient_list", [])
+        )
+        recipients_per_call.append(set(recipients))
+
+    assert {"primary3@sky.org"} in recipients_per_call
+    assert {"instructors@sky.org"} in recipients_per_call
+
+    for call in mock_send.call_args_list:
+        html_content = call.kwargs.get("html_message", "")
+        assert "<html" in html_content.lower()
 
 
 @pytest.mark.django_db

--- a/duty_roster/tests/test_volunteer_surge_instructor.py
+++ b/duty_roster/tests/test_volunteer_surge_instructor.py
@@ -20,6 +20,7 @@ from django.urls import reverse
 
 from duty_roster.models import DutyAssignment, InstructionSlot
 from duty_roster.views import (
+    _notify_instructors_surge_filled,
     _notify_primary_instructor_surge_filled,
     _notify_primary_instructor_surge_withdrawn,
     _notify_surge_instructor_needed,
@@ -641,6 +642,29 @@ def test_notify_primary_returns_false_when_no_surge_instructor(django_user_model
         mock_send.assert_not_called()
 
     assert result is False
+
+
+@pytest.mark.django_db
+def test_notify_instructors_broadcast_includes_site_url(django_user_model):
+    """Broadcast email includes canonical site_url in rendered text body."""
+    _make_site_config()
+    primary = _make_member(
+        django_user_model, "nb_primary", instructor=True, email="nb_primary@sky.org"
+    )
+    surge = _make_member(
+        django_user_model, "nb_surge", instructor=True, email="nb_surge@sky.org"
+    )
+    assignment = _make_assignment(primary, date_offset=84)
+    assignment.surge_instructor = surge
+    assignment.save(update_fields=["surge_instructor"])
+
+    with patch("duty_roster.views.send_mail") as mock_send:
+        mock_send.return_value = 1
+        result = _notify_instructors_surge_filled(assignment)
+
+    assert result is True
+    text_body = mock_send.call_args.args[1]
+    assert "http" in text_body
 
 
 # ---------------------------------------------------------------------------

--- a/duty_roster/tests/test_volunteer_surge_instructor.py
+++ b/duty_roster/tests/test_volunteer_surge_instructor.py
@@ -664,7 +664,7 @@ def test_notify_instructors_broadcast_includes_site_url(django_user_model):
 
     assert result is True
     text_body = mock_send.call_args.args[1]
-    assert "http" in text_body
+    assert "https://sky.org" in text_body.splitlines()
 
 
 # ---------------------------------------------------------------------------

--- a/duty_roster/tests/test_volunteer_surge_tow_pilot.py
+++ b/duty_roster/tests/test_volunteer_surge_tow_pilot.py
@@ -26,6 +26,7 @@ from duty_roster.views import (
     _notify_tow_pilots_surge_filled,
 )
 from siteconfig.models import SiteConfiguration
+from utils.url_helpers import get_canonical_url
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -602,7 +603,10 @@ def test_notify_tow_broadcast_includes_site_url(django_user_model):
 
     assert result is True
     text_body = mock_send.call_args.args[1]
-    assert "https://sky.org" in text_body.splitlines()
+    non_empty_lines = [line.strip() for line in text_body.splitlines() if line.strip()]
+    assert non_empty_lines[-1] == get_canonical_url(
+        config=SiteConfiguration.objects.first()
+    )
 
 
 @pytest.mark.django_db

--- a/duty_roster/tests/test_volunteer_surge_tow_pilot.py
+++ b/duty_roster/tests/test_volunteer_surge_tow_pilot.py
@@ -277,7 +277,7 @@ def test_post_redirects_to_duty_calendar(client, django_user_model):
 
 @pytest.mark.django_db
 def test_post_notifies_primary_tow_pilot_by_email(client, django_user_model):
-    """After a successful POST, the primary tow pilot receives an HTML email."""
+    """After a successful POST, primary and tow-pilots-list emails are sent."""
     _make_site_config()
     primary = _make_member(
         django_user_model,
@@ -297,9 +297,19 @@ def test_post_notifies_primary_tow_pilot_by_email(client, django_user_model):
         mock_send.return_value = 1
         client.post(url)
 
-    mock_send.assert_called_once()
-    call_kwargs = mock_send.call_args
-    assert primary.email in call_kwargs[0][3]  # recipient list
+    assert mock_send.call_count == 2
+
+    recipients_per_call = []
+    for call in mock_send.call_args_list:
+        recipients = (
+            call.args[3]
+            if len(call.args) > 3
+            else call.kwargs.get("recipient_list", [])
+        )
+        recipients_per_call.append(set(recipients))
+
+    assert {primary.email} in recipients_per_call
+    assert {"towpilots@sky.org"} in recipients_per_call
 
 
 @pytest.mark.django_db

--- a/duty_roster/tests/test_volunteer_surge_tow_pilot.py
+++ b/duty_roster/tests/test_volunteer_surge_tow_pilot.py
@@ -312,6 +312,10 @@ def test_post_notifies_primary_tow_pilot_by_email(client, django_user_model):
     assert {primary.email} in recipients_per_call
     assert {"towpilots@sky.org"} in recipients_per_call
 
+    for call in mock_send.call_args_list:
+        html_content = call.kwargs.get("html_message", "")
+        assert "<html" in html_content.lower()
+
 
 @pytest.mark.django_db
 def test_post_success_message_mentions_primary_notified(client, django_user_model):
@@ -598,7 +602,7 @@ def test_notify_tow_broadcast_includes_site_url(django_user_model):
 
     assert result is True
     text_body = mock_send.call_args.args[1]
-    assert "http" in text_body
+    assert "https://sky.org" in text_body.splitlines()
 
 
 @pytest.mark.django_db

--- a/duty_roster/tests/test_volunteer_surge_tow_pilot.py
+++ b/duty_roster/tests/test_volunteer_surge_tow_pilot.py
@@ -23,6 +23,7 @@ from duty_roster.models import DutyAssignment
 from duty_roster.views import (
     _notify_primary_tow_pilot_surge_filled,
     _notify_primary_tow_pilot_surge_withdrawn,
+    _notify_tow_pilots_surge_filled,
 )
 from siteconfig.models import SiteConfiguration
 
@@ -575,6 +576,29 @@ def test_notify_helper_returns_false_when_surge_not_set(django_user_model):
 
     assert result is False
     mock_send.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_notify_tow_broadcast_includes_site_url(django_user_model):
+    """Tow-pilot broadcast email includes canonical site_url in text body."""
+    _make_site_config()
+    primary = _make_member(
+        django_user_model, "tb_primary", towpilot=True, email="tb_primary@sky.org"
+    )
+    surge = _make_member(
+        django_user_model, "tb_surge", towpilot=True, email="tb_surge@sky.org"
+    )
+    assignment = _make_assignment(primary, date_offset=75)
+    assignment.surge_tow_pilot = surge
+    assignment.save(update_fields=["surge_tow_pilot"])
+
+    with patch("duty_roster.views.send_mail") as mock_send:
+        mock_send.return_value = 1
+        result = _notify_tow_pilots_surge_filled(assignment)
+
+    assert result is True
+    text_body = mock_send.call_args.args[1]
+    assert "http" in text_body
 
 
 @pytest.mark.django_db

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -4140,6 +4140,7 @@ def _notify_instructors_surge_filled(assignment):
             "primary_instructor": assignment.instructor,
             "surge_instructor": surge,
             "roster_url": email_config["roster_url"],
+            "site_url": email_config["site_url"],
             "club_name": email_config["club_name"],
             "club_logo_url": get_absolute_club_logo_url(config),
         }
@@ -4244,6 +4245,7 @@ def _notify_tow_pilots_surge_filled(assignment):
             "primary_tow_pilot": assignment.tow_pilot,
             "surge_tow_pilot": surge,
             "roster_url": email_config["roster_url"],
+            "site_url": email_config["site_url"],
             "club_name": email_config["club_name"],
             "club_logo_url": get_absolute_club_logo_url(config),
         }

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -3538,6 +3538,7 @@ def volunteer_as_surge_instructor(request, assignment_id):
             locked.save(update_fields=["surge_instructor"])
 
         notified = _notify_primary_instructor_surge_filled(locked)
+        _notify_instructors_surge_filled(locked)
         base_msg = (
             f"You have been assigned as surge instructor for "
             f"{assignment.date.strftime('%B %d, %Y')}."
@@ -3646,6 +3647,7 @@ def volunteer_as_surge_tow_pilot(request, assignment_id):
             locked.save(update_fields=["surge_tow_pilot"])
 
         notified = _notify_primary_tow_pilot_surge_filled(locked)
+        _notify_tow_pilots_surge_filled(locked)
         base_msg = (
             f"You have been assigned as surge tow pilot for "
             f"{assignment.date.strftime('%B %d, %Y')}."
@@ -4117,6 +4119,54 @@ def _notify_primary_instructor_surge_filled(assignment):
         return False
 
 
+def _notify_instructors_surge_filled(assignment):
+    """Notify the instructors mailing list when a surge instructor slot is filled."""
+    try:
+        surge = assignment.surge_instructor
+        if not surge:
+            return False
+
+        email_config = get_email_config()
+        config = email_config["config"]
+        recipient_list = get_mailing_list(
+            "INSTRUCTORS_MAILING_LIST", "instructors", config
+        )
+
+        ops_date = assignment.date.strftime("%A, %B %d, %Y")
+        subject = f"Surge Instructor Filled - {assignment.date.strftime('%B %d, %Y')}"
+
+        context = {
+            "ops_date": ops_date,
+            "primary_instructor": assignment.instructor,
+            "surge_instructor": surge,
+            "roster_url": email_config["roster_url"],
+            "club_name": email_config["club_name"],
+            "club_logo_url": get_absolute_club_logo_url(config),
+        }
+
+        html_message = render_to_string(
+            "duty_roster/emails/surge_instructor_filled_broadcast.html", context
+        )
+        text_message = render_to_string(
+            "duty_roster/emails/surge_instructor_filled_broadcast.txt", context
+        )
+
+        sent_count = send_mail(
+            subject,
+            text_message,
+            email_config["from_email"],
+            recipient_list,
+            fail_silently=False,
+            html_message=html_message,
+        )
+        return sent_count > 0
+    except Exception:
+        logger.exception(
+            "Failed to send surge-filled broadcast notification to instructors"
+        )
+        return False
+
+
 def _notify_primary_tow_pilot_surge_filled(assignment):
     """Notify the primary tow pilot that a surge tow pilot has volunteered.
 
@@ -4171,6 +4221,52 @@ def _notify_primary_tow_pilot_surge_filled(assignment):
     except Exception:
         logger.exception(
             "Failed to send surge-filled notification to primary tow pilot"
+        )
+        return False
+
+
+def _notify_tow_pilots_surge_filled(assignment):
+    """Notify the tow-pilots mailing list when a surge tow pilot slot is filled."""
+    try:
+        surge = assignment.surge_tow_pilot
+        if not surge:
+            return False
+
+        email_config = get_email_config()
+        config = email_config["config"]
+        recipient_list = get_mailing_list("TOWPILOTS_MAILING_LIST", "towpilots", config)
+
+        ops_date = assignment.date.strftime("%A, %B %d, %Y")
+        subject = f"Surge Tow Pilot Filled - {assignment.date.strftime('%B %d, %Y')}"
+
+        context = {
+            "ops_date": ops_date,
+            "primary_tow_pilot": assignment.tow_pilot,
+            "surge_tow_pilot": surge,
+            "roster_url": email_config["roster_url"],
+            "club_name": email_config["club_name"],
+            "club_logo_url": get_absolute_club_logo_url(config),
+        }
+
+        html_message = render_to_string(
+            "duty_roster/emails/surge_tow_pilot_filled_broadcast.html", context
+        )
+        text_message = render_to_string(
+            "duty_roster/emails/surge_tow_pilot_filled_broadcast.txt", context
+        )
+
+        sent_count = send_mail(
+            subject,
+            text_message,
+            email_config["from_email"],
+            recipient_list,
+            fail_silently=False,
+            html_message=html_message,
+        )
+        return sent_count > 0
+    except Exception:
+        logger.exception(
+            "Failed to send surge-filled broadcast notification to tow pilots"
         )
         return False
 

--- a/instructors/templates/instructors/emails/instructor_acceptance_confirmation.html
+++ b/instructors/templates/instructors/emails/instructor_acceptance_confirmation.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Instruction Request Accepted</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f4;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        <tr>
+            <td align="center" style="padding: 20px 0;">
+                <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; overflow: hidden;">
+                    <tr>
+                        <td style="background-color: #667eea; padding: 30px 40px; text-align: center;">
+                            {% if club_logo_url %}
+                            <img src="{{ club_logo_url }}" alt="{{ club_name }}" style="max-height: 60px; max-width: 200px; height: auto; margin-bottom: 15px;">
+                            {% endif %}
+                            <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: bold;">✅ Instruction Request Accepted</h1>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 32px 40px; color: #4a5568; font-size: 16px; line-height: 1.6;">
+                            <p style="margin-top: 0;">A student instruction request has been accepted.</p>
+                            <p style="margin: 0 0 8px 0;"><strong>Student:</strong> {{ student.full_display_name }}</p>
+                            <p style="margin: 0 0 8px 0;"><strong>Date:</strong> {{ instruction_date }}</p>
+                            <p style="margin: 0 0 8px 0;"><strong>Accepted by:</strong> {{ accepted_by.full_display_name|default:accepted_by.username }}</p>
+                            <p style="margin: 20px 0; text-align: center;">
+                                <a href="{{ instructor_requests_url }}" style="display: inline-block; background-color: #667eea; color: #ffffff; text-decoration: none; padding: 12px 28px; border-radius: 4px; font-weight: bold;">View Instructor Requests</a>
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="background-color: #f4f4f4; padding: 20px; text-align: center;">
+                            <p style="margin: 0; color: #666666; font-size: 12px;">This is an automated message from {{ club_name }}.</p>
+                            <p style="margin: 6px 0 0 0; color: #666666; font-size: 12px;">{{ site_url }}</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/instructors/templates/instructors/emails/instructor_acceptance_confirmation.txt
+++ b/instructors/templates/instructors/emails/instructor_acceptance_confirmation.txt
@@ -1,0 +1,13 @@
+Instruction Request Accepted - {{ instruction_date }}
+
+A student instruction request has been accepted.
+
+Student: {{ student.full_display_name }}
+Date: {{ instruction_date }}
+Accepted by: {{ accepted_by.full_display_name|default:accepted_by.username }}
+
+View instructor requests:
+{{ instructor_requests_url }}
+
+This is an automated message from {{ club_name }}.
+{{ site_url }}

--- a/instructors/tests/test_instructor_emails.py
+++ b/instructors/tests/test_instructor_emails.py
@@ -236,7 +236,7 @@ class TestAcceptRejectNotification:
     def test_sends_email_on_accept(
         self, site_config, duty_assignment, student, instructor
     ):
-        """Test that accepting a slot sends email to student."""
+        """Test that accepting a slot emails student and assigned instructors."""
         # Create slot without triggering signal (bypass signals for setup)
         slot = InstructionSlot(
             assignment=duty_assignment,

--- a/instructors/tests/test_instructor_emails.py
+++ b/instructors/tests/test_instructor_emails.py
@@ -251,14 +251,18 @@ class TestAcceptRejectNotification:
         # Accept the slot
         slot.accept(instructor, note="Looking forward to flying with you!")
 
-        # Should send acceptance email to student
-        assert len(mail.outbox) == 1
-        email = mail.outbox[0]
-        assert "sally@example.com" in email.to
-        assert "confirmed" in email.subject.lower()
+        # Should send acceptance email to student and confirmation to instructors.
+        assert len(mail.outbox) == 2
+        student_email = next(e for e in mail.outbox if "sally@example.com" in e.to)
+        instructors_email = next(
+            e for e in mail.outbox if "Instruction Accepted:" in e.subject
+        )
+
+        assert "confirmed" in student_email.subject.lower()
+        assert set(instructors_email.to) == {"john@example.com", "jane@example.com"}
 
         # Check HTML content
-        html_content = email.alternatives[0][0]
+        html_content = student_email.alternatives[0][0]
         assert "Looking forward to flying with you!" in html_content
 
     @override_settings(


### PR DESCRIPTION
## Summary
- add instructor-team confirmation email when an instruction request is accepted
- add mailing-list broadcast emails when surge instructor and surge tow pilot slots are filled
- add new HTML/TXT templates for these notifications
- update targeted tests for multi-recipient fan-out behavior

## Testing
- pytest instructors/tests/test_instructor_emails.py duty_roster/tests/test_volunteer_surge_instructor.py duty_roster/tests/test_volunteer_surge_tow_pilot.py -q

Closes #732