### PR TITLE
Issue #873: Add in-app towplane oil deadline update for Aircraft Meisters

### DIFF
--- a/e2e_tests/e2e/test_maintenance_deadline_update.py
+++ b/e2e_tests/e2e/test_maintenance_deadline_update.py
@@ -10,7 +10,7 @@ from datetime import date
 from django.contrib.auth.models import Group
 
 from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
-from logsheet.models import AircraftMeister, Glider, MaintenanceDeadline
+from logsheet.models import AircraftMeister, Glider, MaintenanceDeadline, Towplane
 
 
 class TestMaintenanceDeadlineUpdateE2E(DjangoPlaywrightTestCase):
@@ -31,6 +31,15 @@ class TestMaintenanceDeadlineUpdateE2E(DjangoPlaywrightTestCase):
             glider=self.glider,
             description="annual",
             due_date=date(2026, 6, 30),
+        )
+
+        # Create towplane for oil deadline editing workflow
+        self.towplane = Towplane.objects.create(
+            name="Pawnee",
+            make="Piper",
+            model="PA-25",
+            n_number="N456CD",
+            next_oil_change_due="1234.5",
         )
 
         # Create webmaster group
@@ -241,3 +250,31 @@ class TestMaintenanceDeadlineUpdateE2E(DjangoPlaywrightTestCase):
         # Should see update buttons for both aircraft
         update_buttons = self.page.locator(".update-deadline-btn")
         assert update_buttons.count() == 2
+
+    def test_towplane_oil_deadline_can_be_updated_via_modal(self):
+        """Superuser can update towplane oil deadline from maintenance page."""
+        self.create_test_member(username="superuser", is_superuser=True)
+        self.login(username="superuser")
+
+        self.page.goto(f"{self.live_server_url}/logsheet/maintenance-deadlines/")
+        self.page.wait_for_load_state("networkidle")
+
+        oil_button = self.page.locator(".update-oil-deadline-btn").first
+        assert oil_button.is_visible()
+        oil_button.click()
+
+        modal = self.page.locator("#updateOilDeadlineModal.show")
+        modal.wait_for(state="visible", timeout=5000)
+        assert modal.is_visible()
+
+        tach_input = self.page.locator("#new-oil-due")
+        tach_input.fill("1300.5")
+        self.page.locator("#save-oil-deadline-btn").click()
+
+        modal.wait_for(state="hidden", timeout=5000)
+
+        # Inline cell should update immediately without full-page reload.
+        self.page.wait_for_timeout(300)
+        assert "1300.5" in (
+            self.page.locator(f"#oil-due-{self.towplane.id}").text_content() or ""
+        )

--- a/logsheet/templates/logsheet/maintenance_deadlines.html
+++ b/logsheet/templates/logsheet/maintenance_deadlines.html
@@ -67,6 +67,56 @@
   {% endif %}
 </div>
 
+<div class="container my-4">
+  <h2 class="mb-3">Towplane Oil Change Deadlines</h2>
+  {% if towplanes %}
+  <div class="table-responsive">
+    <table class="table table-striped table-bordered table-hover align-middle text-sm" id="oil-deadlines-table">
+      <thead class="table-light">
+        <tr>
+          <th>Towplane</th>
+          <th>Next Oil Change Due (Tach)</th>
+          {% if can_update_oil_deadlines %}
+          <th>Actions</th>
+          {% endif %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for towplane in towplanes %}
+        <tr>
+          <td>🛩️ {{ towplane }}</td>
+          <td id="oil-due-{{ towplane.id }}">
+            {% if towplane.next_oil_change_due is not None %}
+              {{ towplane.next_oil_change_due|floatformat:1 }}
+            {% else %}
+              <span class="text-muted">Not set</span>
+            {% endif %}
+          </td>
+          {% if can_update_oil_deadlines %}
+          <td>
+            {% if is_webmaster or towplane.id in meister_towplanes %}
+            <button
+              class="btn btn-sm btn-primary update-oil-deadline-btn"
+              data-towplane-id="{{ towplane.id }}"
+              data-towplane-name="{{ towplane }}"
+              data-current-oil-due="{% if towplane.next_oil_change_due is not None %}{{ towplane.next_oil_change_due|floatformat:1 }}{% endif %}"
+              aria-label="Update oil deadline for {{ towplane }}">
+              ✏️ Update
+            </button>
+            {% endif %}
+          </td>
+          {% endif %}
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+    <div class="alert alert-info">No active towplanes available.</div>
+  {% endif %}
+</div>
+
+{% if can_update_deadlines or can_update_oil_deadlines %}
 {% if can_update_deadlines %}
 <!-- Modal for updating maintenance deadline -->
 <div class="modal fade" id="updateDeadlineModal" tabindex="-1" aria-labelledby="updateDeadlineModalLabel" aria-hidden="true">
