### PR TITLE
Improve duty roster dual-role balance weighting

### DIFF
--- a/docs/resolved-issues/README.md
+++ b/docs/resolved-issues/README.md
@@ -8,21 +8,6 @@ Each document provides detailed technical analysis, implementation details, test
 
 ## Resolved Issues
 
-### [Issue #749 - Flight Cost Backfill Skip Logic](issue-749-flight-cost-backfill-skip.md)
-**Status**: Complete ✅ | **Date**: March 8, 2026 | **Branch**: `feature/issue-749-update-flight-cost-backfill` | **PR**: #750
-
-Fixed a financial backfill edge case where `update_flight_costs` skipped rental updates when tow actual values were already present.
-
-**Key Achievements**:
-- ✅ Independent field-level backfill logic for tow and rental actuals
-- ✅ Regression tests for rental backfill with existing tow values
-- ✅ Boundary test coverage for strict `--after` date behavior
-- ✅ Safe production behavior with no schema migration required
-
-**Technologies**: Django management commands, pytest, financial data backfill logic
-
----
-
 ### [Dual-Role Balance Weighting (Duty Roster)](issue-dual-role-balance-weighting.md)
 **Status**: Complete ✅ | **Date**: April 9, 2026 | **Branch**: `feature/fix-dual-role-balance-weighting`
 
