### PR TITLE
Enforce anti-repeat across month-boundary roster runs

### DIFF
--- a/duty_roster/ortools_scheduler.py
+++ b/duty_roster/ortools_scheduler.py
@@ -11,13 +11,14 @@ Phase 2 Implementation: Full production constraints matching legacy scheduler be
 """
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import Any
 
 from ortools.sat.python import cp_model
 
 from duty_roster.models import (
+    DutyAssignment,
     DutyAvoidance,
     DutyPairing,
     DutyPreference,
@@ -72,6 +73,7 @@ class SchedulingData:
     role_scarcity: dict[str, dict[str, Any]]
     earliest_duty_day: date
     month_span: int = 1
+    prior_assignments: dict[str, int | None] = field(default_factory=dict)
 
 
 class DutyRosterScheduler:
@@ -253,6 +255,9 @@ class DutyRosterScheduler:
 
         # Constraint 6: Max assignments per month
         self._add_max_assignments_constraints()
+
+        # Constraint 7: Carry-over anti-repeat from prior duty day
+        self._add_carryover_anti_repeat_constraints()
 
         logger.info("Hard constraints added successfully")
 
@@ -439,6 +444,21 @@ class DutyRosterScheduler:
 
             if total_assignments:
                 self.model.Add(sum(total_assignments) <= max_assignments)
+
+    def _add_carryover_anti_repeat_constraints(self):
+        """Block same-role repeats from prior duty day into first scheduled day."""
+        if not self.data.duty_days:
+            return
+
+        first_day = self.data.duty_days[0]
+        for role in self.data.roles:
+            prior_member_id = self.data.prior_assignments.get(role)
+            if not prior_member_id:
+                continue
+
+            key = (prior_member_id, role, first_day)
+            if key in self.x:
+                self.model.Add(self.x[key] == 0)
 
     def _add_objective_function(self):
         """
