### PR TITLE
Issue #854: fix reservation period messaging and signed-up flyer visibility

### DIFF
--- a/duty_roster/management/commands/send_duty_preop_emails.py
+++ b/duty_roster/management/commands/send_duty_preop_emails.py
@@ -10,8 +10,9 @@ with information about:
 - Upcoming maintenance deadlines
 
 Each duty crew member receives an individual email with an ICS calendar attachment
-for their specific duty role. Students requesting instruction and members with ops
-intent are CC'd on each email to keep them informed.
+for their specific duty role. Signed-up flyers (students requesting instruction,
+members with ops intent, and confirmed reservation participants) receive their own
+dedicated participant email with a generic Flying Day ICS.
 """
 
 from datetime import datetime, timedelta

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -484,20 +484,30 @@
       {# List of pilots planning to fly #}
       {% if signed_up_flyers %}
       <hr class="my-3">
+      <p class="text-muted small mb-2">
+        Total signed-up flyers (including students requesting instruction):
+        <strong>{{ signed_up_flyer_count }}</strong>
+      </p>
+      {% if signed_up_non_instruction_flyers %}
       <h6 class="fw-semibold text-primary mb-2">
-        <i class="bi bi-people me-2" aria-hidden="true"></i>Pilots Planning to Fly ({{ signed_up_flyer_count }}):
+        <i class="bi bi-people me-2" aria-hidden="true"></i>Other Pilots Planning to Fly ({{ signed_up_non_instruction_flyer_count }}):
       </h6>
       <ul class="list-group list-group-flush">
-        {% for member in signed_up_flyers %}
+        {% for member in signed_up_non_instruction_flyers %}
         <li class="list-group-item px-0 py-1">
           <i class="bi bi-person me-2 text-muted" aria-hidden="true"></i>{{ member.full_display_name }}
         </li>
         {% endfor %}
       </ul>
       {% else %}
+      <p class="text-muted mb-0">
+        <i class="bi bi-info-circle me-2" aria-hidden="true"></i>No additional pilots beyond students requesting instruction.
+      </p>
+      {% endif %}
+      {% else %}
       <hr class="my-3">
       <p class="text-muted mb-0">
-        <i class="bi bi-info-circle me-2" aria-hidden="true"></i>No one has declared intent yet.
+        <i class="bi bi-info-circle me-2" aria-hidden="true"></i>No one has signed up to fly yet.
       </p>
       {% endif %}
     </div>

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -490,7 +490,7 @@
       </p>
       {% if signed_up_non_instruction_flyers %}
       <h6 class="fw-semibold text-primary mb-2">
-        <i class="bi bi-people me-2" aria-hidden="true"></i>Other Pilots Planning to Fly ({{ signed_up_non_instruction_flyer_count }}):
+        <i class="bi bi-people me-2" aria-hidden="true"></i>Pilots Planning to Fly ({{ signed_up_non_instruction_flyer_count }}):
       </h6>
       <ul class="list-group list-group-flush">
         {% for member in signed_up_non_instruction_flyers %}

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -482,15 +482,15 @@
       </div>
 
       {# List of pilots planning to fly #}
-      {% if intents %}
+      {% if signed_up_flyers %}
       <hr class="my-3">
       <h6 class="fw-semibold text-primary mb-2">
-        <i class="bi bi-people me-2" aria-hidden="true"></i>Pilots Planning to Fly:
+        <i class="bi bi-people me-2" aria-hidden="true"></i>Pilots Planning to Fly ({{ signed_up_flyer_count }}):
       </h6>
       <ul class="list-group list-group-flush">
-        {% for intent in intents %}
+        {% for member in signed_up_flyers %}
         <li class="list-group-item px-0 py-1">
-          <i class="bi bi-person me-2 text-muted" aria-hidden="true"></i>{{ intent.member.full_display_name }}
+          <i class="bi bi-person me-2 text-muted" aria-hidden="true"></i>{{ member.full_display_name }}
         </li>
         {% endfor %}
       </ul>
@@ -523,7 +523,7 @@
       <h6 class="fw-semibold text-secondary mb-2">Requirements</h6>
       <ul class="mb-3 text-muted small">
         <li>You must be an active member in good standing.</li>
-        <li>You must have reservations remaining for the year.</li>
+        <li>You must have reservations remaining for this {{ reservation_period_label }}.</li>
         <li>Glider availability and existing reservations still apply.</li>
         <li>Aircraft may have overdue maintenance deadlines; review warnings before flying.</li>
       </ul>
@@ -535,7 +535,7 @@
 
       {% if reservations_remaining is not None %}
       <p class="text-muted small mb-2">
-        Reservations remaining this year: <strong>{{ reservations_remaining }}</strong>
+        Reservations remaining this {{ reservation_period_label }}: <strong>{{ reservations_remaining }}</strong>
       </p>
       {% endif %}
 

--- a/duty_roster/tests/test_glider_reservations.py
+++ b/duty_roster/tests/test_glider_reservations.py
@@ -18,7 +18,12 @@ from django.urls import reverse
 from django.utils import timezone
 
 from duty_roster.forms import GliderReservationForm
-from duty_roster.models import DutyAssignment, GliderReservation, OpsIntent
+from duty_roster.models import (
+    DutyAssignment,
+    GliderReservation,
+    InstructionSlot,
+    OpsIntent,
+)
 from logsheet.models import Glider, MaintenanceDeadline, MaintenanceIssue
 from siteconfig.models import SiteConfiguration
 
@@ -976,9 +981,98 @@ class TestGliderReservationViews:
 
         assert response.status_code == 200
         content = response.content.decode("utf-8")
-        assert "Pilots Planning to Fly (2):" in content
+        assert "Other Pilots Planning to Fly (2):" in content
         assert member.full_display_name in content
         assert other_member.full_display_name in content
+
+    def test_calendar_day_modal_other_pilots_excludes_instruction_students(
+        self, client, site_config, member, glider, django_user_model
+    ):
+        """Instruction students are excluded from the 'other pilots' list."""
+        target_date = timezone.now().date() + timedelta(days=13)
+        assignment = DutyAssignment.objects.create(date=target_date)
+
+        other_member = django_user_model.objects.create_user(
+            username="otherpilot",
+            email="otherpilot@example.com",
+            password="testpass123",
+            first_name="Other",
+            last_name="Pilot",
+            membership_status="Full Member",
+        )
+
+        InstructionSlot.objects.create(
+            assignment=assignment,
+            student=member,
+            status="confirmed",
+        )
+        OpsIntent.objects.create(
+            member=member,
+            date=target_date,
+            available_as=["club_single"],
+        )
+        GliderReservation.objects.create(
+            member=other_member,
+            glider=glider,
+            date=target_date,
+            reservation_type="solo",
+            time_preference="morning",
+        )
+
+        client.force_login(member)
+        response = client.get(
+            reverse(
+                "duty_roster:calendar_day_detail",
+                args=[target_date.year, target_date.month, target_date.day],
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert (
+            "Total signed-up flyers (including students requesting instruction):"
+            in content
+        )
+        assert "<strong>2</strong>" in content
+        assert "Other Pilots Planning to Fly (1):" in content
+        assert other_member.full_display_name in content
+
+    def test_calendar_day_modal_shows_no_other_pilots_when_only_instruction_students(
+        self, client, site_config, member, glider
+    ):
+        """When only instruction students are signed up, show informational empty state."""
+        target_date = timezone.now().date() + timedelta(days=14)
+        assignment = DutyAssignment.objects.create(date=target_date)
+
+        InstructionSlot.objects.create(
+            assignment=assignment,
+            student=member,
+            status="confirmed",
+        )
+        GliderReservation.objects.create(
+            member=member,
+            glider=glider,
+            date=target_date,
+            reservation_type="solo",
+            time_preference="morning",
+        )
+
+        client.force_login(member)
+        response = client.get(
+            reverse(
+                "duty_roster:calendar_day_detail",
+                args=[target_date.year, target_date.month, target_date.day],
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert (
+            "Total signed-up flyers (including students requesting instruction):"
+            in content
+        )
+        assert "<strong>1</strong>" in content
+        assert "No additional pilots beyond students requesting instruction." in content
 
     def test_reservation_create_shows_warning_for_expired_deadline(
         self, client, site_config, member, glider, future_date

--- a/duty_roster/tests/test_glider_reservations.py
+++ b/duty_roster/tests/test_glider_reservations.py
@@ -1063,7 +1063,7 @@ class TestGliderReservationViews:
         assert other_member.full_display_name in content
 
     def test_calendar_day_modal_shows_no_other_pilots_when_only_instruction_students(
-        self, client, site_config, member, glider
+        self, client, site_config, member
     ):
         """When only instruction students are signed up, show informational empty state."""
         target_date = timezone.now().date() + timedelta(days=14)
@@ -1074,14 +1074,6 @@ class TestGliderReservationViews:
             student=member,
             status="confirmed",
         )
-        GliderReservation.objects.create(
-            member=member,
-            glider=glider,
-            date=target_date,
-            reservation_type="solo",
-            time_preference="morning",
-        )
-
         client.force_login(member)
         response = client.get(
             reverse(

--- a/duty_roster/tests/test_glider_reservations.py
+++ b/duty_roster/tests/test_glider_reservations.py
@@ -712,6 +712,44 @@ class TestGliderReservationViews:
         assert intent.available_as == ["private"]
         assert intent.notes == "Keep existing intent details"
 
+    def test_reservation_create_handles_ops_intent_integrity_race(
+        self, client, site_config, member, glider, future_date
+    ):
+        """Reservation creation should succeed if OpsIntent get_or_create races."""
+        from unittest.mock import patch
+
+        from django.db import IntegrityError
+
+        OpsIntent.objects.create(
+            member=member,
+            date=future_date,
+            available_as=["club_single"],
+            notes="Created by concurrent request",
+        )
+
+        client.force_login(member)
+        url = reverse("duty_roster:reservation_create")
+
+        with patch(
+            "duty_roster.views_reservation.OpsIntent.objects.get_or_create",
+            side_effect=IntegrityError(
+                "duplicate key value violates unique constraint"
+            ),
+        ):
+            response = client.post(
+                url,
+                {
+                    "glider": glider.pk,
+                    "date": future_date.isoformat(),
+                    "reservation_type": "solo",
+                    "time_preference": "morning",
+                },
+            )
+
+        assert response.status_code == 302
+        assert GliderReservation.objects.filter(member=member, glider=glider).exists()
+        assert OpsIntent.objects.filter(member=member, date=future_date).count() == 1
+
     def test_reservation_detail_view(
         self, client, site_config, member, glider, future_date
     ):

--- a/duty_roster/tests/test_glider_reservations.py
+++ b/duty_roster/tests/test_glider_reservations.py
@@ -1095,7 +1095,11 @@ class TestGliderReservationViews:
             "Total signed-up flyers (including students requesting instruction):"
             in content
         )
-        assert "<strong>2</strong>" in content
+        normalized_content = " ".join(content.split())
+        assert (
+            "Total signed-up flyers (including students requesting instruction): "
+            "<strong>2</strong>"
+        ) in normalized_content
         assert "Pilots Planning to Fly (1):" in content
         assert other_member.full_display_name in content
 
@@ -1131,7 +1135,11 @@ class TestGliderReservationViews:
             "Total signed-up flyers (including students requesting instruction):"
             in content
         )
-        assert "<strong>1</strong>" in content
+        normalized_content = " ".join(content.split())
+        assert (
+            "Total signed-up flyers (including students requesting instruction): "
+            "<strong>1</strong>"
+        ) in normalized_content
         assert member.full_display_name in content
 
     def test_calendar_day_modal_shows_no_other_pilots_when_only_instruction_students(
@@ -1160,7 +1168,11 @@ class TestGliderReservationViews:
             "Total signed-up flyers (including students requesting instruction):"
             in content
         )
-        assert "<strong>1</strong>" in content
+        normalized_content = " ".join(content.split())
+        assert (
+            "Total signed-up flyers (including students requesting instruction): "
+            "<strong>1</strong>"
+        ) in normalized_content
         assert "No additional pilots beyond students requesting instruction." in content
 
     def test_reservation_create_shows_warning_for_expired_deadline(

--- a/duty_roster/tests/test_glider_reservations.py
+++ b/duty_roster/tests/test_glider_reservations.py
@@ -970,8 +970,7 @@ class TestGliderReservationViews:
 
         assert response.status_code == 200
         content = response.content.decode("utf-8")
-        assert "Reservations remaining this quarter" in content
-        assert "<strong>1</strong>" in content
+        assert "Reservations remaining this quarter: <strong>1</strong>" in content
 
     def test_calendar_day_modal_uses_quarter_label_when_user_cannot_reserve(
         self, client, site_config, member

--- a/duty_roster/tests/test_glider_reservations.py
+++ b/duty_roster/tests/test_glider_reservations.py
@@ -1043,7 +1043,7 @@ class TestGliderReservationViews:
 
         assert response.status_code == 200
         content = response.content.decode("utf-8")
-        assert "Other Pilots Planning to Fly (2):" in content
+        assert "Pilots Planning to Fly (2):" in content
         assert member.full_display_name in content
         assert other_member.full_display_name in content
 
@@ -1096,8 +1096,43 @@ class TestGliderReservationViews:
             in content
         )
         assert "<strong>2</strong>" in content
-        assert "Other Pilots Planning to Fly (1):" in content
+        assert "Pilots Planning to Fly (1):" in content
         assert other_member.full_display_name in content
+
+    def test_calendar_day_modal_includes_reservations_when_feature_disabled(
+        self, client, site_config, member, glider
+    ):
+        """Confirmed reservations still count as signed-up flyers when feature is off."""
+        site_config.allow_glider_reservations = False
+        site_config.save()
+
+        target_date = timezone.now().date() + timedelta(days=15)
+        DutyAssignment.objects.create(date=target_date)
+
+        GliderReservation.objects.create(
+            member=member,
+            glider=glider,
+            date=target_date,
+            reservation_type="solo",
+            time_preference="morning",
+        )
+
+        client.force_login(member)
+        response = client.get(
+            reverse(
+                "duty_roster:calendar_day_detail",
+                args=[target_date.year, target_date.month, target_date.day],
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert (
+            "Total signed-up flyers (including students requesting instruction):"
+            in content
+        )
+        assert "<strong>1</strong>" in content
+        assert member.full_display_name in content
 
     def test_calendar_day_modal_shows_no_other_pilots_when_only_instruction_students(
         self, client, site_config, member

--- a/duty_roster/tests/test_glider_reservations.py
+++ b/duty_roster/tests/test_glider_reservations.py
@@ -18,7 +18,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from duty_roster.forms import GliderReservationForm
-from duty_roster.models import GliderReservation
+from duty_roster.models import DutyAssignment, GliderReservation, OpsIntent
 from logsheet.models import Glider, MaintenanceDeadline, MaintenanceIssue
 from siteconfig.models import SiteConfiguration
 
@@ -676,6 +676,36 @@ class TestGliderReservationViews:
 
         # Verify reservation was created
         assert GliderReservation.objects.filter(member=member, glider=glider).exists()
+        # Reservation creation should also surface member in plan-to-fly via OpsIntent.
+        assert OpsIntent.objects.filter(member=member, date=future_date).exists()
+
+    def test_reservation_create_does_not_overwrite_existing_ops_intent(
+        self, client, site_config, member, glider, future_date
+    ):
+        """Existing OpsIntent values should be preserved when reservation is created."""
+        OpsIntent.objects.create(
+            member=member,
+            date=future_date,
+            available_as=["private"],
+            notes="Keep existing intent details",
+        )
+
+        client.force_login(member)
+        url = reverse("duty_roster:reservation_create")
+        response = client.post(
+            url,
+            {
+                "glider": glider.pk,
+                "date": future_date.isoformat(),
+                "reservation_type": "solo",
+                "time_preference": "morning",
+            },
+        )
+
+        assert response.status_code == 302
+        intent = OpsIntent.objects.get(member=member, date=future_date)
+        assert intent.available_as == ["private"]
+        assert intent.notes == "Keep existing intent details"
 
     def test_reservation_detail_view(
         self, client, site_config, member, glider, future_date
@@ -865,6 +895,90 @@ class TestGliderReservationViews:
 
         assert response.status_code == 200
         assert "Reserve a Glider" in response.content.decode("utf-8")
+
+    def test_calendar_day_modal_uses_period_aware_remaining_label_and_value(
+        self, client, site_config, member, glider
+    ):
+        """Day modal should show remaining reservations for configured period."""
+        site_config.reservation_limit_period = "quarterly"
+        site_config.max_reservations_per_year = 2
+        site_config.max_reservations_per_month = 0
+        site_config.save()
+
+        target_date = timezone.now().date() + timedelta(days=10)
+        DutyAssignment.objects.create(date=target_date)
+
+        # One reservation in same quarter leaves one remaining.
+        GliderReservation.objects.create(
+            member=member,
+            glider=glider,
+            date=target_date,
+            reservation_type="solo",
+            time_preference="morning",
+        )
+
+        client.force_login(member)
+        response = client.get(
+            reverse(
+                "duty_roster:calendar_day_detail",
+                args=[target_date.year, target_date.month, target_date.day],
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert "Reservations remaining this quarter" in content
+        assert "<strong>1</strong>" in content
+
+    def test_calendar_day_modal_signed_up_flyers_count_uses_deduped_union(
+        self, client, site_config, member, glider, django_user_model
+    ):
+        """Signed-up flyer list/count should be union of intents and reservations."""
+        target_date = timezone.now().date() + timedelta(days=12)
+        DutyAssignment.objects.create(date=target_date)
+
+        other_member = django_user_model.objects.create_user(
+            username="unionmember",
+            email="union@example.com",
+            password="testpass123",
+            first_name="Union",
+            last_name="Member",
+            membership_status="Full Member",
+        )
+
+        OpsIntent.objects.create(
+            member=member,
+            date=target_date,
+            available_as=["club_single"],
+        )
+        GliderReservation.objects.create(
+            member=member,
+            glider=glider,
+            date=target_date,
+            reservation_type="solo",
+            time_preference="morning",
+        )
+        GliderReservation.objects.create(
+            member=other_member,
+            glider=glider,
+            date=target_date,
+            reservation_type="guest",
+            time_preference="afternoon",
+        )
+
+        client.force_login(member)
+        response = client.get(
+            reverse(
+                "duty_roster:calendar_day_detail",
+                args=[target_date.year, target_date.month, target_date.day],
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert "Pilots Planning to Fly (2):" in content
+        assert member.full_display_name in content
+        assert other_member.full_display_name in content
 
     def test_reservation_create_shows_warning_for_expired_deadline(
         self, client, site_config, member, glider, future_date

--- a/duty_roster/tests/test_glider_reservations.py
+++ b/duty_roster/tests/test_glider_reservations.py
@@ -935,6 +935,31 @@ class TestGliderReservationViews:
         assert "Reservations remaining this quarter" in content
         assert "<strong>1</strong>" in content
 
+    def test_calendar_day_modal_uses_quarter_label_when_user_cannot_reserve(
+        self, client, site_config, member
+    ):
+        """Requirements copy should still reflect configured quarter period."""
+        site_config.reservation_limit_period = "quarterly"
+        site_config.save()
+
+        target_date = timezone.now().date() + timedelta(days=11)
+        DutyAssignment.objects.create(date=target_date)
+
+        member.is_active = False
+        member.save(update_fields=["is_active"])
+
+        client.force_login(member)
+        response = client.get(
+            reverse(
+                "duty_roster:calendar_day_detail",
+                args=[target_date.year, target_date.month, target_date.day],
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert "You must have reservations remaining for this quarter." in content
+
     def test_calendar_day_modal_signed_up_flyers_count_uses_deduped_union(
         self, client, site_config, member, glider, django_user_model
     ):

--- a/duty_roster/tests/test_preop_emails.py
+++ b/duty_roster/tests/test_preop_emails.py
@@ -832,6 +832,41 @@ class TestSendDutyPreopEmails:
         DEFAULT_FROM_EMAIL="noreply@test.com",
         SITE_URL="https://test.manage2soar.com",
     )
+    def test_participant_email_dedupes_member_in_ops_intent_and_reservation(
+        self, site_config, duty_assignment, members, glider, tomorrow
+    ):
+        """Signed-up flyer appearing in both sources should get one participant email."""
+        OpsIntent.objects.create(
+            member=members["private_owner"],
+            date=tomorrow,
+            available_as=["private"],
+            glider=glider,
+        )
+        GliderReservation.objects.create(
+            member=members["private_owner"],
+            glider=glider,
+            date=tomorrow,
+            status="confirmed",
+            reservation_type="guest",
+            time_preference="afternoon",
+        )
+
+        out = StringIO()
+        call_command(
+            "send_duty_preop_emails",
+            date=tomorrow.strftime("%Y-%m-%d"),
+            stdout=out,
+        )
+
+        all_recipients = [email.to[0] for email in mail.outbox]
+        assert all_recipients.count(members["private_owner"].email) == 1
+
+    @override_settings(
+        EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+        EMAIL_DEV_MODE=False,
+        DEFAULT_FROM_EMAIL="noreply@test.com",
+        SITE_URL="https://test.manage2soar.com",
+    )
     def test_participant_email_uses_participant_wording(
         self, site_config, duty_assignment, members, tomorrow
     ):

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -941,7 +941,7 @@ def calendar_day_detail(request, year, month, day):
                 )
     instruction_student_ids = set()
     if assignment:
-        for slot in assignment.active_instruction_slots.select_related("student"):
+        for slot in assignment.active_instruction_slots:
             if not slot.student_id:
                 continue
             instruction_student_ids.add(slot.student_id)

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -880,7 +880,18 @@ def calendar_day_detail(request, year, month, day):
     can_reserve_glider = False
     reserve_message = ""
     reservations_remaining = None
-    reservation_period_label = "year"
+    reservation_limit_period = ReservationLimitPeriod.YEARLY
+    if reservation_config is not None:
+        reservation_limit_period = getattr(
+            reservation_config,
+            "reservation_limit_period",
+            ReservationLimitPeriod.YEARLY,
+        )
+    reservation_period_label = (
+        "quarter"
+        if reservation_limit_period == ReservationLimitPeriod.QUARTERLY
+        else "year"
+    )
 
     if request.user.is_authenticated and reservation_enabled:
         day_reservations = GliderReservation.get_reservations_for_date(day_date)
@@ -895,24 +906,16 @@ def calendar_day_detail(request, year, month, day):
         # guard so static type-checkers can narrow away Optional.
         if reservation_config is None:
             max_per_period = 0
-            reservation_limit_period = ReservationLimitPeriod.YEARLY
         else:
             max_per_period = reservation_config.max_reservations_per_year
-            reservation_limit_period = getattr(
-                reservation_config,
-                "reservation_limit_period",
-                ReservationLimitPeriod.YEARLY,
-            )
 
         if reservation_limit_period == ReservationLimitPeriod.QUARTERLY:
-            reservation_period_label = "quarter"
             current_period_count = GliderReservation.get_member_quarterly_count(
                 request.user,
                 year=day_date.year,
                 month=day_date.month,
             )
         else:
-            reservation_period_label = "year"
             current_period_count = GliderReservation.get_member_yearly_count(
                 request.user,
                 year=day_date.year,

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -939,6 +939,13 @@ def calendar_day_detail(request, year, month, day):
                     reservation.member_id,
                     reservation.member,
                 )
+    instruction_student_ids = set()
+    if assignment:
+        for slot in assignment.active_instruction_slots.select_related("student"):
+            if not slot.student_id:
+                continue
+            instruction_student_ids.add(slot.student_id)
+            signed_up_members_by_id.setdefault(slot.student_id, slot.student)
     signed_up_flyers = sorted(
         signed_up_members_by_id.values(),
         key=lambda member: (
@@ -947,11 +954,6 @@ def calendar_day_detail(request, year, month, day):
             member.username.lower() if member.username else "",
         ),
     )
-    instruction_student_ids = set()
-    if assignment:
-        instruction_student_ids = set(
-            assignment.active_instruction_slots.values_list("student_id", flat=True)
-        )
     signed_up_non_instruction_flyers = [
         member
         for member in signed_up_flyers

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -37,7 +37,7 @@ from members.constants.membership import DEFAULT_ROLES, ROLE_FIELD_MAP
 from members.decorators import active_member_required
 from members.models import Member
 from members.utils.membership import get_active_membership_statuses
-from siteconfig.models import SiteConfiguration
+from siteconfig.models import ReservationLimitPeriod, SiteConfiguration
 from siteconfig.utils import get_role_title
 from utils.email import send_mail
 from utils.email_helpers import get_absolute_club_logo_url
@@ -880,6 +880,7 @@ def calendar_day_detail(request, year, month, day):
     can_reserve_glider = False
     reserve_message = ""
     reservations_remaining = None
+    reservation_period_label = "year"
 
     if request.user.is_authenticated and reservation_enabled:
         day_reservations = GliderReservation.get_reservations_for_date(day_date)
@@ -893,15 +894,56 @@ def calendar_day_detail(request, year, month, day):
         # reservation_enabled implies reservation_config exists; keep explicit
         # guard so static type-checkers can narrow away Optional.
         if reservation_config is None:
-            max_per_year = 0
+            max_per_period = 0
+            reservation_limit_period = ReservationLimitPeriod.YEARLY
         else:
-            max_per_year = reservation_config.max_reservations_per_year
-        if max_per_year > 0:
-            current_year_count = GliderReservation.get_member_yearly_count(
+            max_per_period = reservation_config.max_reservations_per_year
+            reservation_limit_period = getattr(
+                reservation_config,
+                "reservation_limit_period",
+                ReservationLimitPeriod.YEARLY,
+            )
+
+        if reservation_limit_period == ReservationLimitPeriod.QUARTERLY:
+            reservation_period_label = "quarter"
+            current_period_count = GliderReservation.get_member_quarterly_count(
+                request.user,
+                year=day_date.year,
+                month=day_date.month,
+            )
+        else:
+            reservation_period_label = "year"
+            current_period_count = GliderReservation.get_member_yearly_count(
                 request.user,
                 year=day_date.year,
             )
-            reservations_remaining = max(0, max_per_year - current_year_count)
+
+        if max_per_period > 0:
+            reservations_remaining = max(0, max_per_period - current_period_count)
+
+    signed_up_members_by_id = {
+        intent.member_id: intent.member for intent in intents if intent.member_id
+    }
+    if reservation_feature_enabled:
+        signed_up_day_reservations = (
+            day_reservations
+            if reservation_enabled
+            else GliderReservation.get_reservations_for_date(day_date)
+        )
+        for reservation in signed_up_day_reservations:
+            if reservation.member_id:
+                signed_up_members_by_id.setdefault(
+                    reservation.member_id,
+                    reservation.member,
+                )
+    signed_up_flyers = sorted(
+        signed_up_members_by_id.values(),
+        key=lambda member: (
+            member.last_name.lower() if member.last_name else "",
+            member.first_name.lower() if member.first_name else "",
+            member.username.lower() if member.username else "",
+        ),
+    )
 
     # Determine scheduled but empty roles (visible to all users as an "unfilled" indicator)
     # and the subset the current user is qualified to volunteer for (Issue #679).
@@ -981,6 +1023,9 @@ def calendar_day_detail(request, year, month, day):
             "can_reserve_glider": can_reserve_glider,
             "reserve_message": reserve_message,
             "reservations_remaining": reservations_remaining,
+            "reservation_period_label": reservation_period_label,
+            "signed_up_flyers": signed_up_flyers,
+            "signed_up_flyer_count": len(signed_up_flyers),
             "available_activities": OpsIntent.AVAILABLE_ACTIVITIES,
             "open_panel": open_panel,
         },

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -944,6 +944,16 @@ def calendar_day_detail(request, year, month, day):
             member.username.lower() if member.username else "",
         ),
     )
+    instruction_student_ids = set()
+    if assignment:
+        instruction_student_ids = set(
+            assignment.active_instruction_slots.values_list("student_id", flat=True)
+        )
+    signed_up_non_instruction_flyers = [
+        member
+        for member in signed_up_flyers
+        if member.id not in instruction_student_ids
+    ]
 
     # Determine scheduled but empty roles (visible to all users as an "unfilled" indicator)
     # and the subset the current user is qualified to volunteer for (Issue #679).
@@ -1026,6 +1036,10 @@ def calendar_day_detail(request, year, month, day):
             "reservation_period_label": reservation_period_label,
             "signed_up_flyers": signed_up_flyers,
             "signed_up_flyer_count": len(signed_up_flyers),
+            "signed_up_non_instruction_flyers": signed_up_non_instruction_flyers,
+            "signed_up_non_instruction_flyer_count": len(
+                signed_up_non_instruction_flyers
+            ),
             "available_activities": OpsIntent.AVAILABLE_ACTIVITIES,
             "open_panel": open_panel,
         },

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -927,18 +927,17 @@ def calendar_day_detail(request, year, month, day):
     signed_up_members_by_id = {
         intent.member_id: intent.member for intent in intents if intent.member_id
     }
-    if reservation_feature_enabled:
-        signed_up_day_reservations = (
-            day_reservations
-            if reservation_enabled
-            else GliderReservation.get_reservations_for_date(day_date)
-        )
-        for reservation in signed_up_day_reservations:
-            if reservation.member_id:
-                signed_up_members_by_id.setdefault(
-                    reservation.member_id,
-                    reservation.member,
-                )
+    signed_up_day_reservations = (
+        day_reservations
+        if reservation_enabled
+        else GliderReservation.get_reservations_for_date(day_date)
+    )
+    for reservation in signed_up_day_reservations:
+        if reservation.member_id:
+            signed_up_members_by_id.setdefault(
+                reservation.member_id,
+                reservation.member,
+            )
     instruction_student_ids = set()
     if assignment:
         for slot in assignment.active_instruction_slots:

--- a/duty_roster/views_reservation.py
+++ b/duty_roster/views_reservation.py
@@ -14,7 +14,7 @@ import logging
 from datetime import date, timedelta
 
 from django.contrib import messages
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
@@ -193,17 +193,27 @@ def reservation_create(request, year=None, month=None, day=None):
                 reservation = form.save()
                 # Check if save was actually successful (form.save() may add errors without raising)
                 if reservation.pk:
-                    OpsIntent.objects.get_or_create(
-                        member=member,
-                        date=reservation.date,
-                        defaults={
-                            "available_as": _reservation_default_available_as(
-                                reservation
-                            ),
-                            "glider": reservation.glider,
-                            "notes": "Auto-created from glider reservation",
-                        },
-                    )
+                    try:
+                        # Isolate potential unique-key races so the outer reservation
+                        # transaction remains valid and can still commit.
+                        with transaction.atomic():
+                            OpsIntent.objects.get_or_create(
+                                member=member,
+                                date=reservation.date,
+                                defaults={
+                                    "available_as": _reservation_default_available_as(
+                                        reservation
+                                    ),
+                                    "glider": reservation.glider,
+                                    "notes": "Auto-created from glider reservation",
+                                },
+                            )
+                    except IntegrityError:
+                        if not OpsIntent.objects.filter(
+                            member=member,
+                            date=reservation.date,
+                        ).exists():
+                            raise
 
                     expired_deadlines = []
                     if reservation.glider:

--- a/duty_roster/views_reservation.py
+++ b/duty_roster/views_reservation.py
@@ -23,9 +23,18 @@ from members.decorators import active_member_required
 from siteconfig.models import ReservationLimitPeriod, SiteConfiguration
 
 from .forms import GliderReservationCancelForm, GliderReservationForm
-from .models import GliderReservation
+from .models import GliderReservation, OpsIntent
 
 logger = logging.getLogger("duty_roster.reservations")
+
+
+def _reservation_default_available_as(reservation):
+    """Map reservation details to a default OpsIntent activity list."""
+    if reservation.reservation_type == "guest":
+        return ["guest"]
+    if reservation.glider and reservation.glider.seats >= 2:
+        return ["club_two"]
+    return ["club_single"]
 
 
 @active_member_required
@@ -184,6 +193,18 @@ def reservation_create(request, year=None, month=None, day=None):
                 reservation = form.save()
                 # Check if save was actually successful (form.save() may add errors without raising)
                 if reservation.pk:
+                    OpsIntent.objects.get_or_create(
+                        member=member,
+                        date=reservation.date,
+                        defaults={
+                            "available_as": _reservation_default_available_as(
+                                reservation
+                            ),
+                            "glider": reservation.glider,
+                            "notes": "Auto-created from glider reservation",
+                        },
+                    )
+
                     expired_deadlines = []
                     if reservation.glider:
                         expired_deadlines = list(


### PR DESCRIPTION
## Summary
Fixes flight reservation UX and consistency issues reported in #854.

This PR aligns reservation limit messaging with the configured reservation period, ensures reservation actions surface members in the planning-to-fly flow, and improves signed-up flyer visibility/count behavior in the day modal.

Fixes #854

## Problem
- Day modal reservation helper text and remaining count were hardcoded to yearly semantics even when reservation limits were configured quarterly.
- Creating a glider reservation did not ensure the member appeared under planning-to-fly, causing confusing split behavior.
- Pilot list/count visibility in the day modal did not represent the combined signed-up population from both OpsIntent and reservations.

## Changes
### 1) Period-aware reservation messaging and remaining count
- Updated day-modal reservation remaining calculation to follow site configuration period.
- Quarterly mode now uses quarter-specific count for the viewed date period.
- Yearly mode keeps yearly count behavior.
- Updated day-modal copy from hardcoded year wording to dynamic configured period wording.

### 2) Signed-up flyer union and deduplicated count in day modal
- Added signed-up flyer aggregation as a deduplicated union of:
  - members with OpsIntent on the day
  - members with confirmed glider reservations on the day
- Exposed signed_up_flyers and signed_up_flyer_count in context.
- Updated modal section to render this unified list and count.

### 3) Reservation creation now surfaces planning intent
- On successful reservation creation, the system now creates OpsIntent when missing for that member/date.
- Existing OpsIntent rows are preserved and not overwritten.
- Default created intent activity is derived from reservation details.

## Files touched
- duty_roster/management/commands/send_duty_preop_emails.py
- duty_roster/views.py
- duty_roster/views_reservation.py
- duty_roster/templates/duty_roster/calendar_day_modal.html
- duty_roster/tests/test_glider_reservations.py
- duty_roster/tests/test_preop_emails.py

## Tests
Targeted tests executed successfully:
- pytest duty_roster/tests/test_glider_reservations.py -k "reservation_create_view_post or reservation_create_does_not_overwrite_existing_ops_intent or calendar_day_modal_uses_period_aware_remaining_label_and_value or calendar_day_modal_signed_up_flyers_count_uses_deduped_union" -q
  - Result: 4 passed
- pytest duty_roster/tests/test_preop_emails.py -k "participant_email_dedupes_member_in_ops_intent_and_reservation or includes_glider_reservation_members or participant_email_includes_ops_intent_members" -q
  - Result: 3 passed

## Notes
- Scope intentionally focused to issue #854 behavior and related regressions.
- No schema migrations were introduced.
