### PR TITLE
Issue #839: logbook year context and analytics tooltip UX improvements

### DIFF
--- a/analytics/queries.py
+++ b/analytics/queries.py
@@ -1264,6 +1264,8 @@ def time_of_day_operations(
         "landing_points": landing_points,
         "mean_earliest_takeoff": mean_earliest_takeoff,
         "mean_latest_landing": mean_latest_landing,
+        "start_year": start_year,
+        "end_year": end_year,
         "total_flight_days": len(
             [day for day in daily_data.values() if day["takeoffs"] or day["landings"]]
         ),

--- a/analytics/tests.py
+++ b/analytics/tests.py
@@ -16,6 +16,8 @@ class TimeOfDayOperationsTestCase(TestCase):
             "landing_points",
             "mean_earliest_takeoff",
             "mean_latest_landing",
+            "start_year",
+            "end_year",
             "total_flight_days",
         ]
         for key in expected_keys:
@@ -26,7 +28,11 @@ class TimeOfDayOperationsTestCase(TestCase):
         self.assertIsInstance(result["landing_points"], list)
         self.assertIsInstance(result["mean_earliest_takeoff"], list)
         self.assertIsInstance(result["mean_latest_landing"], list)
+        self.assertIsInstance(result["start_year"], int)
+        self.assertIsInstance(result["end_year"], int)
         self.assertIsInstance(result["total_flight_days"], int)
+        self.assertEqual(result["start_year"], 2025)
+        self.assertEqual(result["end_year"], 2025)
 
     def test_time_of_day_operations_no_data(self):
         """Test the function works correctly with no flight data."""
@@ -37,4 +43,6 @@ class TimeOfDayOperationsTestCase(TestCase):
         self.assertEqual(result["landing_points"], [])
         self.assertEqual(result["mean_earliest_takeoff"], [])
         self.assertEqual(result["mean_latest_landing"], [])
+        self.assertEqual(result["start_year"], 2025)
+        self.assertEqual(result["end_year"], 2025)
         self.assertEqual(result["total_flight_days"], 0)

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -258,6 +258,8 @@ def dashboard(request):
         "timeops_landing_points": time_ops.get("landing_points", []),
         "timeops_mean_earliest_takeoff": time_ops.get("mean_earliest_takeoff", []),
         "timeops_mean_latest_landing": time_ops.get("mean_latest_landing", []),
+        "timeops_start_year": time_ops.get("start_year", start),
+        "timeops_end_year": time_ops.get("end_year", end),
         "timeops_total_flight_days": time_ops.get("total_flight_days", 0),
     }
 
@@ -360,6 +362,8 @@ def dashboard(request):
             "landing_points": ctx.get("timeops_landing_points", []),
             "mean_earliest_takeoff": ctx.get("timeops_mean_earliest_takeoff", []),
             "mean_latest_landing": ctx.get("timeops_mean_latest_landing", []),
+            "start_year": ctx.get("timeops_start_year", start),
+            "end_year": ctx.get("timeops_end_year", end),
             "total_flight_days": ctx.get("timeops_total_flight_days", 0),
         },
     }

--- a/e2e_tests/e2e/test_analytics_dashboard.py
+++ b/e2e_tests/e2e/test_analytics_dashboard.py
@@ -158,3 +158,56 @@ class TestAnalyticsDashboardE2E(DjangoPlaywrightTestCase):
             f"Horizontal overflow at 412px: scrollWidth={scroll_width}px "
             f"> viewportWidth={viewport_width}px"
         )
+
+    def test_time_ops_tooltip_title_includes_year_context(self):
+        """Time of day tooltip title includes selected year range context."""
+        from datetime import date, time
+
+        from logsheet.models import Airfield, Flight, Glider, Logsheet
+
+        analyst = self.create_test_member(username="analyst")
+        self.login(username="analyst")
+
+        airfield = Airfield.objects.create(identifier="KFRR", name="Front Royal")
+        glider = Glider.objects.create(
+            make="Schleicher",
+            model="ASK-21",
+            n_number="N839UX",
+            competition_number="21",
+            seats=2,
+            is_active=True,
+            club_owned=True,
+        )
+        logsheet = Logsheet.objects.create(
+            log_date=date.today(),
+            airfield=airfield,
+            created_by=analyst,
+            finalized=True,
+        )
+        Flight.objects.create(
+            logsheet=logsheet,
+            pilot=analyst,
+            glider=glider,
+            launch_time=time(10, 0),
+            landing_time=time(10, 35),
+            launch_method="tow",
+            release_altitude=3000,
+        )
+
+        self._go_to_analytics()
+
+        start_year = self.page.input_value("#annual-range input[name='start']")
+        end_year = self.page.input_value("#annual-range input[name='end']")
+
+        tooltip_title = self.page.evaluate(
+            """() => {
+              const cb = window.timeOpsChart?.options?.plugins?.tooltip?.callbacks?.title;
+              if (!cb) return "";
+              return cb([{ parsed: { x: 32 } }]);
+            }"""
+        )
+
+        assert tooltip_title, "Expected tooltip title callback output"
+        assert start_year in tooltip_title
+        if start_year != end_year:
+            assert end_year in tooltip_title

