### PR TITLE
Fix Dependabot alerts # 40-# 45 via Django/cryptography bumps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,12 +15,12 @@ charset-normalizer==3.4.3
 click==8.3.0
 coverage==7.11.0
 crispy-bootstrap4==2025.6
-cryptography==46.0.6
+cryptography==46.0.7
 cyclonedx-python-lib==9.1.0
 defusedxml==0.7.1
 diff-match-patch==20241021
 distlib==0.4.0
-Django==5.2.12
+Django==5.2.13
 django-crispy-forms==2.4
 django-extensions==4.1
 django-htmx==1.23.2


### PR DESCRIPTION
## Summary
Resolve all 6 open Dependabot alerts by bumping vulnerable direct dependencies in `requirements.txt`.

## Updated packages
- `Django` from `5.2.12` to `5.2.13`
- `cryptography` from `46.0.6` to `46.0.7`

## Alerts addressed
- Alert # 40 (Django)
- Alert # 41 (Django)
- Alert # 42 (Django)
- Alert # 43 (Django)
- Alert # 44 (Django)
- Alert # 45 (cryptography)

## Validation
- Installed patched versions in venv:
  - `django 5.2.13`
  - `cryptography 46.0.7`
- Pre-commit hooks passed on commit.