@@ -97,6 +147,39 @@
     </div>
   </div>
 </div>
+{% endif %}
+
+{% if can_update_oil_deadlines %}
+<!-- Modal for updating towplane oil deadline -->
+<div class="modal fade" id="updateOilDeadlineModal" tabindex="-1" aria-labelledby="updateOilDeadlineModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="updateOilDeadlineModalLabel">Update Towplane Oil Deadline</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p><strong>Towplane:</strong> <span id="oil-modal-aircraft"></span></p>
+        <p><strong>Current Due:</strong> <span id="oil-modal-current-due"></span></p>
+
+        <form id="update-oil-deadline-form">
+          {% csrf_token %}
+          <div class="mb-3">
+            <label for="new-oil-due" class="form-label">Next Oil Change Due (tach)</label>
+            <input type="number" class="form-control" id="new-oil-due" name="next_oil_change_due" step="0.1" min="0" required>
+            <div class="form-text">Enter tach time in hours with one decimal place (example: 1234.5).</div>
+          </div>
+          <div id="update-oil-error-message" class="alert alert-danger d-none"></div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-primary" id="save-oil-deadline-btn">Save Changes</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
 
 <!-- Bootstrap Toast for success messages -->
 <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
@@ -114,13 +197,15 @@
   // Tablesort initialized globally; nothing else required here. If special behavior is needed,
   // listen for the 'tablesort:ready' event.
 
