### PR TITLE
Fix issue #834 ADO swap eligibility to use active siteconfig statuses

### DIFF
--- a/duty_roster/forms.py
+++ b/duty_roster/forms.py
@@ -203,8 +203,6 @@ class DutyAssignmentForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         # Optional: Limit dropdowns to members with the right roles
-        from members.utils.membership import get_active_membership_statuses
-
         active_statuses = get_active_membership_statuses()
         active_members = Member.objects.filter(membership_status__in=active_statuses)
         self.fields["instructor"].queryset = active_members.filter(

--- a/duty_roster/forms.py
+++ b/duty_roster/forms.py
@@ -7,6 +7,7 @@ from tinymce.widgets import TinyMCE
 
 from logsheet.models import Glider, MaintenanceIssue
 from members.models import Member
+from members.utils.membership import get_active_membership_statuses
 from siteconfig.models import SiteConfiguration
 
 from .models import (
@@ -468,9 +469,10 @@ class DutySwapRequestForm(forms.ModelForm):
             role_attr = role_attr_map.get(role)
 
             if role_attr:
+                active_statuses = get_active_membership_statuses()
                 eligible = Member.objects.filter(
                     **{role_attr: True},
-                    membership_status__in=["Full Member", "Family Member"],
+                    membership_status__in=active_statuses,
                 ).exclude(pk=requester.pk if requester else None)
                 self.fields["direct_request_to"].queryset = eligible
             else:

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -643,8 +643,8 @@ class TestSwapOfferWorkflow:
             offered_by=bob,
             offer_type="cover",
         )
-        other_offer.refresh_from_db()
-        swap_request.refresh_from_db()
+        other_offer = DutySwapOffer.objects.get(pk=other_offer.pk)
+        swap_request = DutySwapRequest.objects.get(pk=swap_request.pk)
 
         assert accepted_offer.status == "accepted"
         assert other_offer.status == "auto_declined"
@@ -778,8 +778,8 @@ class TestOfferAcceptDecline:
         )
 
         accepted = _accept_offer_and_finalize(swap_request, stale_offer)
-        stale_offer.refresh_from_db()
-        swap_request.refresh_from_db()
+        stale_offer = DutySwapOffer.objects.get(pk=stale_offer.pk)
+        swap_request = DutySwapRequest.objects.get(pk=swap_request.pk)
 
         assert accepted is False
         assert stale_offer.status == "auto_declined"
@@ -825,7 +825,7 @@ class TestCancelAndConvert:
         resp = client.post(url)
         assert resp.status_code in [200, 302]
 
-        direct_request.refresh_from_db()
+        direct_request = DutySwapRequest.objects.get(pk=direct_request.pk)
         assert direct_request.request_type == "general"
         assert direct_request.direct_request_to is None
 
@@ -945,8 +945,8 @@ class TestSwapIntegration:
         client.post(accept_url)
 
         # Verify final state
-        swap_request.refresh_from_db()
-        swap_offer.refresh_from_db()
+        swap_request = DutySwapRequest.objects.get(pk=swap_request.pk)
+        swap_offer = DutySwapOffer.objects.get(pk=swap_offer.pk)
 
         assert swap_request.status == "fulfilled"
         assert swap_offer.status == "accepted"
@@ -1004,8 +1004,8 @@ class TestSwapIntegration:
         assert swap_offer.proposed_swap_date is None
 
         # Verify final state (auto-accepted for cover offers)
-        swap_offer.refresh_from_db()
-        swap_request.refresh_from_db()
+        swap_offer = DutySwapOffer.objects.get(pk=swap_offer.pk)
+        swap_request = DutySwapRequest.objects.get(pk=swap_request.pk)
         assert swap_offer.status == "accepted"
         assert swap_request.status == "fulfilled"
         assert swap_request.accepted_offer == swap_offer

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -117,7 +117,7 @@ def ado_non_qualified(db):
         first_name="Not",
         last_name="Qualified",
         email="ado_non_qualified@example.com",
-        membership_status="Probationary Member",
+        membership_status="Full Member",
         assistant_duty_officer=False,
     )
 
@@ -656,7 +656,6 @@ class TestSwapOfferWorkflow:
         client,
         ado_helper_probationary,
         ado_swap_request,