@@ -35,6 +20,21 @@ Improved OR-Tools objective behavior for dual-role members (for example `instruc
 - ✅ Documented tenant-specific allegation context and fix rationale
 
 **Technologies**: OR-Tools CP-SAT objective tuning, Django duty roster scheduling, pytest regression tests
+
+---
+
+### [Issue #749 - Flight Cost Backfill Skip Logic](issue-749-flight-cost-backfill-skip.md)
+**Status**: Complete ✅ | **Date**: March 8, 2026 | **Branch**: `feature/issue-749-update-flight-cost-backfill` | **PR**: #750
+
+Fixed a financial backfill edge case where `update_flight_costs` skipped rental updates when tow actual values were already present.
+
+**Key Achievements**:
+- ✅ Independent field-level backfill logic for tow and rental actuals
+- ✅ Regression tests for rental backfill with existing tow values
+- ✅ Boundary test coverage for strict `--after` date behavior
+- ✅ Safe production behavior with no schema migration required
+
+**Technologies**: Django management commands, pytest, financial data backfill logic
 
 ---
 

--- a/docs/resolved-issues/README.md
+++ b/docs/resolved-issues/README.md
@@ -106,6 +106,21 @@ Enhanced logsheet unfinalization permissions expanding access beyond superuser-o
 
 ---
 
+### [Dual-Role Balance Weighting (Duty Roster)](issue-dual-role-balance-weighting.md)
+**Status**: Complete ✅ | **Date**: April 9, 2026 | **Branch**: `feature/fix-dual-role-balance-weighting`
+
+Improved OR-Tools objective behavior for dual-role members (for example `instructor` + `towpilot`) so assignment outcomes better follow configured split preferences instead of drifting into a single role.
+
+**Key Achievements**:
+- ✅ Added multi-role split balancing soft objective terms
+- ✅ Preserved hard feasibility constraints while improving fairness pressure
+- ✅ Added targeted regression coverage to verify reduced role-drift
+- ✅ Documented tenant-specific allegation context and fix rationale
+
+**Technologies**: OR-Tools CP-SAT objective tuning, Django duty roster scheduling, pytest regression tests
+
+---
+
 ### [GitHub MCP Integration Enhancement](github-mcp-integration-enhancement.md)
 **Status**: Complete ✅ | **Date**: October 29, 2025 | **Scope**: Development Workflow
 

--- a/docs/resolved-issues/README.md
+++ b/docs/resolved-issues/README.md
@@ -23,6 +23,21 @@ Fixed a financial backfill edge case where `update_flight_costs` skipped rental 
 
 ---
 
+### [Dual-Role Balance Weighting (Duty Roster)](issue-dual-role-balance-weighting.md)
+**Status**: Complete ✅ | **Date**: April 9, 2026 | **Branch**: `feature/fix-dual-role-balance-weighting`
+
+Improved OR-Tools objective behavior for dual-role members (for example `instructor` + `towpilot`) so assignment outcomes better follow configured split preferences instead of drifting into a single role.
+
+**Key Achievements**:
+- ✅ Added multi-role split balancing soft objective terms
+- ✅ Preserved hard feasibility constraints while improving fairness pressure
+- ✅ Added targeted regression coverage to verify reduced role-drift
+- ✅ Documented tenant-specific allegation context and fix rationale
+
+**Technologies**: OR-Tools CP-SAT objective tuning, Django duty roster scheduling, pytest regression tests
+
+---
+
 ### [Issue #253 - Bootstrap5 Logsheet UI/UX Modernization](issue-253-bootstrap5-logsheet-ui-ux.md)
 **Status**: Complete ✅ | **Date**: November 11, 2025 | **Branch**: `issue-253` | **PR**: #255
 
@@ -103,21 +118,6 @@ Enhanced logsheet unfinalization permissions expanding access beyond superuser-o
 - ✅ Enhanced error messages and UI feedback
 
 **Technologies**: Django permissions, RevisionLog integration, Role-based access control, Member model fields
-
----
-
-### [Dual-Role Balance Weighting (Duty Roster)](issue-dual-role-balance-weighting.md)
-**Status**: Complete ✅ | **Date**: April 9, 2026 | **Branch**: `feature/fix-dual-role-balance-weighting`
-
-Improved OR-Tools objective behavior for dual-role members (for example `instructor` + `towpilot`) so assignment outcomes better follow configured split preferences instead of drifting into a single role.
-
-**Key Achievements**:
-- ✅ Added multi-role split balancing soft objective terms
-- ✅ Preserved hard feasibility constraints while improving fairness pressure
-- ✅ Added targeted regression coverage to verify reduced role-drift
-- ✅ Documented tenant-specific allegation context and fix rationale
-
-**Technologies**: OR-Tools CP-SAT objective tuning, Django duty roster scheduling, pytest regression tests
 
 ---
 

--- a/docs/resolved-issues/issue-dual-role-balance-weighting.md
+++ b/docs/resolved-issues/issue-dual-role-balance-weighting.md
@@ -1,0 +1,58 @@
+# Dual-Role Balance Weighting (Duty Roster)
+
+**Status**: Complete
+**Date**: April 9, 2026
+**App**: `duty_roster`
+**Tenant Context**: `tenant-ssc`
+
+## Problem Summary
+A scheduling fairness concern was raised for members who can serve in both `instructor` and `towpilot` roles.
+
+Observed pattern:
+- Some dual-role members were repeatedly assigned to only one role over a generated range.
+- Example allegation: members with 50/50 preference were effectively stuck in a single role.
+
+This was difficult to validate operationally because there are relatively few real scheduling cycles and only a small number of dual-role members in this tenant.
+
+## Root Cause
+The OR-Tools objective already optimized for:
+- role preference weighting,
+- pairing affinity,
+- staleness balancing,
+- assignment concentration,
+- weekend spacing.
+
+However, there was no explicit per-member multi-role split term in the objective.
+
+Result: even when a member had non-zero percentages in multiple roles (for example 50/50 or 25/75), the solver could still settle into one role if other objective terms and constraints made that locally attractive.
+
+## Fix Implemented
+A new soft objective component was added to the OR-Tools scheduler to penalize drift from each dual-role member's preferred split across the generated window.
+
+### What changed
+- Added `ROLE_SPLIT_BALANCE_WEIGHT` constant in `duty_roster/ortools_scheduler.py`.
+- Added `_add_role_split_balance_soft_constraints()` and integrated it into objective building.
+- For each member with at least two eligible roles in the model:
+  - compute role assignment counts across the window,
+  - compute deviation from percentage targets,
+  - add absolute-deviation penalty terms to the objective.
+
+### Preference handling behavior
+- If all relevant role percentages are zero for a multi-role member, roles are treated as equally targeted.
+- If only one role has a positive target, no split balancing is enforced (no split to balance).
+
+## Validation
+Targeted regression test added:
+- `test_role_split_penalty_reduces_dual_role_drift`
+
+What it verifies:
+- With role-split weight disabled, baseline drift is measured.
+- With role-split weight enabled, drift is reduced or at least not worsened.
+
+## Notes and Limits
+- This is a **soft** fairness objective, not a hard constraint.
+- In tight staffing scenarios, hard coverage constraints still take priority over ideal split percentages.
+- The fix improves balancing pressure while preserving model feasibility and operational coverage.
+
+## Outcome
+Dual-role assignment behavior now has explicit balancing pressure aligned with configured percentages, reducing the tendency for members to become stuck in only one of their qualified roles.

--- a/duty_roster/ortools_scheduler.py
+++ b/duty_roster/ortools_scheduler.py
@@ -479,7 +479,8 @@ class DutyRosterScheduler:
         2. Pairing affinity bonus (members who prefer to work together)
         3. Last duty date balancing (prioritize members who haven't worked recently)
         4. Balanced assignment distribution (minimize variance across members)
-        5. Weekend spacing preference (favor wider, more consistent repeat gaps)
+        5. Multi-role split balancing (reduce drift from configured role split)
+        6. Weekend spacing preference (favor wider, more consistent repeat gaps)
 
         The solver will maximize the sum of these weighted terms while respecting
         all hard constraints.

--- a/duty_roster/ortools_scheduler.py
+++ b/duty_roster/ortools_scheduler.py
@@ -40,6 +40,9 @@ FAIRNESS_PENALTY_WEIGHT = (
 MAX_ASSIGNMENT_CONCENTRATION_WEIGHT = (
     120  # Extra penalty for high single-member assignment concentration
 )
+ROLE_SPLIT_BALANCE_WEIGHT = (
+    1  # Penalty weight for drifting away from preferred multi-role split
+)
 WEEKEND_SPACING_PENALTY_BY_LAG_WEEKS = {
     1: 60,
     2: 20,
@@ -628,7 +631,10 @@ class DutyRosterScheduler:
                     -MAX_ASSIGNMENT_CONCENTRATION_WEIGHT * max_member_load
                 )
 
-            # Soft constraint 5: Weekend spacing preference and consistency
+            # Soft constraint 5: Multi-role split balancing per member
+            self._add_role_split_balance_soft_constraints(objective_terms)
+
+            # Soft constraint 6: Weekend spacing preference and consistency
             self._add_weekend_spacing_soft_constraints(
                 objective_terms, member_assigned_on_day
             )
@@ -636,6 +642,94 @@ class DutyRosterScheduler:
         # Set objective: maximize total weighted satisfaction
         self.model.Maximize(sum(objective_terms))
         logger.info(f"Objective function built with {len(objective_terms)} terms")
+
+    def _add_role_split_balance_soft_constraints(self, objective_terms):
+        """Penalize drift from preferred role split for multi-role members."""
+        if not self.data.duty_days:
+            return
+
+        max_days = len(self.data.duty_days)
+
+        for member in self.data.members:
+            pref = self.data.preferences.get(member.id)
+            if not pref:
+                continue
+
+            eligible_roles = [
+                role
+                for role in self.data.roles
+                if getattr(member, role, False)
+                and any((member.id, role, day) in self.x for day in self.data.duty_days)
+            ]
+            if len(eligible_roles) < 2:
+                continue
+
+            role_percentages = {
+                role: self._get_role_percent(pref, role) for role in eligible_roles
+            }
+            if all(percent == 0 for percent in role_percentages.values()):
+                role_targets = {role: 1 for role in eligible_roles}
+            else:
+                role_targets = {
+                    role: percent
+                    for role, percent in role_percentages.items()
+                    if percent > 0
+                }
+                if len(role_targets) < 2:
+                    continue
+
+            denominator = sum(role_targets.values())
+            role_count_vars = {}
+
+            for role in role_targets:
+                role_vars = [
+                    self.x[member.id, role, day]
+                    for day in self.data.duty_days
+                    if (member.id, role, day) in self.x
+                ]
+                if not role_vars:
+                    continue
+
+                count_var = self.model.NewIntVar(
+                    0,
+                    max_days,
+                    f"role_count_{member.id}_{role}",
+                )
+                self.model.Add(count_var == sum(role_vars))
+                role_count_vars[role] = count_var
+
+            if len(role_count_vars) < 2:
+                continue
+
+            total_var = self.model.NewIntVar(
+                0,
+                max_days,
+                f"role_count_total_{member.id}",
+            )
+            self.model.Add(total_var == sum(role_count_vars.values()))
+
+            abs_bound = denominator * max_days
+            for role, target in role_targets.items():
+                count_var = role_count_vars.get(role)
+                if count_var is None:
+                    continue
+
+                deviation = self.model.NewIntVar(
+                    -abs_bound,
+                    abs_bound,
+                    f"role_split_dev_{member.id}_{role}",
+                )
+                self.model.Add(
+                    deviation == denominator * count_var - target * total_var
+                )
+
+                abs_deviation = self.model.NewIntVar(
+                    0,
+                    abs_bound,
+                    f"role_split_abs_dev_{member.id}_{role}",
+                )
+                self.model.AddAbsEquality(abs_deviation, deviation)
+                objective_terms.append(-ROLE_SPLIT_BALANCE_WEIGHT * abs_deviation)
 
     def _add_weekend_spacing_soft_constraints(
         self, objective_terms, member_assigned_on_day

--- a/duty_roster/tests/test_ortools_scheduler.py
+++ b/duty_roster/tests/test_ortools_scheduler.py
@@ -889,9 +889,18 @@ class ORToolsHardConstraintsTests(TestCase):
             month_span=1,
         )
 
+        deterministic_seed = 12345
+
+        baseline_scheduler = DutyRosterScheduler(data)
+        baseline_scheduler.solver.parameters.num_search_workers = 1
+        baseline_scheduler.solver.parameters.random_seed = deterministic_seed
         with patch("duty_roster.ortools_scheduler.ROLE_SPLIT_BALANCE_WEIGHT", 0):
-            baseline = DutyRosterScheduler(data).solve(timeout_seconds=10.0)
-        tuned = DutyRosterScheduler(data).solve(timeout_seconds=10.0)
+            baseline = baseline_scheduler.solve(timeout_seconds=10.0)
+
+        tuned_scheduler = DutyRosterScheduler(data)
+        tuned_scheduler.solver.parameters.num_search_workers = 1
+        tuned_scheduler.solver.parameters.random_seed = deterministic_seed
+        tuned = tuned_scheduler.solve(timeout_seconds=10.0)
 
         self.assertIn(baseline["status"], ("OPTIMAL", "FEASIBLE"))
         self.assertIn(tuned["status"], ("OPTIMAL", "FEASIBLE"))

--- a/duty_roster/tests/test_ortools_scheduler.py
+++ b/duty_roster/tests/test_ortools_scheduler.py
@@ -23,6 +23,7 @@ from duty_roster.models import (
 )
 from duty_roster.ortools_scheduler import (
     MAX_ASSIGNMENT_CONCENTRATION_WEIGHT,
+    ROLE_SPLIT_BALANCE_WEIGHT,
     WEEKEND_SPACING_PENALTY_BY_LAG_WEEKS,
     DutyRosterScheduler,
     SchedulingData,
@@ -803,6 +804,119 @@ class ORToolsHardConstraintsTests(TestCase):
             tuned_peak,
             baseline_peak,
             f"Expected tuned objective to reduce or match peak load; baseline={baseline_peak}, tuned={tuned_peak}",
+        )
+
+    def test_role_split_penalty_reduces_dual_role_drift(self):
+        """Role-split penalty should not worsen dual-role split drift."""
+        dual_member = Member.objects.create(
+            username="dual_split_member",
+            email="dual_split_member@test.com",
+            first_name="Dual",
+            last_name="Split",
+            membership_status="Full Member",
+            instructor=True,
+            towpilot=True,
+            is_active=True,
+        )
+        dual_pref = DutyPreference.objects.create(member=dual_member)
+        dual_pref.instructor_percent = 50
+        dual_pref.towpilot_percent = 50
+        dual_pref.max_assignments_per_month = 8
+        dual_pref.allow_weekend_double = True
+        dual_pref.last_duty_date = date(2019, 1, 1)
+        dual_pref.save()
+
+        instructor_only = Member.objects.create(
+            username="instructor_only_split",
+            email="instructor_only_split@test.com",
+            first_name="Instructor",
+            last_name="Only",
+            membership_status="Full Member",
+            instructor=True,
+            is_active=True,
+        )
+        DutyPreference.objects.create(
+            member=instructor_only,
+            instructor_percent=100,
+            max_assignments_per_month=8,
+            allow_weekend_double=True,
+            last_duty_date=date(2026, 3, 20),
+        )
+
+        tow_only = Member.objects.create(
+            username="tow_only_split",
+            email="tow_only_split@test.com",
+            first_name="Tow",
+            last_name="Only",
+            membership_status="Full Member",
+            towpilot=True,
+            is_active=True,
+        )
+        DutyPreference.objects.create(
+            member=tow_only,
+            towpilot_percent=100,
+            max_assignments_per_month=8,
+            allow_weekend_double=True,
+            last_duty_date=date(2026, 3, 20),
+        )
+
+        duty_days = [
+            date(2026, 4, 4),
+            date(2026, 4, 5),
+            date(2026, 4, 11),
+            date(2026, 4, 12),
+            date(2026, 4, 18),
+            date(2026, 4, 19),
+        ]
+
+        data = SchedulingData(
+            members=[dual_member, instructor_only, tow_only],
+            duty_days=duty_days,
+            roles=["instructor", "towpilot"],
+            preferences={
+                dual_member.id: dual_pref,
+                instructor_only.id: DutyPreference.objects.get(member=instructor_only),
+                tow_only.id: DutyPreference.objects.get(member=tow_only),
+            },
+            blackouts=set(),
+            avoidances=set(),
+            pairings=set(),
+            role_scarcity={
+                "instructor": {"scarcity_score": 1.0},
+                "towpilot": {"scarcity_score": 1.0},
+            },
+            earliest_duty_day=duty_days[0],
+            month_span=1,
+        )
+
+        with patch("duty_roster.ortools_scheduler.ROLE_SPLIT_BALANCE_WEIGHT", 0):
+            baseline = DutyRosterScheduler(data).solve(timeout_seconds=10.0)
+        tuned = DutyRosterScheduler(data).solve(timeout_seconds=10.0)
+
+        self.assertIn(baseline["status"], ("OPTIMAL", "FEASIBLE"))
+        self.assertIn(tuned["status"], ("OPTIMAL", "FEASIBLE"))
+        self.assertGreater(ROLE_SPLIT_BALANCE_WEIGHT, 0)
+
+        def _dual_counts(result):
+            instructor_count = 0
+            tow_count = 0
+            for day in result["schedule"]:
+                if day["slots"].get("instructor") == dual_member.id:
+                    instructor_count += 1
+                if day["slots"].get("towpilot") == dual_member.id:
+                    tow_count += 1
+            return instructor_count, tow_count
+
+        baseline_inst, baseline_tow = _dual_counts(baseline)
+        tuned_inst, tuned_tow = _dual_counts(tuned)
+
+        baseline_drift = abs(baseline_inst - baseline_tow)
+        tuned_drift = abs(tuned_inst - tuned_tow)
+
+        self.assertLessEqual(
+            tuned_drift,
+            baseline_drift,
+            f"Expected role split penalty to reduce or match drift; baseline={baseline_drift}, tuned={tuned_drift}",
         )
 
     def test_adjacent_weekend_spacing_can_make_schedule_infeasible(self):


### PR DESCRIPTION
## Summary
Improve dual-role assignment fairness in OR-Tools duty roster generation and document the resolved issue.

## Problem
For dual-qualified members (instructor + towpilot), generated schedules could drift into one role repeatedly, even when member preferences requested split distribution (for example 50/50).

## Changes
- Added multi-role split drift penalty objective terms in OR-Tools scheduler.
- Added regression coverage around role-split drift behavior.
- Added resolved-issue documentation:
  - docs/resolved-issues/issue-dual-role-balance-weighting.md
- Added entry to docs/resolved-issues/README.md index.

## Validation
- `pytest duty_roster/tests/test_ortools_scheduler.py -k "role_split_penalty_reduces_dual_role_drift" -q`
  - 1 passed
