### PR TITLE
Hotfix: resolve siteconfig migration history inconsistency (0038/0040)

### DIFF
--- a/siteconfig/migrations/0038_alter_siteconfiguration_max_reservations_per_year.py
+++ b/siteconfig/migrations/0038_alter_siteconfiguration_max_reservations_per_year.py
@@ -4,12 +4,8 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    # This migration aligns historical migration state with the current
-    # SiteConfiguration model wording after reservation_limit_period was added.
-    # Keeping this explicit alter avoids future accidental regeneration noise.
-
     dependencies = [
-        ("siteconfig", "0037_add_contact_spam_keywords"),
+        ("siteconfig", "0036_add_reservation_limit_period"),
     ]
 
     operations = [

--- a/siteconfig/migrations/0040_merge_0037_0039.py
+++ b/siteconfig/migrations/0040_merge_0037_0039.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siteconfig", "0037_add_contact_spam_keywords"),
+        ("siteconfig", "0039_add_duty_default_max_assignments_per_month"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Emergency Hotfix
Fixes tenant outage caused by `InconsistentMigrationHistory` during deploy.

## Root Cause
- `siteconfig.0038` was changed to depend on `0037`
- Existing tenant databases already had `0038` applied before `0037`
- Django correctly rejected migration history consistency checks

## Changes
- restore `siteconfig.0038` dependency to `0036` (historical/applied order)
- add merge migration `siteconfig.0040_merge_0037_0039` to reconcile migration graph leaves without data changes

## Validation
- `python manage.py migrate --plan` no longer reports conflicting migrations
- `showmigrations siteconfig` includes `0040_merge_0037_0039`

## Operational impact
After merge/deploy, migration checks in tenant pods should proceed without `InconsistentMigrationHistory` for this chain.
