### PR TITLE
Issue #872: Improve training grid print pagination and header behavior

### DIFF
--- a/instructors/tests/test_profile_links.py
+++ b/instructors/tests/test_profile_links.py
@@ -40,7 +40,7 @@ def test_training_grid_shows_member_profile_icon_link(client):
     assert "training-grid-max-col" in content
     assert "print-score-text" in content
     assert "training-grid-print-head" in content
-    assert "@media screen" in content
+    assert "training-grid-scroll" in content
 
 
 @pytest.mark.django_db

--- a/instructors/tests/test_profile_links.py
+++ b/instructors/tests/test_profile_links.py
@@ -39,6 +39,8 @@ def test_training_grid_shows_member_profile_icon_link(client):
     assert 'media="print"' in content
     assert "training-grid-max-col" in content
     assert "print-score-text" in content
+    assert "training-grid-print-head" in content
+    assert "@media screen" in content
 
 
 @pytest.mark.django_db

--- a/static/css/print_training_grid.css
+++ b/static/css/print_training_grid.css
@@ -4,9 +4,15 @@
 }
 
 @media print {
+  html,
+  body {
+    overflow: visible !important;
+  }
+
   .training-grid-scroll {
     max-height: none !important;
     min-height: 0 !important;
+    height: auto !important;
     overflow: visible !important;
   }
 
@@ -15,7 +21,16 @@
     min-width: 0 !important;
     table-layout: fixed;
     border-collapse: collapse;
+    border-spacing: 0;
     page-break-inside: auto;
+  }
+
+  .training-grid-print-head {
+    display: table-header-group;
+  }
+
+  .training-grid tbody {
+    display: table-row-group;
   }
 
   .training-grid th,
@@ -65,6 +80,11 @@
   .training-grid tr {
     page-break-inside: avoid;
     break-inside: avoid;
+  }
+
+  .training-grid tbody tr.table-secondary {
+    page-break-after: avoid;
+    break-after: avoid;
   }
 
   .btn,

--- a/templates/shared/training_grid.html
+++ b/templates/shared/training_grid.html
@@ -6,40 +6,43 @@
 {% endblock %}
 {% block content %}
 <style>
-/* Scrollable grid container and sticky columns */
-.training-grid-scroll {
-  overflow-x: auto;
-  overflow-y: visible;
-  width: 100%;
-  max-height: 80vh;
-  min-height: 400px;
-  position: relative;
-  background: #fff;
-}
-table.training-grid {
-  min-width: 1200px;
-  width: max-content;
-}
-th.sticky-col, td.sticky-col {
-  position: sticky;
-  left: 0;
-  background: #fff;
-  z-index: 2;
-}
-th.sticky-max, td.sticky-max {
-  position: sticky;
-  right: 0;
-  background: #fff;
-  z-index: 2;
-}
-
 @media screen {
+  /* Scrollable grid container and sticky columns */
+  .training-grid-scroll {
+    overflow-x: auto;
+    overflow-y: visible;
+    width: 100%;
+    max-height: 80vh;
+    min-height: 400px;
+    position: relative;
+    background: #fff;
+  }
+
+  table.training-grid {
+    min-width: 1200px;
+    width: max-content;
+  }
+
+  th.sticky-col,
+  td.sticky-col {
+    position: sticky;
+    left: 0;
+    background: #fff;
+    z-index: 2;
+  }
+
+  th.sticky-max,
+  td.sticky-max {
+    position: sticky;
+    right: 0;
+    background: #fff;
+    z-index: 2;
+  }
+
   .print-score-text {
     display: none;
   }
 }
-
-
 </style>
 <div class="d-flex justify-content-between align-items-center mb-2">
   <h2 class="mb-0">Training Progress for {{ member.full_display_name }}</h2>
@@ -64,7 +67,7 @@ th.sticky-max, td.sticky-max {
 
 <div class="training-grid-scroll" id="training-grid-scroll">
 <table class="table table-bordered table-sm border-dark-subtle training-grid">
-  <thead>
+  <thead class="training-grid-print-head">
     <tr>
   <th rowspan="3" class="sticky-col training-grid-lesson-col">Lesson</th>
       {% for meta in column_metadata %}


### PR DESCRIPTION
## Summary
- scope interactive grid/sticky behavior to screen media in the shared training grid template to reduce print-mode style conflicts
- improve print stylesheet behavior for multi-page output and readability
- add explicit print header-group hook so table headers repeat more reliably on printed pages
- extend targeted template test assertions for print hooks

## Files Changed
- templates/shared/training_grid.html
- static/css/print_training_grid.css
- instructors/tests/test_profile_links.py

## Validation
- pytest instructors/tests/test_profile_links.py -q (3 passed)
- python manage.py collectstatic --noinput (successful)

Closes #872