-        ado_duty_assignment,
         site_config,
     ):
         """Active ADO members in Probationary status can make swap offers."""

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -21,7 +21,10 @@ from duty_roster.models import (
     DutySwapRequest,
     MemberBlackout,
 )
-from duty_roster.views_swap import _accept_offer_and_finalize
+from duty_roster.views_swap import (
+    _accept_offer_and_finalize,
+    get_eligible_members_for_role,
+)
 from members.models import Member
 from siteconfig.models import SiteConfiguration
 
@@ -81,6 +84,58 @@ def charlie(db):
 
 
 @pytest.fixture
+def ado_requester(db):
+    """Create an ADO requester assigned to the original duty date."""
+    return Member.objects.create(
+        username="ado_requester",
+        first_name="Ado",
+        last_name="Requester",
+        email="ado_requester@example.com",
+        membership_status="Full Member",
+        assistant_duty_officer=True,
+    )
+
+
+@pytest.fixture
+def ado_helper_probationary(db):
+    """Create an ADO-qualified helper with active non-Full/Family status."""
+    return Member.objects.create(
+        username="ado_probationary",
+        first_name="Probationary",
+        last_name="Helper",
+        email="ado_probationary@example.com",
+        membership_status="Probationary Member",
+        assistant_duty_officer=True,
+    )
+
+
+@pytest.fixture
+def ado_non_qualified(db):
+    """Create an active member without ADO qualification."""
+    return Member.objects.create(
+        username="ado_non_qualified",
+        first_name="Not",
+        last_name="Qualified",
+        email="ado_non_qualified@example.com",
+        membership_status="Probationary Member",
+        assistant_duty_officer=False,
+    )
+
+
+@pytest.fixture
+def ado_inactive(db):
+    """Create an ADO-qualified member in an inactive status."""
+    return Member.objects.create(
+        username="ado_inactive",
+        first_name="Inactive",
+        last_name="Helper",
+        email="ado_inactive@example.com",
+        membership_status="Inactive",
+        assistant_duty_officer=True,
+    )
+
+
+@pytest.fixture
 def alice_duty_assignment(alice, db):
     """Create a duty assignment for Alice (tow pilot) in the future."""
     return DutyAssignment.objects.create(
@@ -119,6 +174,27 @@ def swap_offer(bob, swap_request, bob_duty_assignment, db):
         offer_type="swap",
         proposed_swap_date=bob_duty_assignment.date,
         status="pending",
+    )
+
+
+@pytest.fixture
+def ado_duty_assignment(ado_requester, db):
+    """Create a future duty assignment for an assistant duty officer."""
+    return DutyAssignment.objects.create(
+        date=date.today() + timedelta(days=16),
+        assistant_duty_officer=ado_requester,
+    )
+
+
+@pytest.fixture
+def ado_swap_request(ado_requester, ado_duty_assignment, db):
+    """Create an open ADO swap request."""
+    return DutySwapRequest.objects.create(
+        requester=ado_requester,
+        original_date=ado_duty_assignment.date,
+        role="ADO",
+        request_type="general",
+        status="open",
     )
 
 
@@ -574,6 +650,75 @@ class TestSwapOfferWorkflow:
         assert other_offer.status == "auto_declined"
         assert swap_request.status == "fulfilled"
         assert swap_request.accepted_offer == accepted_offer