-  // Handle Update button clicks
+  // Handle update actions for both maintenance date and oil tach deadlines.
   document.addEventListener('DOMContentLoaded', function() {
-    let currentDeadlineId = null;
-    const modal = new bootstrap.Modal(document.getElementById('updateDeadlineModal'));
-    const updateUrl = "{% url 'logsheet:update_maintenance_deadline' deadline_id=0 %}".replace('/0/', '/{id}/');
+    const csrfToken = (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value || '';
 
-    // Open modal when Update button is clicked
+    {% if can_update_deadlines %}
+    let currentDeadlineId = null;
+    const deadlineModal = new bootstrap.Modal(document.getElementById('updateDeadlineModal'));
+    const updateDeadlineUrl = "{% url 'logsheet:update_maintenance_deadline' deadline_id=0 %}".replace('/0/', '/{id}/');
+
     document.querySelectorAll('.update-deadline-btn').forEach(button => {
       button.addEventListener('click', function() {
         currentDeadlineId = this.dataset.deadlineId;
@@ -129,29 +214,26 @@
         document.getElementById('modal-current-date').textContent = this.dataset.currentDate;
         document.getElementById('new-due-date').value = this.dataset.currentDate;
         document.getElementById('update-error-message').classList.add('d-none');
-        modal.show();
+        deadlineModal.show();
       });
     });
 
-    // Handle form submission (works for both button click and Enter key)
     document.getElementById('update-deadline-form').addEventListener('submit', function(e) {
       e.preventDefault();
-      const form = this;
-      const formData = new FormData(form);
+      const formData = new FormData(this);
       const errorDiv = document.getElementById('update-error-message');
       const submitBtn = document.getElementById('save-deadline-btn');
 
-      // Disable button during request
       submitBtn.disabled = true;
       submitBtn.textContent = 'Saving...';
 
-      const url = updateUrl.replace('{id}', currentDeadlineId);
+      const url = updateDeadlineUrl.replace('{id}', currentDeadlineId);
 
       fetch(url, {
         method: 'POST',
         body: formData,
         headers: {
-          'X-CSRFToken': (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value || '',
+          'X-CSRFToken': csrfToken,
           'X-Requested-With': 'XMLHttpRequest'
         }
       })
@@ -183,16 +265,13 @@
       })
       .then(data => {
         if (data.success) {
-          // Update the table cell with new date
           document.getElementById(`due-date-${currentDeadlineId}`).textContent = data.new_due_date;
-          modal.hide();
+          deadlineModal.hide();
 
-          // Show success toast
           document.getElementById('toast-message').textContent = data.message;
           const toast = new bootstrap.Toast(document.getElementById('successToast'));
           toast.show();
 
-          // Reload page after toast to update status badges
           setTimeout(() => location.reload(), 1500);
         } else {
           errorDiv.textContent = data.error || data.message || 'An error occurred. Please try again.';
@@ -204,11 +283,96 @@
         errorDiv.classList.remove('d-none');
       })
       .finally(() => {
-        // Re-enable button
         submitBtn.disabled = false;
         submitBtn.textContent = 'Save Changes';
       });
     });
+    {% endif %}
+
+    {% if can_update_oil_deadlines %}
+    let currentTowplaneId = null;
+    const oilModal = new bootstrap.Modal(document.getElementById('updateOilDeadlineModal'));
+    const updateOilUrl = "{% url 'logsheet:update_towplane_oil_deadline' towplane_id=0 %}".replace('/0/', '/{id}/');
+
+    document.querySelectorAll('.update-oil-deadline-btn').forEach(button => {
+      button.addEventListener('click', function() {
+        currentTowplaneId = this.dataset.towplaneId;
+        const currentDue = this.dataset.currentOilDue || 'Not set';
+        document.getElementById('oil-modal-aircraft').textContent = this.dataset.towplaneName;
+        document.getElementById('oil-modal-current-due').textContent = currentDue;
+        document.getElementById('new-oil-due').value = this.dataset.currentOilDue || '';
+        document.getElementById('update-oil-error-message').classList.add('d-none');
+        oilModal.show();
+      });
+    });
+
+    document.getElementById('update-oil-deadline-form').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const formData = new FormData(this);
+      const errorDiv = document.getElementById('update-oil-error-message');
+      const submitBtn = document.getElementById('save-oil-deadline-btn');
+
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Saving...';
+
+      const url = updateOilUrl.replace('{id}', currentTowplaneId);
+
+      fetch(url, {
+        method: 'POST',
+        body: formData,
+        headers: {
+          'X-CSRFToken': csrfToken,
+          'X-Requested-With': 'XMLHttpRequest'
+        }
+      })
+      .then(async (response) => {
+        const contentType = response.headers.get('content-type') || '';
+        let data = null;
+
+        if (contentType.includes('application/json')) {
+          try {
+            data = await response.json();
+          } catch (e) {
+            data = null;
+          }
+        }
+
+        if (!response.ok) {
+          const message =
+            (data && (data.error || data.message)) ||
+            `Request failed with status ${response.status}`;
+          throw new Error(message);
+        }
+
+        if (!data) {
+          throw new Error('Invalid server response. Please try again.');
+        }
+
+        return data;
+      })
+      .then(data => {
+        if (data.success) {
+          document.getElementById(`oil-due-${currentTowplaneId}`).textContent = data.new_due;
+          oilModal.hide();
+
+          document.getElementById('toast-message').textContent = data.message;
+          const toast = new bootstrap.Toast(document.getElementById('successToast'));
+          toast.show();
+        } else {
+          errorDiv.textContent = data.error || data.message || 'An error occurred. Please try again.';
+          errorDiv.classList.remove('d-none');
+        }
+      })
+      .catch(error => {
+        errorDiv.textContent = error.message || 'An error occurred. Please try again.';
+        errorDiv.classList.remove('d-none');
+      })
+      .finally(() => {
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Save Changes';
+      });
+    });
+    {% endif %}
   });
 </script>
 {% endif %}