--- a/instructors/templates/instructors/logbook.html
+++ b/instructors/templates/instructors/logbook.html
@@ -22,10 +22,53 @@
   </button>
 </form>
 
+{% if all_years %}
+<div class="year-filter-panel mb-3">
+  <h5 class="mb-2">Year Scope for Totals</h5>
+  <div class="d-flex flex-wrap gap-2 align-items-center">
+    {% for year in all_years %}
+      <form method="get" style="display:inline">
+        <input type="hidden" name="year" value="{{ year }}">
+        <button
+          type="submit"
+          class="btn {% if selected_year == year %}btn-primary{% else %}btn-outline-primary{% endif %} btn-sm"
+        >
+          {{ year }}
+        </button>
+      </form>
+    {% endfor %}
+  </div>
+  {% if selected_year %}
+    <small class="text-muted d-block mt-2">
+      Showing year-scoped rows and running totals for {{ selected_year }}. Use "Show All Years"
+      above if you need full-history carry-over context.
+    </small>
+  {% else %}
+    <small class="text-muted d-block mt-2">
+      Select a single year to focus totals and compare against the opening balance context.
+    </small>
+  {% endif %}
+</div>
+{% endif %}
+
+{% if opening_balance %}
+<div class="alert alert-info mb-3" role="alert">
+  <div class="fw-semibold mb-1">Opening balance before {{ opening_balance.year }}</div>
+  <div class="small">
+    Total: <strong>{{ opening_balance.total }}</strong> |
+    PIC: <strong>{{ opening_balance.pic }}</strong> |
+    Dual Received: <strong>{{ opening_balance.dual_received }}</strong> |
+    Solo: <strong>{{ opening_balance.solo }}</strong> |
+    Instruction Given: <strong>{{ opening_balance.inst_given }}</strong> |
+    Ground: <strong>{{ opening_balance.ground_inst }}</strong>
+  </div>
+</div>
+{% endif %}
+
 <!-- Year Navigation -->
 {% if years %}
 <div class="year-navigation">
-  <h5 class="mb-3">📅 Jump to Year:</h5>
+  <h5 class="mb-3">📅 {% if selected_year %}Jump Within Loaded Sections:{% else %}Jump to Year:{% endif %}</h5>
   <div class="year-links">
     {% for year in all_years %}
       {% if year in years %}
@@ -39,7 +82,7 @@
     {% endfor %}
   </div>
   <small class="text-muted mt-2 d-block">
-    Click on any year to jump to that section. Years with no flights are not shown.
+    Click on any loaded year to jump to that section. Years with no flights are not shown.
   </small>
 </div>
 {% endif %}