+
+    def test_ado_probationary_member_can_make_offer(
+        self,
+        client,
+        ado_helper_probationary,
+        ado_swap_request,
+        ado_duty_assignment,
+        site_config,
+    ):
+        """Active ADO members in Probationary status can make swap offers."""
+        client.force_login(ado_helper_probationary)
+        url = reverse("duty_roster:make_swap_offer", args=[ado_swap_request.id])
+
+        # GET should load the offer form (no false "not qualified" rejection).
+        response = client.get(url)
+        assert response.status_code == 200
+
+        # POST cover offer should succeed and auto-accept.
+        response = client.post(
+            url,
+            {
+                "offer_type": "cover",
+                "notes": "I can cover this ADO duty.",
+            },
+        )
+        assert response.status_code == 302
+
+        offer = DutySwapOffer.objects.get(
+            swap_request=ado_swap_request,
+            offered_by=ado_helper_probationary,
+            offer_type="cover",
+        )
+        ado_swap_request.refresh_from_db()
+        assert offer.status == "accepted"
+        assert ado_swap_request.status == "fulfilled"
+
+        updated_assignment = DutyAssignment.objects.get(
+            date=ado_swap_request.original_date
+        )
+        assert updated_assignment.assistant_duty_officer == ado_helper_probationary
+
+    def test_ado_non_qualified_member_is_rejected(
+        self, client, ado_non_qualified, ado_swap_request, site_config
+    ):
+        """Active members without ADO qualification are rejected for ADO offers."""
+        client.force_login(ado_non_qualified)
+        url = reverse("duty_roster:make_swap_offer", args=[ado_swap_request.id])
+        response = client.get(url, follow=True)
+
+        assert response.status_code == 200
+        assert "You are not qualified for this role." in response.content.decode()
+
+    def test_ado_inactive_member_not_eligible(self, ado_inactive, ado_swap_request):
+        """Inactive ADO members are excluded by status policy in helper."""
+        eligible = get_eligible_members_for_role(
+            ado_swap_request.role,
+            exclude_member=ado_swap_request.requester,
+        )
+        assert not eligible.filter(pk=ado_inactive.pk).exists()
+
+    def test_ado_probationary_member_is_eligible(
+        self, ado_helper_probationary, ado_swap_request
+    ):
+        """Probationary Member ADO is included when status is active in siteconfig policy."""
+        eligible = get_eligible_members_for_role(
+            ado_swap_request.role,
+            exclude_member=ado_swap_request.requester,
+        )
+        assert eligible.filter(pk=ado_helper_probationary.pk).exists()
 
 
 @pytest.mark.django_db

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -21,6 +21,7 @@ from django.views.decorators.http import require_POST
 
 from members.decorators import active_member_required
 from members.models import Member
+from members.utils.membership import get_active_membership_statuses
 from siteconfig.models import SiteConfiguration
 from siteconfig.utils import get_role_title
 from utils.email import get_dev_mode_info, send_mail
@@ -76,8 +77,9 @@ def get_eligible_members_for_role(role, exclude_member=None):
     if not role_attr:
         return Member.objects.none()
 
+    active_statuses = get_active_membership_statuses()
     queryset = Member.objects.filter(
-        **{role_attr: True}, membership_status__in=["Full Member", "Family Member"]
+        **{role_attr: True}, membership_status__in=active_statuses
     )
 
     if exclude_member:

--- a/members/tests/test_utils.py
+++ b/members/tests/test_utils.py
@@ -4,6 +4,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
+from django.db import transaction
 
 from members.utils import is_active_member
 from members.utils.membership import (
@@ -88,7 +89,7 @@ def test_get_active_membership_statuses_empty():
     assert len(active_statuses) == 0
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_dynamic_membership_status_changes():
     """Test that membership status changes are reflected immediately."""
     # Create a status that starts as active
@@ -171,3 +172,33 @@ def test_fallback_active_membership_statuses_are_not_cached():
     assert "Recovered Active" not in fallback
     assert "Recovered Active" in recovered
     assert recovered != fallback
+
+
+@pytest.mark.django_db(transaction=True)
+def test_membership_status_save_clears_cache_on_commit():
+    """Cache clear callback should run after the surrounding transaction commits."""
+    with patch(
+        "members.utils.membership.clear_active_membership_statuses_cache"
+    ) as clear:
+        with transaction.atomic():
+            MembershipStatus.objects.create(name="Commit Save Status", is_active=True)
+            assert clear.call_count == 0
+
+        assert clear.call_count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_membership_status_delete_clears_cache_on_commit():
+    """Delete path should also defer cache invalidation until commit."""
+    status = MembershipStatus.objects.create(
+        name="Commit Delete Status", is_active=True
+    )
+
+    with patch(
+        "members.utils.membership.clear_active_membership_statuses_cache"
+    ) as clear:
+        with transaction.atomic():
+            status.delete()
+            assert clear.call_count == 0
+
+        assert clear.call_count == 1

--- a/members/tests/test_utils.py
+++ b/members/tests/test_utils.py
@@ -151,3 +151,23 @@ def test_get_active_membership_statuses_uses_cache():
 
     assert first == second
     assert wrapped.call_count == 1
+
+
+@pytest.mark.django_db
+def test_fallback_active_membership_statuses_are_not_cached():
+    """Fallback list should not be cached after transient DB/model failures."""
+    MembershipStatus.objects.create(name="Recovered Active", is_active=True)
+
+    with patch(
+        "siteconfig.models.MembershipStatus.get_active_statuses",
+        side_effect=RuntimeError("transient failure"),
+    ):
+        with pytest.warns(DeprecationWarning):
+            fallback = get_active_membership_statuses()
+
+    recovered = get_active_membership_statuses()
+
+    # If fallback had been cached, this would still return legacy constants.
+    assert "Recovered Active" not in fallback
+    assert "Recovered Active" in recovered
+    assert recovered != fallback

--- a/members/tests/test_utils.py
+++ b/members/tests/test_utils.py
@@ -1,12 +1,25 @@
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 
 from members.utils import is_active_member
-from members.utils.membership import get_active_membership_statuses
+from members.utils.membership import (
+    clear_active_membership_statuses_cache,
+    get_active_membership_statuses,
+)
 from siteconfig.models import MembershipStatus
 
 User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def clear_membership_status_cache_between_tests():
+    clear_active_membership_statuses_cache()
+    yield
+    cache.clear()
 
 
 @pytest.mark.django_db
@@ -124,3 +137,17 @@ def test_membership_status_deletion_integration():
     # Now deletion should succeed (no members using it)
     status.delete()
     assert not MembershipStatus.objects.filter(name="Protected Status").exists()
+
+
+@pytest.mark.django_db
+def test_get_active_membership_statuses_uses_cache():
+    MembershipStatus.objects.create(name="Cached Active", is_active=True)
+    with patch(
+        "siteconfig.models.MembershipStatus.get_active_statuses",
+        wraps=MembershipStatus.get_active_statuses,
+    ) as wrapped:
+        first = get_active_membership_statuses()
+        second = get_active_membership_statuses()
+
+    assert first == second
+    assert wrapped.call_count == 1

--- a/members/tests/test_utils.py
+++ b/members/tests/test_utils.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
-from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import transaction
 
@@ -20,7 +19,7 @@ User = get_user_model()
 def clear_membership_status_cache_between_tests():
     clear_active_membership_statuses_cache()
     yield
-    cache.clear()
+    clear_active_membership_statuses_cache()
 
 
 @pytest.mark.django_db

--- a/members/utils/membership.py
+++ b/members/utils/membership.py
@@ -2,7 +2,20 @@ import logging
 import warnings
 from typing import Iterable, List, Optional
 
+from django.conf import settings
+from django.core.cache import cache
+
 logger = logging.getLogger(__name__)
+
+ACTIVE_MEMBERSHIP_STATUSES_CACHE_KEY = "members:active_membership_statuses"
+ACTIVE_MEMBERSHIP_STATUSES_CACHE_TIMEOUT = getattr(
+    settings, "ACTIVE_MEMBERSHIP_STATUSES_CACHE_TIMEOUT", 300
+)
+
+
+def clear_active_membership_statuses_cache() -> None:
+    """Clear cached active membership statuses."""
+    cache.delete(ACTIVE_MEMBERSHIP_STATUSES_CACHE_KEY)
 
 
 def get_active_membership_statuses() -> List[str]:
@@ -21,10 +34,20 @@ def get_active_membership_statuses() -> List[str]:
         siteconfig table doesn't exist. A deprecation warning is logged
         when fallback is used.
     """
+    cached_statuses = cache.get(ACTIVE_MEMBERSHIP_STATUSES_CACHE_KEY)
+    if cached_statuses is not None:
+        return list(cached_statuses)
+
     try:
         from siteconfig.models import MembershipStatus
 
-        return list(MembershipStatus.get_active_statuses())
+        statuses = list(MembershipStatus.get_active_statuses())
+        cache.set(
+            ACTIVE_MEMBERSHIP_STATUSES_CACHE_KEY,
+            statuses,
+            ACTIVE_MEMBERSHIP_STATUSES_CACHE_TIMEOUT,
+        )
+        return statuses
     except Exception as e:
         # Fallback to hardcoded list during migrations or if table/app doesn't exist
         from ..constants.membership import DEFAULT_ACTIVE_STATUSES
@@ -39,7 +62,13 @@ def get_active_membership_statuses() -> List[str]:
             DeprecationWarning,
             stacklevel=2,
         )
-        return list(DEFAULT_ACTIVE_STATUSES)
+        fallback_statuses = list(DEFAULT_ACTIVE_STATUSES)
+        cache.set(
+            ACTIVE_MEMBERSHIP_STATUSES_CACHE_KEY,
+            fallback_statuses,
+            ACTIVE_MEMBERSHIP_STATUSES_CACHE_TIMEOUT,
+        )
+        return fallback_statuses
 
 
 def get_all_membership_statuses() -> List[str]:

--- a/members/utils/membership.py
+++ b/members/utils/membership.py
@@ -63,11 +63,8 @@ def get_active_membership_statuses() -> List[str]:
             stacklevel=2,
         )
         fallback_statuses = list(DEFAULT_ACTIVE_STATUSES)
-        cache.set(
-            ACTIVE_MEMBERSHIP_STATUSES_CACHE_KEY,
-            fallback_statuses,
-            ACTIVE_MEMBERSHIP_STATUSES_CACHE_TIMEOUT,
-        )
+        # Do not cache fallback values. This ensures DB-backed policy resumes
+        # immediately once transient startup/migration issues are resolved.
         return fallback_statuses
 
 

--- a/siteconfig/models.py
+++ b/siteconfig/models.py
@@ -809,6 +809,14 @@ class MembershipStatus(models.Model):
     def __str__(self):
         return self.name
 
+    def save(self, *args, **kwargs):
+        """Override save to clear membership status cache."""
+        result = super().save(*args, **kwargs)
+        from members.utils.membership import clear_active_membership_statuses_cache
+
+        clear_active_membership_statuses_cache()
+        return result
+
     def delete(self, *args, **kwargs):
         """Override delete to prevent deletion if members are using this status."""
         # Import here to avoid circular imports
@@ -829,6 +837,9 @@ class MembershipStatus(models.Model):
             pass
 
         super().delete(*args, **kwargs)
+        from members.utils.membership import clear_active_membership_statuses_cache
+
+        clear_active_membership_statuses_cache()
 
     @classmethod
     def get_active_statuses(cls):

--- a/siteconfig/models.py
+++ b/siteconfig/models.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from django.core.exceptions import ValidationError
 from django.core.files.storage import default_storage
 from django.core.validators import MinValueValidator
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Q
 from django.utils.crypto import get_random_string
 from tinymce.models import HTMLField
@@ -814,7 +814,7 @@ class MembershipStatus(models.Model):
         result = super().save(*args, **kwargs)
         from members.utils.membership import clear_active_membership_statuses_cache
 
-        clear_active_membership_statuses_cache()
+        transaction.on_commit(clear_active_membership_statuses_cache)
         return result
 
     def delete(self, *args, **kwargs):
@@ -839,7 +839,7 @@ class MembershipStatus(models.Model):
         super().delete(*args, **kwargs)
         from members.utils.membership import clear_active_membership_statuses_cache
 
-        clear_active_membership_statuses_cache()
+        transaction.on_commit(clear_active_membership_statuses_cache)
 
     @classmethod
     def get_active_statuses(cls):


### PR DESCRIPTION
## Summary
- replace hardcoded swap-offer membership filter (Full/Family only) with dynamic active statuses from siteconfig via get_active_membership_statuses()
- keep existing role qualification checks (DO/ADO/INSTRUCTOR/TOW flags) and requester exclusion behavior unchanged
- add regression tests for ADO swap offers covering active Probationary eligibility, non-qualified rejection, and inactive-status exclusion

## Tenant Evidence (tenant-demo)
- request_role=ADO
- user assistant_duty_officer=True
- user membership_status=Probationary Member
- eligible_current_logic_contains_user=False
- role_flag_and_active_status_contains_user=True

## Testing
- pytest duty_roster/tests/test_duty_swap.py -q
- 53 passed

Closes #834