@@ -880,6 +900,7 @@ def extract_scheduling_data(
 
     from duty_roster.roster_generator import (
         count_calendar_months_inclusive,
+        get_previous_duty_day,
         get_weekend_dates_in_range,
         resolve_roster_date_range,
     )
@@ -948,6 +969,27 @@ def extract_scheduling_data(
     # Determine earliest duty day for staleness calculation
     earliest_duty_day = min(duty_days) if duty_days else today
 
+    prior_assignments = {}
+    if duty_days:
+        previous_duty_day = get_previous_duty_day(duty_days[0])
+        if previous_duty_day:
+            previous_assignment = DutyAssignment.objects.filter(
+                date=previous_duty_day
+            ).first()
+            if previous_assignment:
+                role_to_field = {
+                    "instructor": "instructor_id",
+                    "duty_officer": "duty_officer_id",
+                    "assistant_duty_officer": "assistant_duty_officer_id",
+                    "towpilot": "tow_pilot_id",
+                }
+                for role in roles:
+                    field_name = role_to_field.get(role)
+                    if field_name:
+                        prior_assignments[role] = getattr(
+                            previous_assignment, field_name
+                        )
+
     return SchedulingData(
         members=members,
         duty_days=duty_days,
@@ -959,6 +1001,7 @@ def extract_scheduling_data(
         role_scarcity=role_scarcity,
         earliest_duty_day=earliest_duty_day,
         month_span=month_span,
+        prior_assignments=prior_assignments,
     )
 
 

--- a/duty_roster/ortools_scheduler.py
+++ b/duty_roster/ortools_scheduler.py
@@ -456,7 +456,15 @@ class DutyRosterScheduler:
                 continue
 
             key = (prior_member_id, role, first_day)
-            if key in self.x:
+            alternative_candidates = [
+                self.x[m.id, role, first_day]
+                for m in self.data.members
+                if m.id != prior_member_id and (m.id, role, first_day) in self.x
+            ]
+
+            # Only enforce carry-over hard-block when at least one alternative
+            # candidate can satisfy the slot on the first generated day.
+            if key in self.x and alternative_candidates:
                 self.model.Add(self.x[key] == 0)
 
     def _add_objective_function(self):

--- a/duty_roster/ortools_scheduler.py
+++ b/duty_roster/ortools_scheduler.py
@@ -18,7 +18,6 @@ from typing import Any
 from ortools.sat.python import cp_model
 
 from duty_roster.models import (
-    DutyAssignment,
     DutyAvoidance,
     DutyPairing,
     DutyPreference,
@@ -899,8 +898,9 @@ def extract_scheduling_data(
     from django.utils.timezone import now
 
     from duty_roster.roster_generator import (
+        DUTY_ROLE_TO_ASSIGNMENT_FIELD,
         count_calendar_months_inclusive,
-        get_previous_duty_day,
+        get_previous_scheduled_assignment,
         get_weekend_dates_in_range,
         resolve_roster_date_range,
     )
@@ -971,24 +971,12 @@ def extract_scheduling_data(
 
     prior_assignments = {}
     if duty_days:
-        previous_duty_day = get_previous_duty_day(duty_days[0])
-        if previous_duty_day:
-            previous_assignment = DutyAssignment.objects.filter(
-                date=previous_duty_day
-            ).first()
-            if previous_assignment:
-                role_to_field = {
-                    "instructor": "instructor_id",
-                    "duty_officer": "duty_officer_id",
-                    "assistant_duty_officer": "assistant_duty_officer_id",
-                    "towpilot": "tow_pilot_id",
-                }
-                for role in roles:
-                    field_name = role_to_field.get(role)
-                    if field_name:
-                        prior_assignments[role] = getattr(
-                            previous_assignment, field_name
-                        )
+        previous_assignment = get_previous_scheduled_assignment(duty_days[0])
+        if previous_assignment:
+            for role in roles:
+                field_name = DUTY_ROLE_TO_ASSIGNMENT_FIELD.get(role)
+                if field_name:
+                    prior_assignments[role] = getattr(previous_assignment, field_name)
 
     return SchedulingData(
         members=members,

--- a/duty_roster/roster_generator.py
+++ b/duty_roster/roster_generator.py
@@ -22,6 +22,13 @@ from siteconfig.models import SiteConfiguration
 
 logger = logging.getLogger("duty_roster.generator")
 
+DUTY_ROLE_TO_ASSIGNMENT_FIELD = {
+    "instructor": "instructor_id",
+    "duty_officer": "duty_officer_id",
+    "assistant_duty_officer": "assistant_duty_officer_id",
+    "towpilot": "tow_pilot_id",
+}
+
 DEFAULT_MAX_ASSIGNMENTS = 8
 DEFAULT_MAX_ASSIGNMENTS_CACHE_KEY = "duty_default_max_assignments_per_month"
 DEFAULT_MAX_ASSIGNMENTS_CACHE_TTL_SECONDS = 300
@@ -183,15 +190,16 @@ def get_weekend_dates_in_range(start_date: date, end_date: date) -> list[date]:
     return weekend_dates
 
 
-def get_previous_duty_day(anchor_date: date) -> date | None:
-    """Return the nearest prior operational weekend day before anchor_date."""
-    probe = anchor_date - timedelta(days=1)
-    # Two weeks safely spans weekend adjacency patterns across month boundaries.
-    for _ in range(14):
-        if probe.weekday() in (5, 6) and is_within_operational_season(probe):
-            return probe
-        probe -= timedelta(days=1)
-    return None
+def get_previous_scheduled_assignment(anchor_date: date):
+    """Return most recent scheduled DutyAssignment before anchor_date."""
+    return (
+        DutyAssignment.objects.filter(
+            date__lt=anchor_date,
+            is_scheduled=True,
+        )
+        .order_by("-date")
+        .first()
+    )
 
 
 def count_calendar_months_inclusive(start_date: date, end_date: date) -> int:
@@ -798,22 +806,12 @@ def _generate_roster_legacy(
     schedule = []
     last_assigned = {role: None for role in roles_to_schedule}
     if weekend_dates:
-        previous_duty_day = get_previous_duty_day(weekend_dates[0])
-        if previous_duty_day:
-            previous_assignment = DutyAssignment.objects.filter(
-                date=previous_duty_day
-            ).first()
-            if previous_assignment:
-                role_to_field = {
-                    "instructor": "instructor_id",
-                    "duty_officer": "duty_officer_id",
-                    "assistant_duty_officer": "assistant_duty_officer_id",
-                    "towpilot": "tow_pilot_id",
-                }
-                for role in roles_to_schedule:
-                    field_name = role_to_field.get(role)
-                    if field_name:
-                        last_assigned[role] = getattr(previous_assignment, field_name)
+        previous_assignment = get_previous_scheduled_assignment(weekend_dates[0])
+        if previous_assignment:
+            for role in roles_to_schedule:
+                field_name = DUTY_ROLE_TO_ASSIGNMENT_FIELD.get(role)
+                if field_name:
+                    last_assigned[role] = getattr(previous_assignment, field_name)
     for day in weekend_dates:
         assigned_today = set()
         slots = {}

--- a/duty_roster/roster_generator.py
+++ b/duty_roster/roster_generator.py
@@ -16,17 +16,14 @@ from duty_roster.models import (
     MemberBlackout,
 )
 from duty_roster.operational_calendar import get_operational_weekend
-from members.constants.membership import DEFAULT_ROLES
+from members.constants.membership import DEFAULT_ROLES, ROLE_FIELD_MAP
 from members.models import Member
 from siteconfig.models import SiteConfiguration
 
 logger = logging.getLogger("duty_roster.generator")
 
 DUTY_ROLE_TO_ASSIGNMENT_FIELD = {
-    "instructor": "instructor_id",
-    "duty_officer": "duty_officer_id",
-    "assistant_duty_officer": "assistant_duty_officer_id",
-    "towpilot": "tow_pilot_id",
+    role: f"{field_name}_id" for role, field_name in ROLE_FIELD_MAP.items()
 }
 
 DEFAULT_MAX_ASSIGNMENTS = 8

--- a/duty_roster/roster_generator.py
+++ b/duty_roster/roster_generator.py
@@ -9,6 +9,7 @@ from decimal import ROUND_CEILING, Decimal
 from django.core.cache import cache
 
 from duty_roster.models import (
+    DutyAssignment,
     DutyAvoidance,
     DutyPairing,
     DutyPreference,
@@ -180,6 +181,17 @@ def get_weekend_dates_in_range(start_date: date, end_date: date) -> list[date]:
             weekend_dates.append(current)
         current += timedelta(days=1)
     return weekend_dates
+
+
+def get_previous_duty_day(anchor_date: date) -> date | None:
+    """Return the nearest prior operational weekend day before anchor_date."""
+    probe = anchor_date - timedelta(days=1)
+    # Two weeks safely spans weekend adjacency patterns across month boundaries.
+    for _ in range(14):
+        if probe.weekday() in (5, 6) and is_within_operational_season(probe):
+            return probe
+        probe -= timedelta(days=1)
+    return None
 
 
 def count_calendar_months_inclusive(start_date: date, end_date: date) -> int:
@@ -785,6 +797,23 @@ def _generate_roster_legacy(
 
     schedule = []
     last_assigned = {role: None for role in roles_to_schedule}
+    if weekend_dates:
+        previous_duty_day = get_previous_duty_day(weekend_dates[0])
+        if previous_duty_day:
+            previous_assignment = DutyAssignment.objects.filter(
+                date=previous_duty_day
+            ).first()
+            if previous_assignment:
+                role_to_field = {
+                    "instructor": "instructor_id",
+                    "duty_officer": "duty_officer_id",
+                    "assistant_duty_officer": "assistant_duty_officer_id",
+                    "towpilot": "tow_pilot_id",
+                }
+                for role in roles_to_schedule:
+                    field_name = role_to_field.get(role)
+                    if field_name:
+                        last_assigned[role] = getattr(previous_assignment, field_name)
     for day in weekend_dates:
         assigned_today = set()
         slots = {}

--- a/duty_roster/tests/test_ortools_scheduler.py
+++ b/duty_roster/tests/test_ortools_scheduler.py
@@ -560,6 +560,34 @@ class ORToolsHardConstraintsTests(TestCase):
             "Expected latest scheduled assignment to be used for carry-over.",
         )
 
+    def test_carryover_hard_block_skips_when_no_alternative_candidate(self):
+        """Carry-over should not make model infeasible when first day has one option."""
+        data = SchedulingData(
+            members=[self.member1],
+            duty_days=[date(2026, 3, 1)],
+            roles=["instructor"],
+            preferences={
+                self.member1.id: DutyPreference.objects.get(member=self.member1),
+            },
+            blackouts=set(),
+            avoidances=set(),
+            pairings=set(),
+            role_scarcity={"instructor": {"scarcity_score": 1.0}},
+            earliest_duty_day=date(2026, 3, 1),
+            prior_assignments={"instructor": self.member1.id},
+        )
+
+        scheduler = DutyRosterScheduler(data)
+        result = scheduler.solve(timeout_seconds=5.0)
+
+        self.assertIn(result["status"], ("OPTIMAL", "FEASIBLE"))
+        assigned = result["schedule"][0]["slots"]["instructor"]
+        self.assertEqual(
+            assigned,
+            self.member1.id,
+            "Expected first day to remain assignable when no alternative exists.",
+        )
+
     def test_max_assignments_constraint(self):
         """Test that members don't exceed max_assignments_per_month."""
         # Set low max for member1

--- a/duty_roster/tests/test_ortools_scheduler.py
+++ b/duty_roster/tests/test_ortools_scheduler.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from duty_roster.models import (
+    DutyAssignment,
     DutyAvoidance,
     DutyPairing,
     DutyPreference,
@@ -504,6 +505,32 @@ class ORToolsHardConstraintsTests(TestCase):
             slots_day1,
             slots_day2,
             "Instructor should not repeat on adjacent duty days even across week gaps.",
+        )
+
+    def test_carryover_anti_repeat_blocks_first_day_repeat(self):
+        """First generated day should respect prior published duty-day assignment."""
+        DutyAssignment.objects.create(
+            date=date(2026, 2, 28),
+            instructor=self.member1,
+        )
+
+        data = extract_scheduling_data(
+            start_date=date(2026, 3, 1),
+            end_date=date(2026, 3, 1),
+            roles=["instructor"],
+        )
+
+        self.assertEqual(data.prior_assignments.get("instructor"), self.member1.id)
+
+        scheduler = DutyRosterScheduler(data)
+        result = scheduler.solve(timeout_seconds=5.0)
+
+        self.assertIn(result["status"], ("OPTIMAL", "FEASIBLE"))
+        assigned = result["schedule"][0]["slots"]["instructor"]
+        self.assertNotEqual(
+            assigned,
+            self.member1.id,
+            "Carry-over anti-repeat should prevent first-day same-role repeat.",
         )
 
     def test_max_assignments_constraint(self):

--- a/duty_roster/tests/test_ortools_scheduler.py
+++ b/duty_roster/tests/test_ortools_scheduler.py
@@ -533,6 +533,33 @@ class ORToolsHardConstraintsTests(TestCase):
             "Carry-over anti-repeat should prevent first-day same-role repeat.",
         )
 
+    def test_carryover_uses_latest_scheduled_assignment_only(self):
+        """Carry-over source should skip ad-hoc days and use latest scheduled day."""
+        # Last published/scheduled roster day before anchor
+        DutyAssignment.objects.create(
+            date=date(2026, 2, 21),
+            instructor=self.member1,
+            is_scheduled=True,
+        )
+        # Later ad-hoc day should be ignored for carry-over sourcing
+        DutyAssignment.objects.create(
+            date=date(2026, 2, 28),
+            instructor=self.member2,
+            is_scheduled=False,
+        )
+
+        data = extract_scheduling_data(
+            start_date=date(2026, 3, 1),
+            end_date=date(2026, 3, 1),
+            roles=["instructor"],
+        )
+
+        self.assertEqual(
+            data.prior_assignments.get("instructor"),
+            self.member1.id,
+            "Expected latest scheduled assignment to be used for carry-over.",
+        )
+
     def test_max_assignments_constraint(self):
         """Test that members don't exceed max_assignments_per_month."""
         # Set low max for member1


### PR DESCRIPTION
## Summary
Enforces anti-repeat behavior across separate roster-generation runs by carrying forward the prior duty-day assignment into the first generated day.

## Problem
The anti-repeat rule was only applied within the current generated date range. If April had already been published and May was generated later, the first May duty day could reuse the same member/role from the last April duty day.

## Changes
- Added previous-duty-day lookup utility in the generator.
- Legacy scheduler now seeds last-assigned role state from the prior published duty day.
- OR-Tools scheduler now loads prior role assignments into scheduling data and adds a hard carry-over anti-repeat constraint on the first generated day.
- Added regression test for cross-run carry-over enforcement.

## Files
- duty_roster/roster_generator.py
- duty_roster/ortools_scheduler.py
- duty_roster/tests/test_ortools_scheduler.py

## Validation
- pytest duty_roster/tests/test_ortools_scheduler.py -k "carryover_anti_repeat_blocks_first_day_repeat or anti_repeat_constraint" -q
  - 3 passed
- Manual tenant check (April published -> May generated): no carry-over repeats on first May duty day across all core roles.
