### PR TITLE
Restore Remove Selected Dates control in OR-Tools propose roster

### DIFF
--- a/duty_roster/templates/duty_roster/propose_roster.html
+++ b/duty_roster/templates/duty_roster/propose_roster.html
@@ -169,10 +169,12 @@
     </tbody>
   </table>
 
-  {% if draft and not use_ortools_scheduler %}
+  {% if draft %}
   <div class="d-flex gap-2 mb-3">
     <button name="action" value="remove_dates" class="btn btn-warning">🗑️ Remove Selected Dates</button>
+    {% if not use_ortools_scheduler %}
     <button name="action" value="roll" class="btn btn-secondary">🔄 Roll Again</button>
+    {% endif %}
     {% if removed_dates %}
     <button name="action" value="restore_dates" class="btn btn-outline-secondary">↩️ Restore All Dates</button>
     {% endif %}

--- a/duty_roster/tests/test_propose_roster_removed_dates.py
+++ b/duty_roster/tests/test_propose_roster_removed_dates.py
@@ -397,6 +397,48 @@ class TestProposeRosterSessionTracking:
         )
         assert roll_again_button is None
 
+    def test_remove_dates_visible_when_ortools_enabled(
+        self, client, rostermeister, instructor_member
+    ):
+        """Remove Selected Dates should remain available when OR-Tools is enabled."""
+        config = SiteConfiguration.objects.first()
+        if not config:
+            config = SiteConfiguration.objects.create(
+                club_name="Test Club",
+                domain_name="test.org",
+                club_abbreviation="TC",
+                schedule_instructors=True,
+                schedule_tow_pilots=True,
+                schedule_duty_officers=True,
+                schedule_assistant_duty_officers=True,
+            )
+        else:
+            config.schedule_instructors = True
+            config.schedule_tow_pilots = True
+            config.schedule_duty_officers = True
+            config.schedule_assistant_duty_officers = True
+        config.use_ortools_scheduler = True
+        config.save()
+
+        client.login(username="rostermeister", password="testpass123")
+        url = reverse("duty_roster:propose_roster")
+
+        session = client.session
+        session["proposed_roster"] = [
+            {"date": "2026-03-07", "slots": {}, "diagnostics": {}}
+        ]
+        session.save()
+
+        response = client.post(url, {"year": 2026, "month": 3})
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        remove_dates_button = re.search(
+            r'<button[^>]*name="action"[^>]*value="remove_dates"[^>]*class="[^"]*btn btn-warning[^"]*"[^>]*>\s*🗑️\s*Remove Selected Dates\s*</button>',
+            content,
+        )
+        assert remove_dates_button is not None
+
     def test_roll_again_visible_when_ortools_disabled(
         self, client, rostermeister, instructor_member
     ):


### PR DESCRIPTION
## Summary
- restore the Remove Selected Dates button for draft rosters when OR-Tools scheduler is enabled
- keep Roll Again hidden in OR-Tools mode
- add regression test to ensure Remove Selected Dates remains visible in OR-Tools mode

## Validation
- pytest duty_roster/tests/test_propose_roster_removed_dates.py -q