@@ -192,7 +235,7 @@
 
       {# Running Totals #}
       <tr class="table-info fw-bold">
-        <td colspan="3" class="text-end">Running Totals:</td>
+        <td colspan="3" class="text-end">{{ totals_scope_label }}:</td>
         <td></td>
         <td class="text-end">{{ page.cumulative.A }}</td>
         <td class="text-end">{{ page.cumulative.G }}</td>
@@ -249,26 +292,28 @@
 </div>
 
 
-{% endblock %}
-document.addEventListener('DOMContentLoaded', function() {
-
 <script>
 // Show loading modal on "Show All Years" form submit
 document.addEventListener('DOMContentLoaded', function() {
   var form = document.getElementById('show-all-years-form');
-  var modal = new bootstrap.Modal(document.getElementById('loadingModal'));
+  var modalElement = document.getElementById('loadingModal');
+  var modal = modalElement ? new bootstrap.Modal(modalElement) : null;
   if (form) {
     form.addEventListener('submit', function() {
-      setTimeout(function() { modal.show(); }, 10);
+      if (modal) {
+        setTimeout(function() { modal.show(); }, 10);
+      }
     });
   }
   // Hide modal when page is loaded
   window.addEventListener('load', function() {
     var modalEl = document.getElementById('loadingModal');
-    if (modalEl.classList.contains('show')) {
+    if (modalEl && modalEl.classList.contains('show')) {
       var modalInstance = bootstrap.Modal.getInstance(modalEl);
       if (modalInstance) modalInstance.hide();
     }
   });
 });
 </script>
+
+{% endblock %}

--- a/instructors/tests/test_member_logbook_performance.py
+++ b/instructors/tests/test_member_logbook_performance.py
@@ -460,6 +460,86 @@ class TestMemberLogbookPerformance:
         total_rows = sum(len(page["rows"]) for page in pages)
         assert total_rows == 2  # Only 2021 and 2023 flights
 
+    def test_logbook_single_year_sets_selected_year_and_opening_balance(
+        self, setup_logbook_data
+    ):
+        """Single-year mode should expose selected_year and opening balance context."""
+        data = setup_logbook_data
+        student = data["student"]
+        glider = data["glider"]
+        airfield = data["airfield"]
+
+        # Prior-year flight contributes to opening balance.
+        ls_prior = create_logsheet(datetime.date(2025, 6, 15), airfield, student)
+        Flight.objects.create(
+            logsheet=ls_prior,
+            pilot=student,
+            glider=glider,
+            launch_method="tow",
+            launch_time=datetime.time(10, 0),
+            landing_time=datetime.time(10, 30),
+            release_altitude=3000,
+        )
+
+        # Target-year flight should appear in rows.
+        ls_target = create_logsheet(datetime.date(2026, 6, 15), airfield, student)
+        Flight.objects.create(
+            logsheet=ls_target,
+            pilot=student,
+            glider=glider,
+            launch_method="tow",
+            launch_time=datetime.time(11, 0),
+            landing_time=datetime.time(11, 20),
+            release_altitude=2800,
+        )
+
+        client = Client()
+        client.force_login(student)
+
+        response = client.get(reverse("instructors:member_logbook") + "?year=2026")
+
+        assert response.status_code == 200
+        assert response.context["selected_year"] == 2026
+        opening_balance = response.context["opening_balance"]
+        assert opening_balance is not None
+        assert opening_balance["year"] == 2026
+        assert opening_balance["total"] == "0:30"
+
+        pages = response.context["pages"]
+        total_rows = sum(len(page["rows"]) for page in pages)
+        assert total_rows == 1
+
+    def test_logbook_multi_year_query_does_not_set_single_year_context(
+        self, setup_logbook_data
+    ):
+        """Multi-year query should keep opening balance disabled."""
+        data = setup_logbook_data
+        student = data["student"]
+        instructor = data["instructor"]
+        glider = data["glider"]
+        airfield = data["airfield"]
+
+        for year in [2025, 2026]:
+            ls = create_logsheet(datetime.date(year, 1, 10), airfield, student)
+            Flight.objects.create(
+                logsheet=ls,
+                pilot=student,
+                instructor=instructor,
+                glider=glider,
+                launch_method="tow",
+                duration=datetime.timedelta(minutes=25),
+            )
+
+        client = Client()
+        client.force_login(student)
+        response = client.get(
+            reverse("instructors:member_logbook") + "?year=2025&year=2026"
+        )
+
+        assert response.status_code == 200
+        assert response.context["selected_year"] is None
+        assert response.context["opening_balance"] is None
+
     def test_logbook_cumulative_totals(self, setup_logbook_data):
         """Test that cumulative totals are correctly calculated."""
         data = setup_logbook_data

--- a/instructors/tests/test_member_logbook_performance.py
+++ b/instructors/tests/test_member_logbook_performance.py
@@ -540,6 +540,33 @@ class TestMemberLogbookPerformance:
         assert response.context["selected_year"] is None
         assert response.context["opening_balance"] is None
 
+    def test_logbook_invalid_year_query_is_ignored(self, setup_logbook_data):
+        """Invalid year query values should be ignored and not crash the view."""
+        data = setup_logbook_data
+        student = data["student"]
+        glider = data["glider"]
+        airfield = data["airfield"]
+
+        ls = create_logsheet(datetime.date(2026, 6, 15), airfield, student)
+        Flight.objects.create(
+            logsheet=ls,
+            pilot=student,
+            glider=glider,
+            launch_method="tow",
+            launch_time=datetime.time(11, 0),
+            landing_time=datetime.time(11, 20),
+            release_altitude=2800,
+        )
+
+        client = Client()
+        client.force_login(student)
+
+        response = client.get(reverse("instructors:member_logbook") + "?year=0")
+
+        assert response.status_code == 200
+        assert response.context["selected_year"] is None
+        assert response.context["opening_balance"] is None
+
     def test_logbook_cumulative_totals(self, setup_logbook_data):
         """Test that cumulative totals are correctly calculated."""
         data = setup_logbook_data

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -11,7 +11,8 @@ from django.contrib import messages
 from django.contrib.auth.decorators import user_passes_test
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.db.models import Count, Max, Q, Sum
+from django.db.models import Count, Max, Q, Sum, Value
+from django.db.models.functions import Coalesce, Trim
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 
@@ -2033,10 +2034,11 @@ def member_logbook(request, member_id=None):
 
     opening_balance = None
     if selected_year is not None:
+        opening_balance_cutoff = datetime.date(selected_year, 1, 1)
         instructor_present_filter = (
             Q(instructor__isnull=False)
-            | (Q(guest_instructor_name__isnull=False) & ~Q(guest_instructor_name=""))
-            | (Q(legacy_instructor_name__isnull=False) & ~Q(legacy_instructor_name=""))
+            | Q(guest_instructor_name_trimmed__gt="")
+            | Q(legacy_instructor_name_trimmed__gt="")
         )
         pilot_non_instruction_filter = Q(pilot=member) & ~instructor_present_filter
         dual_received_filter = Q(pilot=member) & instructor_present_filter
@@ -2053,9 +2055,16 @@ def member_logbook(request, member_id=None):
                 logsheet__log_date__gte=rating_date
             )
 
-        prior_flights = Flight.objects.filter(
+        prior_flights = Flight.objects.alias(
+            guest_instructor_name_trimmed=Trim(
+                Coalesce("guest_instructor_name", Value(""))
+            ),
+            legacy_instructor_name_trimmed=Trim(
+                Coalesce("legacy_instructor_name", Value(""))
+            ),
+        ).filter(
             Q(pilot=member) | Q(instructor=member) | Q(passenger=member),
-            logsheet__log_date__year__lt=selected_year,
+            logsheet__log_date__lt=opening_balance_cutoff,
         )
         prior_agg = prior_flights.aggregate(
             dual_received_dur=Sum("duration", filter=dual_received_filter),
@@ -2098,7 +2107,7 @@ def member_logbook(request, member_id=None):
 
         prior_ground = GroundInstruction.objects.filter(
             student=member,
-            date__year__lt=selected_year,
+            date__lt=opening_balance_cutoff,
         ).aggregate(total_dur=Sum("duration"))
         opening_m["ground_inst_m"] = duration_to_minutes(prior_ground.get("total_dur"))
 

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -1642,7 +1642,12 @@ def member_logbook(request, member_id=None):
 
     # Years requested to load
     show_all_years = request.GET.get("show_all_years")
-    show_years = [int(y) for y in request.GET.getlist("year") if y.isdigit()]
+    valid_years = set(all_years)
+    show_years = [
+        int(y)
+        for y in request.GET.getlist("year")
+        if y.isdigit() and int(y) in valid_years
+    ]
     selected_year = None
     if show_all_years:
         years_to_load = all_years

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -1641,11 +1641,14 @@ def member_logbook(request, member_id=None):
 
     # Years requested to load
     show_all_years = request.GET.get("show_all_years")
-    show_years = request.GET.getlist("year")
+    show_years = [int(y) for y in request.GET.getlist("year") if y.isdigit()]
+    selected_year = None
     if show_all_years:
         years_to_load = all_years
     elif show_years:
-        years_to_load = [int(y) for y in show_years if y.isdigit()]
+        years_to_load = show_years
+        if len(show_years) == 1:
+            selected_year = show_years[0]
     else:
         # Default: last 12 months
         years_to_load = [today.year, today.year - 1]
@@ -2028,6 +2031,74 @@ def member_logbook(request, member_id=None):
         else:
             page["is_first_for_year"] = False
 
+    opening_balance = None
+    if selected_year is not None:
+        opening_m = {
+            "ground_inst_m": 0,
+            "dual_received_m": 0,
+            "solo_m": 0,
+            "pic_m": 0,
+            "inst_given_m": 0,
+            "total_m": 0,
+            "A": 0,
+            "G": 0,
+            "S": 0,
+        }
+
+        prior_flights = Flight.objects.filter(
+            Q(pilot=member) | Q(instructor=member) | Q(passenger=member),
+            logsheet__log_date__year__lt=selected_year,
+        ).select_related("logsheet")
+
+        for f in prior_flights:
+            classification = classify_logbook_flight_minutes(
+                f,
+                member.id,
+                rating_date,
+            )
+            if classification["is_passenger"]:
+                continue
+
+            opening_m["dual_received_m"] += classification["dual_m"]
+            opening_m["solo_m"] += classification["solo_m"]
+            opening_m["pic_m"] += classification["pic_m"]
+            opening_m["inst_given_m"] += classification["inst_m"]
+            opening_m["total_m"] += classification["duration_m"]
+            opening_m["A"] += 1 if f.launch_method == "tow" else 0
+            opening_m["G"] += 1 if f.launch_method == "winch" else 0
+            opening_m["S"] += 1 if f.launch_method == "self" else 0
+
+        prior_ground = GroundInstruction.objects.filter(
+            student=member,
+            date__year__lt=selected_year,
+        )
+        opening_m["ground_inst_m"] = sum(
+            int(g.duration.total_seconds() // 60) if g.duration else 0
+            for g in prior_ground
+        )
+
+        opening_balance = {
+            "year": selected_year,
+            "ground_inst": format_hhmm(timedelta(minutes=opening_m["ground_inst_m"])),
+            "dual_received": format_hhmm(
+                timedelta(minutes=opening_m["dual_received_m"])
+            ),
+            "solo": format_hhmm(timedelta(minutes=opening_m["solo_m"])),
+            "pic": format_hhmm(timedelta(minutes=opening_m["pic_m"])),
+            "inst_given": format_hhmm(timedelta(minutes=opening_m["inst_given_m"])),
+            "total": format_hhmm(timedelta(minutes=opening_m["total_m"])),
+            "A": opening_m["A"],
+            "G": opening_m["G"],
+            "S": opening_m["S"],
+        }
+
+    is_single_year_scope = selected_year is not None
+    totals_scope_label = (
+        f"Running totals for {selected_year}"
+        if is_single_year_scope
+        else "Running totals across loaded years"
+    )
+
     return render(
         request,
         "instructors/logbook.html",
@@ -2037,6 +2108,10 @@ def member_logbook(request, member_id=None):
             "years": years,
             "year_page_map": year_page_map,
             "all_years": all_years,
+            "selected_year": selected_year,
+            "opening_balance": opening_balance,
+            "is_single_year_scope": is_single_year_scope,
+            "totals_scope_label": totals_scope_label,
             "glider_time_summary": glider_time_summary,
         },
     )

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -11,7 +11,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import user_passes_test
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.db.models import Max, Q
+from django.db.models import Count, Max, Q, Sum
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 
@@ -2033,49 +2033,74 @@ def member_logbook(request, member_id=None):
 
     opening_balance = None
     if selected_year is not None:
-        opening_m = {
-            "ground_inst_m": 0,
-            "dual_received_m": 0,
-            "solo_m": 0,
-            "pic_m": 0,
-            "inst_given_m": 0,
-            "total_m": 0,
-            "A": 0,
-            "G": 0,
-            "S": 0,
-        }
+        instructor_present_filter = (
+            Q(instructor__isnull=False)
+            | (Q(guest_instructor_name__isnull=False) & ~Q(guest_instructor_name=""))
+            | (Q(legacy_instructor_name__isnull=False) & ~Q(legacy_instructor_name=""))
+        )
+        pilot_non_instruction_filter = Q(pilot=member) & ~instructor_present_filter
+        dual_received_filter = Q(pilot=member) & instructor_present_filter
+        solo_filter = (
+            pilot_non_instruction_filter
+            & Q(passenger__isnull=True)
+            & Q(passenger_name="")
+        )
+        instructor_given_filter = Q(instructor=member)
+        member_non_passenger_filter = Q(pilot=member) | Q(instructor=member)
+        rated_dual_pic_filter = Q(pk__in=[])
+        if rating_date:
+            rated_dual_pic_filter = dual_received_filter & Q(
+                logsheet__log_date__gte=rating_date
+            )
 
         prior_flights = Flight.objects.filter(
             Q(pilot=member) | Q(instructor=member) | Q(passenger=member),
             logsheet__log_date__year__lt=selected_year,
-        ).select_related("logsheet")
+        )
+        prior_agg = prior_flights.aggregate(
+            dual_received_dur=Sum("duration", filter=dual_received_filter),
+            solo_dur=Sum("duration", filter=solo_filter),
+            pilot_non_instruction_pic_dur=Sum(
+                "duration", filter=pilot_non_instruction_filter
+            ),
+            instructor_given_dur=Sum("duration", filter=instructor_given_filter),
+            rated_dual_pic_dur=Sum("duration", filter=rated_dual_pic_filter),
+            total_dur=Sum("duration", filter=member_non_passenger_filter),
+            tow_count=Count(
+                "id", filter=member_non_passenger_filter & Q(launch_method="tow")
+            ),
+            winch_count=Count(
+                "id", filter=member_non_passenger_filter & Q(launch_method="winch")
+            ),
+            self_count=Count(
+                "id", filter=member_non_passenger_filter & Q(launch_method="self")
+            ),
+        )
 
-        for f in prior_flights:
-            classification = classify_logbook_flight_minutes(
-                f,
-                member.id,
-                rating_date,
-            )
-            if classification["is_passenger"]:
-                continue
+        def duration_to_minutes(value):
+            return int(value.total_seconds() // 60) if value else 0
 
-            opening_m["dual_received_m"] += classification["dual_m"]
-            opening_m["solo_m"] += classification["solo_m"]
-            opening_m["pic_m"] += classification["pic_m"]
-            opening_m["inst_given_m"] += classification["inst_m"]
-            opening_m["total_m"] += classification["duration_m"]
-            opening_m["A"] += 1 if f.launch_method == "tow" else 0
-            opening_m["G"] += 1 if f.launch_method == "winch" else 0
-            opening_m["S"] += 1 if f.launch_method == "self" else 0
+        opening_m = {
+            "ground_inst_m": 0,
+            "dual_received_m": duration_to_minutes(prior_agg.get("dual_received_dur")),
+            "solo_m": duration_to_minutes(prior_agg.get("solo_dur")),
+            "pic_m": (
+                duration_to_minutes(prior_agg.get("pilot_non_instruction_pic_dur"))
+                + duration_to_minutes(prior_agg.get("rated_dual_pic_dur"))
+                + duration_to_minutes(prior_agg.get("instructor_given_dur"))
+            ),
+            "inst_given_m": duration_to_minutes(prior_agg.get("instructor_given_dur")),
+            "total_m": duration_to_minutes(prior_agg.get("total_dur")),
+            "A": prior_agg.get("tow_count") or 0,
+            "G": prior_agg.get("winch_count") or 0,
+            "S": prior_agg.get("self_count") or 0,
+        }
 
         prior_ground = GroundInstruction.objects.filter(
             student=member,
             date__year__lt=selected_year,
-        )
-        opening_m["ground_inst_m"] = sum(
-            int(g.duration.total_seconds() // 60) if g.duration else 0
-            for g in prior_ground
-        )
+        ).aggregate(total_dur=Sum("duration"))
+        opening_m["ground_inst_m"] = duration_to_minutes(prior_ground.get("total_dur"))
 
         opening_balance = {
             "year": selected_year,

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -2068,7 +2068,7 @@ def member_logbook(request, member_id=None):
                 Coalesce("legacy_instructor_name", Value(""))
             ),
         ).filter(
-            Q(pilot=member) | Q(instructor=member) | Q(passenger=member),
+            Q(pilot=member) | Q(instructor=member),
             logsheet__log_date__lt=opening_balance_cutoff,
         )
         prior_agg = prior_flights.aggregate(

--- a/static/analytics/analytics.css
+++ b/static/analytics/analytics.css
@@ -1,86 +1,140 @@
 /* Analytics layout & theming */
 
 /* ========= Design tokens ========= */
-:root{
+:root {
   --chart-h-short: 360px;
-  --chart-h:       420px;
-  --chart-h-tall:  500px;
-  --chart-h-xl:    540px;
+  --chart-h: 420px;
+  --chart-h-tall: 500px;
+  --chart-h-xl: 540px;
 
-  --chart-title-pr: 5rem;          /* padding-right so title doesn't sit under tool buttons */
-  --chart-text: #212529;           /* bootstrap body color */
-  --chart-grid: rgba(0,0,0,.1);    /* grid/axis default */
+  --chart-title-pr: 5rem;
+  /* padding-right so title doesn't sit under tool buttons */
+  --chart-text: #212529;
+  /* bootstrap body color */
+  --chart-grid: rgba(0, 0, 0, .1);
+  /* grid/axis default */
 }
 
-@media (prefers-color-scheme: dark){
-  :root{
+@media (prefers-color-scheme: dark) {
+  :root {
     --chart-text: #e9ecef;
-    --chart-grid: rgba(255,255,255,.16);
+    --chart-grid: rgba(255, 255, 255, .16);
   }
 }
 
 /* ========= Chart containers ========= */
-.chart-card{ position: relative; }
+.chart-card {
+  position: relative;
+}
 
-.chart-box{
+.chart-box {
   height: var(--chart-h);
   position: relative;
 }
-.chart-box--short{ height: var(--chart-h-short); }
-.chart-box--tall { height: var(--chart-h-tall); }
-.chart-box--xl   { height: var(--chart-h-xl);   }
+
+.chart-box--short {
+  height: var(--chart-h-short);
+}
+
+.chart-box--tall {
+  height: var(--chart-h-tall);
+}
+
+.chart-box--xl {
+  height: var(--chart-h-xl);
+}
 
 /* Make canvas stretch to the box */
-.chart-box > canvas{
+.chart-box>canvas {
   width: 100% !important;
   height: 100% !important;
   display: block;
 }
 
 /* ========= Title padding so it doesn’t overlap the tools ========= */
-.chart-title-pad{ padding-right: var(--chart-title-pr) !important; }
+.chart-title-pad {
+  padding-right: var(--chart-title-pr) !important;
+}
 
 /* ========= Tool buttons (PNG/SVG/CSV) ========= */
-.chart-tools{
+.chart-tools {
   position: absolute;
   top: .5rem;
   right: .5rem;
   z-index: 3;
 }
-.chart-tools .btn{
+
+.chart-tools .btn {
   padding: .2rem .5rem;
   line-height: 1.1;
 }
 
 /* ========= Responsive tweaks ========= */
-@media (max-width: 576px){
+@media (max-width: 576px) {
   :root {
     --chart-title-pr: 4rem;
   }
-  .chart-box        { height: 280px; }
-  .chart-box--short { height: 220px; }
-  .chart-box--tall  { height: 340px; }
-  .chart-box--xl    { height: 380px; }
+
+  .chart-box {
+    height: 280px;
+  }
+
+  .chart-box--short {
+    height: 220px;
+  }
+
+  .chart-box--tall {
+    height: 340px;
+  }
+
+  .chart-box--xl {
+    height: 380px;
+  }
 }
 
 /* Very narrow phones (≤430px) */
-@media (max-width: 430px){
+@media (max-width: 430px) {
   :root {
     --chart-title-pr: 3.5rem;
   }
-  .chart-box        { height: 240px; }
-  .chart-box--short { height: 190px; }
-  .chart-box--tall  { height: 300px; }
-  .chart-box--xl    { height: 340px; }
+
+  .chart-box {
+    height: 240px;
+  }
+
+  .chart-box--short {
+    height: 190px;
+  }
+
+  .chart-box--tall {
+    height: 300px;
+  }
+
+  .chart-box--xl {
+    height: 340px;
+  }
+
   /* Keep tool buttons compact on very small screens */
-  .chart-tools .btn { padding: .15rem .35rem; font-size: .75rem; }
+  .chart-tools .btn {
+    padding: .15rem .35rem;
+    font-size: .75rem;
+  }
 }
 
 /* ========= Print: hide controls, compress heights ========= */
-@media print{
+@media print {
+
   .chart-tools,
   form,
-  .alert{ display: none !important; }
-  .card{ break-inside: avoid; }
-  .chart-box{ height: 320px; }
+  .alert {
+    display: none !important;
+  }
+
+  .card {
+    break-inside: avoid;
+  }
+
+  .chart-box {
+    height: 320px;
+  }
 }

--- a/static/analytics/analytics.css
+++ b/static/analytics/analytics.css
@@ -2,10 +2,10 @@
 
 /* ========= Design tokens ========= */
 :root{
-  --chart-h-short: 380px;
-  --chart-h:       440px;
-  --chart-h-tall:  520px;
-  --chart-h-xl:    560px;
+  --chart-h-short: 360px;
+  --chart-h:       420px;
+  --chart-h-tall:  500px;
+  --chart-h-xl:    540px;
 
   --chart-title-pr: 5rem;          /* padding-right so title doesn't sit under tool buttons */
   --chart-text: #212529;           /* bootstrap body color */

--- a/static/analytics/charts.js
+++ b/static/analytics/charts.js
@@ -748,6 +748,10 @@ function initTimeOps(d) {
   const meanEarliestTakeoff = d.mean_earliest_takeoff || [];
   const meanLatestLanding = d.mean_latest_landing || [];
   const totalFlightDays = d.total_flight_days || 0;
+  const startYear = Number(d.start_year || new Date().getFullYear());
+  const endYear = Number(d.end_year || startYear);
+  const yearLabel = startYear === endYear ? `${startYear}` : `${startYear}-${endYear}`;
+  const referenceYear = endYear;
   const status = document.getElementById("timeOpsStatus");
 
   if (!takeoffPoints.length && !landingPoints.length) {
@@ -824,11 +828,11 @@ function initTimeOps(d) {
             title: (items) => {
               if (!items.length) return "";
               const day = items[0].parsed.x;
-              // Convert Julian day to approximate date for context
-              const date = new Date(2024, 0, day); // Using 2024 as reference year
+              // Convert Julian day to approximate date and include selected year context.
+              const date = new Date(referenceYear, 0, day);
               const month = date.toLocaleDateString(undefined, { month: "short" });
               const dayOfMonth = date.getDate();
-              return `Day ${day} (≈${month} ${dayOfMonth})`;
+              return `Day ${day} (${yearLabel} • ≈${month} ${dayOfMonth})`;
             },
             label: (item) => {
               const time = formatTime(item.parsed.y);

--- a/static/analytics/charts.js
+++ b/static/analytics/charts.js
@@ -853,7 +853,7 @@ function initTimeOps(d) {
             callback: function (value) {
               // Show month labels at key points
               if ([1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335].includes(value)) {
-                const date = new Date(2024, 0, value);
+                const date = new Date(referenceYear, 0, value);
                 return date.toLocaleDateString(undefined, { month: "short" });
               }
               return value;

--- a/static/css/logbook.css
+++ b/static/css/logbook.css
@@ -38,6 +38,21 @@ td.logbook-comments {
     text-align: right;
 }
 
+.year-filter-panel {
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 5px;
+    padding: 12px;
+}
+
+.year-filter-panel h5 {
+    margin-bottom: 0.5rem;
+}
+
+.year-filter-panel .btn {
+    min-width: 68px;
+}
+
 /* Year Navigation Styles */
 .year-navigation {
     background-color: #f8f9fa;

--- a/static/css/logsheet.css
+++ b/static/css/logsheet.css
@@ -2350,6 +2350,7 @@
    Stack label above the field to give the editor the full width.
    ===================================================================== */
 @media (max-width: 575px) {
+
     .closeout-form-table th,
     .closeout-form-table td {
         display: block;

--- a/static/css/logsheet.css
+++ b/static/css/logsheet.css
@@ -1700,13 +1700,13 @@
 .summary-card {
     background: white;
     border-radius: 8px;
-    padding: 0.6rem 1rem;
+    padding: 0.75rem 1.1rem;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     display: flex;
     align-items: center;
     gap: 0.75rem;
     flex: 1;
-    min-width: 130px;
+    min-width: 148px;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 


### PR DESCRIPTION
## Summary
Implements Issue #839 UX improvements across logbook and analytics:
- improves year-scoped context in pilot logbook totals
- includes year context in Analytics "Time of Day Operations" tooltip
- harmonizes chart/summary visual sizing for better desktop proportion

Fixes #839

## Changes
### 1) Logbook year-scoped totals UX
- Added explicit year-scope controls in the pilot logbook UI.
- Added opening-balance context when viewing a single selected year.
- Clarified totals labeling so users can distinguish year-scoped running totals vs multi-year loaded totals.
- Preserved existing multi-year navigation behavior.

### 2) Analytics tooltip year context
- Added `start_year` and `end_year` metadata to `time_of_day_operations` query output.
- Propagated this metadata through analytics view payloads.
- Updated Time of Day Operations tooltip title to include single-year or year-range context.

### 3) Visual proportion tuning
- Tuned analytics chart height tokens for more consistent chart/panel balance.
- Adjusted logsheet summary-card sizing for improved visual parity.

## Files changed
- analytics/queries.py
- analytics/tests.py
- analytics/views.py
- e2e_tests/e2e/test_analytics_dashboard.py
- instructors/templates/instructors/logbook.html
- instructors/tests/test_member_logbook_performance.py
- instructors/views.py
- static/analytics/analytics.css
- static/analytics/charts.js
- static/css/logbook.css
- static/css/logsheet.css

## Validation
- `pytest -q analytics/tests.py instructors/tests/test_member_logbook_performance.py e2e_tests/e2e/test_analytics_dashboard.py`
- Result: **21 passed**, 0 failed.

## Notes
- Scope remains UX-focused and does not change schema.
- Existing multi-year workflows are preserved while improving year-context discoverability.