--- a/logsheet/tests/test_maintenance_deadline_update.py
+++ b/logsheet/tests/test_maintenance_deadline_update.py
@@ -53,6 +53,18 @@ def maintenance_officer(glider):
 
 
 @pytest.fixture
+def towplane_meister(towplane):
+    """Create a maintenance officer (Aircraft Meister) for the towplane."""
+    meister = Member.objects.create(
+        username="towplane_meister",
+        email="towplane_meister@example.com",
+        membership_status="Full Member",
+    )
+    AircraftMeister.objects.create(towplane=towplane, member=meister)
+    return meister
+
+
+@pytest.fixture
 def webmaster(webmaster_group):
     """Create a webmaster."""
     webmaster = Member.objects.create(
@@ -468,3 +480,175 @@ def test_maintenance_deadline_constraint_requires_aircraft():
 
     # Verify the error is from our constraint
     assert "maintenance_deadline_must_have_aircraft" in str(exc_info.value)
+
+
+@pytest.mark.django_db
+class TestTowplaneOilDeadlineUpdate:
+    """Test permission checks and validation for towplane oil deadline updates."""
+
+    def test_towplane_meister_can_update_oil_deadline(
+        self, client, towplane_meister, towplane
+    ):
+        """Towplane meisters can update oil deadlines for assigned towplanes."""
+        client.force_login(towplane_meister)
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={"next_oil_change_due": "1234.5"},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["new_due"] == "1234.5"
+
+        towplane.refresh_from_db()
+        assert str(towplane.next_oil_change_due) == "1234.5"
+
+    def test_glider_meister_cannot_update_towplane_oil_deadline(
+        self, client, maintenance_officer, towplane
+    ):
+        """Glider meisters cannot update towplane oil deadlines."""
+        client.force_login(maintenance_officer)
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={"next_oil_change_due": "1234.5"},
+        )
+
+        assert response.status_code == 403
+        payload = response.json()
+        assert payload["success"] is False
+        assert "not authorized" in payload["error"].lower()
+
+    def test_webmaster_can_update_towplane_oil_deadline(
+        self, client, webmaster, towplane
+    ):
+        """Webmasters can update towplane oil deadlines."""
+        client.force_login(webmaster)
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={"next_oil_change_due": "4321.1"},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["new_due"] == "4321.1"
+
+    def test_regular_member_cannot_update_towplane_oil_deadline(
+        self, client, regular_member, towplane
+    ):
+        """Regular members cannot update towplane oil deadlines."""
+        client.force_login(regular_member)
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={"next_oil_change_due": "99.9"},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["success"] is False
+
+    def test_missing_tach_value_returns_error(self, client, webmaster, towplane):
+        """Missing next_oil_change_due returns 400."""
+        client.force_login(webmaster)
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={},
+        )
+
+        assert response.status_code == 400
+        payload = response.json()
+        assert payload["success"] is False
+        assert "required" in payload["error"].lower()
+
+    def test_invalid_tach_value_returns_error(self, client, webmaster, towplane):
+        """Invalid tach value returns 400."""
+        client.force_login(webmaster)
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={"next_oil_change_due": "not-a-number"},
+        )
+
+        assert response.status_code == 400
+        payload = response.json()
+        assert payload["success"] is False
+        assert "invalid tach value" in payload["error"].lower()
+
+    def test_negative_tach_value_returns_error(self, client, webmaster, towplane):
+        """Negative tach value returns 400."""
+        client.force_login(webmaster)
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={"next_oil_change_due": "-1.0"},
+        )
+
+        assert response.status_code == 400
+        payload = response.json()
+        assert payload["success"] is False
+        assert "zero or greater" in payload["error"].lower()
+
+    def test_get_request_rejected_for_oil_update(self, client, webmaster, towplane):
+        """GET requests are rejected for oil deadline updates."""
+        client.force_login(webmaster)
+
+        response = client.get(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            )
+        )
+
+        assert response.status_code == 405
+
+    def test_towplane_meister_sees_oil_update_button(
+        self, client, towplane_meister, towplane
+    ):
+        """Towplane meisters see oil update controls in maintenance deadlines view."""
+        towplane.next_oil_change_due = 1200.0
+        towplane.save(update_fields=["next_oil_change_due"])
+
+        client.force_login(towplane_meister)
+        response = client.get(reverse("logsheet:maintenance_deadlines"))
+
+        assert response.status_code == 200
+        assert b"update-oil-deadline-btn" in response.content
+
+    def test_regular_member_does_not_see_oil_update_button(
+        self, client, regular_member, towplane
+    ):
+        """Regular members do not see oil update controls."""
+        towplane.next_oil_change_due = 1200.0
+        towplane.save(update_fields=["next_oil_change_due"])
+
+        client.force_login(regular_member)
+        response = client.get(reverse("logsheet:maintenance_deadlines"))
+
+        assert response.status_code == 200
+        assert b"update-oil-deadline-btn" not in response.content

