### PR TITLE
Fix 3 Dependabot alerts in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ charset-normalizer==3.4.3
 click==8.3.0
 coverage==7.11.0
 crispy-bootstrap4==2025.6
-cryptography==46.0.5
+cryptography==46.0.6
 cyclonedx-python-lib==9.1.0
 defusedxml==0.7.1
 diff-match-patch==20241021
@@ -89,7 +89,7 @@ pydantic_core==2.41.5
 pydenticon==0.3.1
 pyee==13.0.0
 pyflakes==3.4.0
-Pygments==2.19.2
+Pygments==2.20.0
 PyJWT==2.12.0
 pyparsing==3.2.5
 pytest==8.4.2
@@ -106,7 +106,7 @@ pytz==2025.2
 PyYAML==6.0.3
 qrcode==8.2
 regex==2025.11.3
-requests==2.32.5
+requests==2.33.0
 requests-oauthlib==2.0.0
 rich==14.2.0
 rsa==4.9.1


### PR DESCRIPTION
## Summary
- Updates three vulnerable direct dependencies in requirements.txt to their first patched releases.
- Keeps the change set minimal and limited to dependency version bumps only.

## Security Alerts Addressed
- Dependabot alert #37: requests -> 2.33.0 (from 2.32.5)
- Dependabot alert #38: cryptography -> 46.0.6 (from 46.0.5)
- Dependabot alert #39: Pygments -> 2.20.0 (from 2.19.2)

## Files Changed
- requirements.txt

## Validation
- source .venv/bin/activate && pip install -r requirements.txt
- source .venv/bin/activate && pytest members/tests/test_utils.py -q
- Result: 13 passed

## Risk
- Low: patch/minor dependency version updates with no application logic changes.

## Rollback
- Revert this PR commit if any incompatibility is detected after merge.