### PR TITLE
Fix OR-Tools adjacent-duty-day repeat assignments

### DIFF
--- a/duty_roster/ortools_scheduler.py
+++ b/duty_roster/ortools_scheduler.py
@@ -335,10 +335,11 @@ class DutyRosterScheduler:
 
     def _add_anti_repeat_constraints(self):
         """
-        Constraint: Members cannot do the same role on consecutive days.
+        Constraint: Members cannot do the same role on consecutive duty days.
 
-        Only applies to calendar-consecutive days (e.g., Saturday->Sunday),
-        not across week gaps (e.g., Sunday->next Saturday).
+        Applies to adjacent entries in the duty day sequence, which preserves
+        historical behavior for weekend rosters where the next duty day may be
+        several calendar days later (for example Sunday -> next Saturday).
         """
         for member in self.data.members:
             for role in self.data.roles:
@@ -346,15 +347,13 @@ class DutyRosterScheduler:
                     day1 = self.data.duty_days[i]
                     day2 = self.data.duty_days[i + 1]
 
-                    # Check if days are calendar-consecutive (not week-separated)
-                    if (day2 - day1).days == 1:
-                        # Check if both variables exist in our sparse set
-                        key1 = (member.id, role, day1)
-                        key2 = (member.id, role, day2)
+                    # Check if both variables exist in our sparse set
+                    key1 = (member.id, role, day1)
+                    key2 = (member.id, role, day2)
 
-                        if key1 in self.x and key2 in self.x:
-                            # Constraint: can't do same role on both days
-                            self.model.Add(self.x[key1] + self.x[key2] <= 1)
+                    if key1 in self.x and key2 in self.x:
+                        # Constraint: can't do same role on consecutive duty days
+                        self.model.Add(self.x[key1] + self.x[key2] <= 1)
 
     def _has_adjacent_weekday_pairs(self) -> bool:
         """Return True when any duty day has a matching day exactly 7 days later."""

--- a/duty_roster/tests/test_ortools_scheduler.py
+++ b/duty_roster/tests/test_ortools_scheduler.py
@@ -477,6 +477,35 @@ class ORToolsHardConstraintsTests(TestCase):
                     f"Member {day1_slots[role]} assigned to {role} on consecutive days",
                 )
 
+    def test_anti_repeat_constraint_applies_to_adjacent_duty_days(self):
+        """Test anti-repeat across adjacent duty days with a calendar gap."""
+        data = SchedulingData(
+            members=[self.member1, self.member2],
+            duty_days=[date(2026, 3, 1), date(2026, 3, 7)],
+            roles=["instructor"],
+            preferences={
+                self.member1.id: DutyPreference.objects.get(member=self.member1),
+                self.member2.id: DutyPreference.objects.get(member=self.member2),
+            },
+            blackouts=set(),
+            avoidances=set(),
+            pairings=set(),
+            role_scarcity={"instructor": {"scarcity_score": 1.0}},
+            earliest_duty_day=date(2026, 3, 1),
+        )
+
+        scheduler = DutyRosterScheduler(data)
+        result = scheduler.solve(timeout_seconds=5.0)
+
+        self.assertIn(result["status"], ("OPTIMAL", "FEASIBLE"))
+        slots_day1 = result["schedule"][0]["slots"]["instructor"]
+        slots_day2 = result["schedule"][1]["slots"]["instructor"]
+        self.assertNotEqual(
+            slots_day1,
+            slots_day2,
+            "Instructor should not repeat on adjacent duty days even across week gaps.",
+        )
+
     def test_max_assignments_constraint(self):
         """Test that members don't exceed max_assignments_per_month."""
         # Set low max for member1


### PR DESCRIPTION
## Summary
Fixes duplicate-looking roster assignments caused by OR-Tools anti-repeat behavior only applying to calendar-consecutive days.

## Problem
Recent scheduler behavior allowed the same member to be assigned to the same role on adjacent duty days when those duty days were separated by weekday gaps (for example Sunday to next Saturday).

## Changes
- Update OR-Tools anti-repeat constraint to apply across adjacent duty days in the scheduling sequence, not only day+1 calendar dates.
- Add a regression test to ensure adjacent duty-day anti-repeat is enforced across week-gap transitions.

## Files
- duty_roster/ortools_scheduler.py
- duty_roster/tests/test_ortools_scheduler.py

## Validation
- pytest duty_roster/tests/test_ortools_scheduler.py -k "anti_repeat_constraint or adjacent_weekend_spacing_enforced_with_sat_sun_schedule" -q
  - 3 passed
- Manual generation check for May-June range confirmed no adjacent-duty-day same-role repeats.