--- a/logsheet/tests/test_maintenance_deadline_update.py
+++ b/logsheet/tests/test_maintenance_deadline_update.py
@@ -6,6 +6,7 @@ maintenance deadlines via the web interface.
 """
 
 from datetime import date
+from decimal import Decimal
 
 import pytest
 from django.contrib.auth.models import Group
@@ -613,6 +614,53 @@ class TestTowplaneOilDeadlineUpdate:
         payload = response.json()
         assert payload["success"] is False
         assert "zero or greater" in payload["error"].lower()
+
+    def test_tach_value_above_field_max_returns_error(
+        self, client, webmaster, towplane
+    ):
+        """Values above the DecimalField max are rejected."""
+        client.force_login(webmaster)
+        field = Towplane._meta.get_field("next_oil_change_due")
+        step = Decimal(10) ** (-field.decimal_places)
+        max_supported_due = (
+            Decimal(10) ** (field.max_digits - field.decimal_places)
+        ) - step
+        above_max = max_supported_due + step
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={"next_oil_change_due": str(above_max)},
+        )
+
+        assert response.status_code == 400
+        payload = response.json()
+        assert payload["success"] is False
+        assert "exceeds maximum supported tach value" in payload["error"].lower()
+
+    def test_tach_value_with_extra_decimal_places_is_quantized(
+        self, client, webmaster, towplane
+    ):
+        """Values with extra precision are rounded/quantized before saving."""
+        client.force_login(webmaster)
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={"next_oil_change_due": "1234.56"},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["new_due"] == "1234.6"
+
+        towplane.refresh_from_db()
+        assert str(towplane.next_oil_change_due) == "1234.6"
 
     def test_get_request_rejected_for_oil_update(self, client, webmaster, towplane):
         """GET requests are rejected for oil deadline updates."""

--- a/logsheet/tests/test_maintenance_deadline_update.py
+++ b/logsheet/tests/test_maintenance_deadline_update.py
@@ -581,6 +581,25 @@ class TestTowplaneOilDeadlineUpdate:
         assert payload["success"] is False
         assert "required" in payload["error"].lower()
 
+    def test_whitespace_tach_value_returns_required_error(
+        self, client, webmaster, towplane
+    ):
+        """Whitespace-only next_oil_change_due returns required 400."""
+        client.force_login(webmaster)
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={"next_oil_change_due": "   "},
+        )
+
+        assert response.status_code == 400
+        payload = response.json()
+        assert payload["success"] is False
+        assert "required" in payload["error"].lower()
+
     def test_invalid_tach_value_returns_error(self, client, webmaster, towplane):
         """Invalid tach value returns 400."""
         client.force_login(webmaster)
@@ -674,6 +693,22 @@ class TestTowplaneOilDeadlineUpdate:
         )
 
         assert response.status_code == 405
+
+    def test_inactive_towplane_cannot_be_updated(self, client, webmaster, towplane):
+        """Inactive towplanes are not updatable via endpoint."""
+        client.force_login(webmaster)
+        towplane.is_active = False
+        towplane.save(update_fields=["is_active"])
+
+        response = client.post(
+            reverse(
+                "logsheet:update_towplane_oil_deadline",
+                kwargs={"towplane_id": towplane.id},
+            ),
+            data={"next_oil_change_due": "1234.5"},
+        )
+
+        assert response.status_code == 404
 
     def test_towplane_meister_sees_oil_update_button(
         self, client, towplane_meister, towplane

--- a/logsheet/urls.py
+++ b/logsheet/urls.py
@@ -121,6 +121,11 @@ urlpatterns = [
         name="update_maintenance_deadline",
     ),
     path(
+        "maintenance-deadlines/towplane/<int:towplane_id>/update-oil/",
+        views.update_towplane_oil_deadline,
+        name="update_towplane_oil_deadline",
+    ),
+    path(
         "equipment/glider/<int:pk>/logbook/",
         views.glider_logbook,
         name="glider_logbook",

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -2,7 +2,7 @@
 import csv
 import logging
 from datetime import date, datetime, timedelta
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 
 from django.contrib import messages
 from django.core.exceptions import ValidationError
@@ -3240,6 +3240,10 @@ def maintenance_deadlines(request):
         is_webmaster or bool(meister_gliders) or bool(meister_towplanes)
     )
 
+    # Towplane oil deadlines are managed by towplane meisters or webmasters.
+    towplanes = Towplane.objects.filter(is_active=True).order_by("n_number")
+    can_update_oil_deadlines = is_webmaster or bool(meister_towplanes)
+
     return render(
         request,
         "logsheet/maintenance_deadlines.html",
@@ -3251,6 +3255,8 @@ def maintenance_deadlines(request):
             "meister_gliders": meister_gliders,
             "meister_towplanes": meister_towplanes,
             "can_update_deadlines": can_update_deadlines,
+            "towplanes": towplanes,
+            "can_update_oil_deadlines": can_update_oil_deadlines,
         },
     )
 
@@ -3349,6 +3355,85 @@ def update_maintenance_deadline(request, deadline_id):
             "success": True,
             "message": f"Deadline updated successfully to {new_due_date}.",
             "new_due_date": new_due_date.strftime("%Y-%m-%d"),
+        }
+    )
+
+
+@require_POST
+@active_member_required
+def update_towplane_oil_deadline(request, towplane_id):
+    towplane = get_object_or_404(Towplane, pk=towplane_id)
+    member = request.user
+
+    is_webmaster = (
+        member.is_superuser or member.groups.filter(name="Webmasters").exists()
+    )
+    is_meister = AircraftMeister.objects.filter(
+        towplane=towplane, member=member
+    ).exists()
+
+    if not (is_webmaster or is_meister):
+        return JsonResponse(
+            {
+                "success": False,
+                "error": "You are not authorized to update this oil deadline.",
+            },
+            status=403,
+        )
+
+    new_due_str = request.POST.get("next_oil_change_due")
+    if not new_due_str:
+        return JsonResponse(
+            {"success": False, "error": "Next oil change due value is required."},
+            status=400,
+        )
+
+    try:
+        new_due = Decimal(new_due_str).quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+    except (InvalidOperation, ValueError, TypeError):
+        return JsonResponse(
+            {
+                "success": False,
+                "error": "Invalid tach value. Use a numeric value like 1234.5.",
+            },
+            status=400,
+        )
+
+    if new_due < 0:
+        return JsonResponse(
+            {
+                "success": False,
+                "error": "Next oil change due must be zero or greater.",
+            },
+            status=400,
+        )
+
+    if new_due > Decimal("9999999.9"):
+        return JsonResponse(
+            {
+                "success": False,
+                "error": "Value exceeds maximum supported tach value (9999999.9).",
+            },
+            status=400,
+        )
+
+    old_due = towplane.next_oil_change_due
+    towplane.next_oil_change_due = new_due
+    towplane.save(update_fields=["next_oil_change_due"])
+
+    logger.info(
+        "Towplane oil deadline updated by %s: %s changed from %s to %s",
+        member.username,
+        towplane,
+        old_due,
+        new_due,
+    )
+
+    return JsonResponse(
+        {
+            "success": True,
+            "message": f"Oil deadline updated successfully to {new_due:.1f}.",
+            "new_due": f"{new_due:.1f}",
         }
     )
 

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -3364,6 +3364,15 @@ def update_maintenance_deadline(request, deadline_id):
 def update_towplane_oil_deadline(request, towplane_id):
     towplane = get_object_or_404(Towplane, pk=towplane_id)
     member = request.user
+    next_oil_change_due_field = Towplane._meta.get_field("next_oil_change_due")
+    quantizer = Decimal(10) ** (-next_oil_change_due_field.decimal_places)
+    max_supported_due = (
+        Decimal(10)
+        ** (
+            next_oil_change_due_field.max_digits
+            - next_oil_change_due_field.decimal_places
+        )
+    ) - quantizer
 
     is_webmaster = (
         member.is_superuser or member.groups.filter(name="Webmasters").exists()
@@ -3389,7 +3398,7 @@ def update_towplane_oil_deadline(request, towplane_id):
         )
 
     try:
-        new_due = Decimal(new_due_str).quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+        new_due = Decimal(new_due_str).quantize(quantizer, rounding=ROUND_HALF_UP)
     except (InvalidOperation, ValueError, TypeError):
         return JsonResponse(
             {
@@ -3408,11 +3417,14 @@ def update_towplane_oil_deadline(request, towplane_id):
             status=400,
         )
 
-    if new_due > Decimal("9999999.9"):
+    if new_due > max_supported_due:
         return JsonResponse(
             {
                 "success": False,
-                "error": "Value exceeds maximum supported tach value (9999999.9).",
+                "error": (
+                    "Value exceeds maximum supported tach value "
+                    f"({max_supported_due})."
+                ),
             },
             status=400,
         )
@@ -3429,11 +3441,13 @@ def update_towplane_oil_deadline(request, towplane_id):
         new_due,
     )
 
+    formatted_due = f"{new_due:.{next_oil_change_due_field.decimal_places}f}"
+
     return JsonResponse(
         {
             "success": True,
-            "message": f"Oil deadline updated successfully to {new_due:.1f}.",
-            "new_due": f"{new_due:.1f}",
+            "message": f"Oil deadline updated successfully to {formatted_due}.",
+            "new_due": formatted_due,
         }
     )
 

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -3362,7 +3362,9 @@ def update_maintenance_deadline(request, deadline_id):
 @require_POST
 @active_member_required
 def update_towplane_oil_deadline(request, towplane_id):
-    towplane = get_object_or_404(Towplane, pk=towplane_id)
+    towplane = get_object_or_404(
+        Towplane.objects.filter(is_active=True), pk=towplane_id
+    )
     member = request.user
     next_oil_change_due_field = Towplane._meta.get_field("next_oil_change_due")
     quantizer = Decimal(10) ** (-next_oil_change_due_field.decimal_places)
@@ -3390,7 +3392,7 @@ def update_towplane_oil_deadline(request, towplane_id):
             status=403,
         )
 
-    new_due_str = request.POST.get("next_oil_change_due")
+    new_due_str = (request.POST.get("next_oil_change_due") or "").strip()
     if not new_due_str:
         return JsonResponse(
             {"success": False, "error": "Next oil change due value is required."},


### PR DESCRIPTION
## Summary
- add in-app UI on maintenance deadlines page to manage towplane oil change tach deadlines
- add new endpoint to update `next_oil_change_due` with authorization for superusers, Webmasters, and assigned Aircraft Meisters
- add server-side validation for tach input (required, numeric, non-negative, bounded)
- add helper text in the modal clarifying tach hours format with one decimal place

## Scope
- towplanes only
- editable field: `next_oil_change_due`
- no schema/migration changes

## Files changed
- `logsheet/views.py`
- `logsheet/urls.py`
- `logsheet/templates/logsheet/maintenance_deadlines.html`
- `logsheet/tests/test_maintenance_deadline_update.py`
- `e2e_tests/e2e/test_maintenance_deadline_update.py`

## Validation
- `pytest logsheet/tests/test_maintenance_deadline_update.py -q` (passed)
- `pytest e2e_tests/e2e/test_maintenance_deadline_update.py -k towplane_oil_deadline_can_be_updated_via_modal -q` (passed)
- `python manage.py collectstatic --noinput` (ran successfully)

Closes #873