### PR TITLE
Auto-dismiss stale overdue SPR reminders

### DIFF
--- a/instructors/management/commands/notify_late_sprs.py
+++ b/instructors/management/commands/notify_late_sprs.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.template.loader import render_to_string
-from django.utils.timezone import now
+from django.utils import timezone
 
 from instructors.utils import get_overdue_sprs
 from notifications.models import Notification
@@ -29,7 +29,7 @@ class Command(BaseCronJobCommand):
 
     def execute_job(self, *args, **options):
         max_days = options.get("max_days", 30)
-        as_of_date = now().date()
+        as_of_date = timezone.localdate()
         cutoff_date = as_of_date - timedelta(days=max_days)
 
         self.log_info(f"Checking for overdue SPRs from flights since {cutoff_date}")

--- a/instructors/management/commands/notify_late_sprs.py
+++ b/instructors/management/commands/notify_late_sprs.py
@@ -5,7 +5,6 @@ from django.template.loader import render_to_string
 from django.utils.timezone import now
 
 from instructors.utils import get_overdue_sprs, get_spr_escalation_level
-from logsheet.models import Flight
 from notifications.models import Notification
 from siteconfig.models import SiteConfiguration
 from utils.email import send_mail
@@ -30,27 +29,11 @@ class Command(BaseCronJobCommand):
 
     def execute_job(self, *args, **options):
         max_days = options.get("max_days", 30)
-        cutoff_date = now().date() - timedelta(days=max_days)
+        as_of_date = now().date()
+        cutoff_date = as_of_date - timedelta(days=max_days)
 
         self.log_info(f"Checking for overdue SPRs from flights since {cutoff_date}")
-
-        # Find instructional flights that might need SPRs
-        instructional_flights = Flight.objects.filter(
-            instructor__isnull=False,  # Has an instructor
-            logsheet__finalized=True,  # From finalized logsheets only
-            logsheet__log_date__gte=cutoff_date,  # Within our time window
-            logsheet__log_date__lt=now().date(),  # Not today's flights
-        )
-
-        if not instructional_flights.exists():
-            self.log_info("No instructional flights found requiring SPR check")
-            return
-
-        self.log_info(
-            f"Checking {instructional_flights.count()} instructional flights for missing SPRs"
-        )
-
-        overdue_sprs = get_overdue_sprs(max_days=max_days, as_of_date=now().date())
+        overdue_sprs = get_overdue_sprs(max_days=max_days, as_of_date=as_of_date)
 
         if not overdue_sprs:
             self.log_info("No overdue SPRs found")

--- a/instructors/management/commands/notify_late_sprs.py
+++ b/instructors/management/commands/notify_late_sprs.py
@@ -1,13 +1,11 @@
-from datetime import date, timedelta
+from datetime import timedelta
 
 from django.conf import settings
-from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils.timezone import now
 
-from instructors.models import InstructionReport
+from instructors.utils import get_overdue_sprs, get_spr_escalation_level
 from logsheet.models import Flight
-from members.models import Member
 from notifications.models import Notification
 from siteconfig.models import SiteConfiguration
 from utils.email import send_mail
@@ -37,15 +35,11 @@ class Command(BaseCronJobCommand):
         self.log_info(f"Checking for overdue SPRs from flights since {cutoff_date}")
 
         # Find instructional flights that might need SPRs
-        instructional_flights = (
-            Flight.objects.filter(
-                instructor__isnull=False,  # Has an instructor
-                logsheet__finalized=True,  # From finalized logsheets only
-                logsheet__log_date__gte=cutoff_date,  # Within our time window
-                logsheet__log_date__lt=now().date(),  # Not today's flights
-            )
-            .select_related("instructor", "pilot", "logsheet")
-            .order_by("logsheet__log_date", "instructor")
+        instructional_flights = Flight.objects.filter(
+            instructor__isnull=False,  # Has an instructor
+            logsheet__finalized=True,  # From finalized logsheets only
+            logsheet__log_date__gte=cutoff_date,  # Within our time window
+            logsheet__log_date__lt=now().date(),  # Not today's flights
         )
 
         if not instructional_flights.exists():
@@ -56,51 +50,7 @@ class Command(BaseCronJobCommand):
             f"Checking {instructional_flights.count()} instructional flights for missing SPRs"
         )
 
-        # Group flights by instructor and student combination
-        instructor_student_flights = {}
-
-        for flight in instructional_flights:
-            if not flight.instructor or not flight.pilot:
-                continue
-
-            key = (flight.instructor, flight.pilot)
-            if key not in instructor_student_flights:
-                instructor_student_flights[key] = []
-
-            instructor_student_flights[key].append(flight)
-
-        # Check each instructor-student combination for missing SPRs
-        overdue_sprs = {}
-
-        for (instructor, student), flights in instructor_student_flights.items():
-            # Sort flights by date to process chronologically
-            flights.sort(key=lambda f: f.logsheet.log_date)
-
-            for flight in flights:
-                flight_date = flight.logsheet.log_date
-                days_since_flight = (now().date() - flight_date).days
-
-                # Check if there's an SPR for this flight
-                spr_exists = InstructionReport.objects.filter(
-                    instructor=instructor, student=student, report_date=flight_date
-                ).exists()
-
-                if not spr_exists and days_since_flight >= 7:  # Overdue threshold
-                    # Determine escalation level
-                    escalation_level = self._get_escalation_level(days_since_flight)
-
-                    if instructor not in overdue_sprs:
-                        overdue_sprs[instructor] = []
-
-                    overdue_sprs[instructor].append(
-                        {
-                            "flight": flight,
-                            "student": student,
-                            "days_overdue": days_since_flight,
-                            "escalation_level": escalation_level,
-                            "flight_date": flight_date,
-                        }
-                    )
+        overdue_sprs = get_overdue_sprs(max_days=max_days, as_of_date=now().date())
 
         if not overdue_sprs:
             self.log_info("No overdue SPRs found")
@@ -141,16 +91,7 @@ class Command(BaseCronJobCommand):
 
     def _get_escalation_level(self, days_overdue):
         """Determine escalation level based on days overdue"""
-        if days_overdue >= 30:
-            return "FINAL"  # 30+ days: Final notice
-        elif days_overdue >= 25:
-            return "URGENT"  # 25+ days: Urgent
-        elif days_overdue >= 21:
-            return "WARNING"  # 21+ days: Strong warning
-        elif days_overdue >= 14:
-            return "REMINDER"  # 14+ days: Escalated reminder
-        else:  # 7+ days
-            return "NOTICE"  # 7+ days: Initial notice
+        return get_spr_escalation_level(days_overdue)
 
     def _send_notification(self, instructor, spr_data):
         """Send email and in-app notification to instructor about overdue SPRs"""

--- a/instructors/management/commands/notify_late_sprs.py
+++ b/instructors/management/commands/notify_late_sprs.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils.timezone import now
 
-from instructors.utils import get_overdue_sprs, get_spr_escalation_level
+from instructors.utils import get_overdue_sprs
 from notifications.models import Notification
 from siteconfig.models import SiteConfiguration
 from utils.email import send_mail
@@ -71,10 +71,6 @@ class Command(BaseCronJobCommand):
             )
         else:
             self.log_info("No notifications sent (dry run mode)")
-
-    def _get_escalation_level(self, days_overdue):
-        """Determine escalation level based on days overdue"""
-        return get_spr_escalation_level(days_overdue)
 
     def _send_notification(self, instructor, spr_data):
         """Send email and in-app notification to instructor about overdue SPRs"""

--- a/instructors/signals.py
+++ b/instructors/signals.py
@@ -9,7 +9,11 @@ from django.urls import NoReverseMatch, reverse
 from notifications.models import Notification
 
 from .models import GroundInstruction, InstructionReport, MemberQualification
-from .utils import update_student_progress_snapshot
+from .utils import (
+    OVERDUE_SPR_NOTIFICATION_FRAGMENT,
+    get_instructor_overdue_spr_count,
+    update_student_progress_snapshot,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +80,27 @@ def notify_student_on_instruction_report(sender, instance, created, **kwargs):
         logger.exception("notify_student_on_instruction_report failed")
         # Don't re-raise from signal handlers; swallowing prevents breaking
         # the main save operation (tests and production rely on this pattern).
+        return
+
+
+@receiver(post_save, sender=InstructionReport)
+def dismiss_stale_overdue_spr_notifications(sender, instance, **kwargs):
+    """Dismiss overdue SPR reminders once an instructor has no overdue SPRs left."""
+    try:
+        instructor = instance.instructor
+        if not instructor:
+            return
+
+        if get_instructor_overdue_spr_count(instructor) > 0:
+            return
+
+        Notification.objects.filter(
+            user=instructor,
+            dismissed=False,
+            message__contains=OVERDUE_SPR_NOTIFICATION_FRAGMENT,
+        ).update(dismissed=True)
+    except Exception:
+        logger.exception("dismiss_stale_overdue_spr_notifications failed")
         return
 
 

--- a/instructors/signals.py
+++ b/instructors/signals.py
@@ -99,14 +99,18 @@ def dismiss_stale_overdue_spr_notifications(sender, instance, **kwargs):
         ):
             return
 
-        if get_instructor_has_overdue_sprs(instructor):
-            return
-
-        Notification.objects.filter(
+        overdue_notification_qs = Notification.objects.filter(
             user=instructor,
             dismissed=False,
             message__contains=OVERDUE_SPR_NOTIFICATION_FRAGMENT,
-        ).update(dismissed=True)
+        )
+        if not overdue_notification_qs.exists():
+            return
+
+        if get_instructor_has_overdue_sprs(instructor):
+            return
+
+        overdue_notification_qs.update(dismissed=True)
     except Exception:
         logger.exception("dismiss_stale_overdue_spr_notifications failed")
         return

--- a/instructors/signals.py
+++ b/instructors/signals.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from datetime import date
 
 from django.apps import apps
 from django.db.models.signals import post_save
@@ -89,6 +90,10 @@ def dismiss_stale_overdue_spr_notifications(sender, instance, **kwargs):
     try:
         instructor = instance.instructor
         if not instructor:
+            return
+
+        # Overdue reminders only concern reports that are at least 7 days old.
+        if not instance.report_date or (date.today() - instance.report_date).days < 7:
             return
 
         if get_instructor_overdue_spr_count(instructor) > 0:

--- a/instructors/signals.py
+++ b/instructors/signals.py
@@ -1,11 +1,11 @@
 import logging
 import sys
-from datetime import date
 
 from django.apps import apps
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.urls import NoReverseMatch, reverse
+from django.utils import timezone
 
 from notifications.models import Notification
 
@@ -93,7 +93,10 @@ def dismiss_stale_overdue_spr_notifications(sender, instance, **kwargs):
             return
 
         # Overdue reminders only concern reports that are at least 7 days old.
-        if not instance.report_date or (date.today() - instance.report_date).days < 7:
+        if (
+            not instance.report_date
+            or (timezone.localdate() - instance.report_date).days < 7
+        ):
             return
 
         if get_instructor_overdue_spr_count(instructor) > 0:

--- a/instructors/signals.py
+++ b/instructors/signals.py
@@ -12,7 +12,7 @@ from notifications.models import Notification
 from .models import GroundInstruction, InstructionReport, MemberQualification
 from .utils import (
     OVERDUE_SPR_NOTIFICATION_FRAGMENT,
-    get_instructor_overdue_spr_count,
+    get_instructor_has_overdue_sprs,
     update_student_progress_snapshot,
 )
 
@@ -99,7 +99,7 @@ def dismiss_stale_overdue_spr_notifications(sender, instance, **kwargs):
         ):
             return
 
-        if get_instructor_overdue_spr_count(instructor) > 0:
+        if get_instructor_has_overdue_sprs(instructor):
             return
 
         Notification.objects.filter(

--- a/instructors/tests/test_instructor_notifications.py
+++ b/instructors/tests/test_instructor_notifications.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 
 import pytest
 from django.test import RequestFactory
+from django.utils import timezone
 
 from instructors.models import (
     ClubQualificationType,
@@ -128,7 +129,7 @@ def test_overdue_reminder_dismissed_when_final_spr_completed(django_user_model):
     student = django_user_model.objects.create_user(
         username="stud_cleanup1", password="pw"
     )
-    flight_date = date.today() - timedelta(days=8)
+    flight_date = timezone.localdate() - timedelta(days=8)
 
     _create_finalized_instructional_flight(
         instructor=instructor,
@@ -165,8 +166,8 @@ def test_overdue_reminder_not_dismissed_when_other_overdue_remains(django_user_m
         username="stud_cleanup2b", password="pw"
     )
 
-    first_date = date.today() - timedelta(days=8)
-    second_date = date.today() - timedelta(days=9)
+    first_date = timezone.localdate() - timedelta(days=8)
+    second_date = timezone.localdate() - timedelta(days=9)
 
     _create_finalized_instructional_flight(
         instructor=instructor,
@@ -212,8 +213,8 @@ def test_overdue_cleanup_is_instructor_scoped(django_user_model):
         username="stud_cleanup3b", password="pw"
     )
 
-    first_date = date.today() - timedelta(days=8)
-    second_date = date.today() - timedelta(days=9)
+    first_date = timezone.localdate() - timedelta(days=8)
+    second_date = timezone.localdate() - timedelta(days=9)
 
     _create_finalized_instructional_flight(
         instructor=instructor_one,

--- a/instructors/tests/test_instructor_notifications.py
+++ b/instructors/tests/test_instructor_notifications.py
@@ -1,6 +1,7 @@
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
+from django.test import RequestFactory
 
 from instructors.models import (
     ClubQualificationType,
@@ -8,8 +9,33 @@ from instructors.models import (
     InstructionReport,
     MemberQualification,
 )
+from instructors.utils import OVERDUE_SPR_NOTIFICATION_FRAGMENT
+from logsheet.models import Airfield, Flight, Glider, Logsheet
 from members.models import Badge, MemberBadge
+from notifications.context_processors import notifications as notifications_context
 from notifications.models import Notification
+
+
+def _create_finalized_instructional_flight(
+    *, instructor, student, flight_date, suffix="001"
+):
+    airfield = Airfield.objects.create(identifier=f"T{suffix}", name=f"Test {suffix}")
+    glider = Glider.objects.create(
+        make="Schweizer", model="2-33", n_number=f"N{suffix}"
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=flight_date,
+        airfield=airfield,
+        created_by=instructor,
+        finalized=True,
+    )
+    return Flight.objects.create(
+        logsheet=logsheet,
+        pilot=student,
+        instructor=instructor,
+        glider=glider,
+        flight_type="dual",
+    )
 
 
 @pytest.mark.django_db
@@ -92,3 +118,161 @@ def test_member_badge_creates_notification(django_user_model):
     assert Notification.objects.filter(
         user=member, message__contains=badge.name
     ).exists()
+
+
+@pytest.mark.django_db
+def test_overdue_reminder_dismissed_when_final_spr_completed(django_user_model):
+    instructor = django_user_model.objects.create_user(
+        username="inst_cleanup1", password="pw"
+    )
+    student = django_user_model.objects.create_user(
+        username="stud_cleanup1", password="pw"
+    )
+    flight_date = date.today() - timedelta(days=8)
+
+    _create_finalized_instructional_flight(
+        instructor=instructor,
+        student=student,
+        flight_date=flight_date,
+        suffix="101",
+    )
+
+    reminder = Notification.objects.create(
+        user=instructor,
+        message="📝 You have 1 overdue Student Progress Report(s)",
+    )
+
+    InstructionReport.objects.create(
+        student=student,
+        instructor=instructor,
+        report_date=flight_date,
+        report_text="completed",
+    )
+
+    reminder.refresh_from_db()
+    assert reminder.dismissed is True
+
+
+@pytest.mark.django_db
+def test_overdue_reminder_not_dismissed_when_other_overdue_remains(django_user_model):
+    instructor = django_user_model.objects.create_user(
+        username="inst_cleanup2", password="pw"
+    )
+    student_one = django_user_model.objects.create_user(
+        username="stud_cleanup2a", password="pw"
+    )
+    student_two = django_user_model.objects.create_user(
+        username="stud_cleanup2b", password="pw"
+    )
+
+    first_date = date.today() - timedelta(days=8)
+    second_date = date.today() - timedelta(days=9)
+
+    _create_finalized_instructional_flight(
+        instructor=instructor,
+        student=student_one,
+        flight_date=first_date,
+        suffix="102",
+    )
+    _create_finalized_instructional_flight(
+        instructor=instructor,
+        student=student_two,
+        flight_date=second_date,
+        suffix="103",
+    )
+
+    reminder = Notification.objects.create(
+        user=instructor,
+        message="📝 You have 2 overdue Student Progress Report(s)",
+    )
+
+    InstructionReport.objects.create(
+        student=student_one,
+        instructor=instructor,
+        report_date=first_date,
+        report_text="completed one",
+    )
+
+    reminder.refresh_from_db()
+    assert reminder.dismissed is False
+
+
+@pytest.mark.django_db
+def test_overdue_cleanup_is_instructor_scoped(django_user_model):
+    instructor_one = django_user_model.objects.create_user(
+        username="inst_cleanup3a", password="pw"
+    )
+    instructor_two = django_user_model.objects.create_user(
+        username="inst_cleanup3b", password="pw"
+    )
+    student_one = django_user_model.objects.create_user(
+        username="stud_cleanup3a", password="pw"
+    )
+    student_two = django_user_model.objects.create_user(
+        username="stud_cleanup3b", password="pw"
+    )
+
+    first_date = date.today() - timedelta(days=8)
+    second_date = date.today() - timedelta(days=9)
+
+    _create_finalized_instructional_flight(
+        instructor=instructor_one,
+        student=student_one,
+        flight_date=first_date,
+        suffix="104",
+    )
+    _create_finalized_instructional_flight(
+        instructor=instructor_two,
+        student=student_two,
+        flight_date=second_date,
+        suffix="105",
+    )
+
+    reminder_one = Notification.objects.create(
+        user=instructor_one,
+        message="📝 You have 1 overdue Student Progress Report(s)",
+    )
+    reminder_two = Notification.objects.create(
+        user=instructor_two,
+        message="📝 You have 1 overdue Student Progress Report(s)",
+    )
+
+    InstructionReport.objects.create(
+        student=student_one,
+        instructor=instructor_one,
+        report_date=first_date,
+        report_text="completed",
+    )
+
+    reminder_one.refresh_from_db()
+    reminder_two.refresh_from_db()
+
+    assert reminder_one.dismissed is True
+    assert reminder_two.dismissed is False
+
+
+@pytest.mark.django_db
+def test_context_processor_hides_stale_overdue_notification(django_user_model):
+    instructor = django_user_model.objects.create_user(
+        username="inst_cleanup4", password="pw"
+    )
+
+    stale = Notification.objects.create(
+        user=instructor,
+        message=f"📌 You have 1 {OVERDUE_SPR_NOTIFICATION_FRAGMENT}(s)",
+        dismissed=False,
+    )
+    keep = Notification.objects.create(
+        user=instructor,
+        message="General notification",
+        dismissed=False,
+    )
+
+    request = RequestFactory().get("/")
+    request.user = instructor
+
+    context = notifications_context(request)
+    rendered_notifications = context["notifications"]
+
+    assert stale not in rendered_notifications
+    assert keep in rendered_notifications

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -49,7 +49,7 @@ def get_overdue_sprs(max_days=30, as_of_date=None, instructor=None):
     A flight is considered overdue when it is at least 7 days old and no
     InstructionReport exists for the same instructor, student and flight date.
     """
-    as_of = as_of_date or timezone.now().date()
+    as_of = as_of_date or timezone.localdate()
     cutoff_date = as_of - timedelta(days=max_days)
 
     flights_qs = Flight.objects.filter(
@@ -132,7 +132,7 @@ def get_instructor_has_overdue_sprs(instructor, max_days=30, as_of_date=None):
     if not instructor:
         return False
 
-    as_of = as_of_date or timezone.now().date()
+    as_of = as_of_date or timezone.localdate()
     cutoff_date = as_of - timedelta(days=max_days)
     overdue_cutoff = as_of - timedelta(days=7)
 

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -51,13 +51,17 @@ def get_overdue_sprs(max_days=30, as_of_date=None, instructor=None):
     """
     as_of = as_of_date or timezone.localdate()
     cutoff_date = as_of - timedelta(days=max_days)
+    overdue_cutoff = as_of - timedelta(days=7)
+
+    if overdue_cutoff < cutoff_date:
+        return {}
 
     flights_qs = Flight.objects.filter(
         instructor__isnull=False,
         pilot__isnull=False,
         logsheet__finalized=True,
         logsheet__log_date__gte=cutoff_date,
-        logsheet__log_date__lt=as_of,
+        logsheet__log_date__lte=overdue_cutoff,
     )
 
     if instructor is not None:
@@ -92,9 +96,6 @@ def get_overdue_sprs(max_days=30, as_of_date=None, instructor=None):
     for flight in flights:
         flight_date = flight.logsheet.log_date
         days_since_flight = (as_of - flight_date).days
-
-        if days_since_flight < 7:
-            continue
 
         report_key = (flight.instructor_id, flight.pilot_id, flight_date)
         if report_key in existing_reports:

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -120,9 +120,7 @@ def get_instructor_overdue_spr_count(instructor, max_days=30, as_of_date=None):
         as_of_date=as_of_date,
         instructor=instructor,
     )
-    if not overdue:
-        return 0
-    return len(next(iter(overdue.values())))
+    return len(overdue.get(instructor, []))
 
 
 def is_overdue_spr_notification_message(message):

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -27,6 +27,108 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
+OVERDUE_SPR_NOTIFICATION_FRAGMENT = "overdue Student Progress Report"
+
+
+def get_spr_escalation_level(days_overdue):
+    """Determine escalation level for an overdue SPR based on age in days."""
+    if days_overdue >= 30:
+        return "FINAL"
+    if days_overdue >= 25:
+        return "URGENT"
+    if days_overdue >= 21:
+        return "WARNING"
+    if days_overdue >= 14:
+        return "REMINDER"
+    return "NOTICE"
+
+
+def get_overdue_sprs(max_days=30, as_of_date=None, instructor=None):
+    """Return overdue SPR data grouped by instructor.
+
+    A flight is considered overdue when it is at least 7 days old and no
+    InstructionReport exists for the same instructor, student and flight date.
+    """
+    as_of = as_of_date or timezone.now().date()
+    cutoff_date = as_of - timedelta(days=max_days)
+
+    flights_qs = Flight.objects.filter(
+        instructor__isnull=False,
+        pilot__isnull=False,
+        logsheet__finalized=True,
+        logsheet__log_date__gte=cutoff_date,
+        logsheet__log_date__lt=as_of,
+    )
+
+    if instructor is not None:
+        flights_qs = flights_qs.filter(instructor=instructor)
+
+    flights = list(
+        flights_qs.select_related("instructor", "pilot", "logsheet").order_by(
+            "logsheet__log_date", "instructor", "pilot"
+        )
+    )
+
+    if not flights:
+        return {}
+
+    report_qs = InstructionReport.objects.filter(
+        report_date__gte=cutoff_date,
+        report_date__lt=as_of,
+    )
+
+    if instructor is not None:
+        report_qs = report_qs.filter(instructor=instructor)
+    else:
+        report_qs = report_qs.filter(
+            instructor_id__in={flight.instructor_id for flight in flights}
+        )
+
+    existing_reports = set(
+        report_qs.values_list("instructor_id", "student_id", "report_date")
+    )
+
+    overdue_by_instructor = {}
+    for flight in flights:
+        flight_date = flight.logsheet.log_date
+        days_since_flight = (as_of - flight_date).days
+
+        if days_since_flight < 7:
+            continue
+
+        report_key = (flight.instructor_id, flight.pilot_id, flight_date)
+        if report_key in existing_reports:
+            continue
+
+        overdue_by_instructor.setdefault(flight.instructor, []).append(
+            {
+                "flight": flight,
+                "student": flight.pilot,
+                "days_overdue": days_since_flight,
+                "escalation_level": get_spr_escalation_level(days_since_flight),
+                "flight_date": flight_date,
+            }
+        )
+
+    return overdue_by_instructor
+
+
+def get_instructor_overdue_spr_count(instructor, max_days=30, as_of_date=None):
+    """Return overdue SPR count for a single instructor."""
+    overdue = get_overdue_sprs(
+        max_days=max_days,
+        as_of_date=as_of_date,
+        instructor=instructor,
+    )
+    if not overdue:
+        return 0
+    return len(next(iter(overdue.values())))
+
+
+def is_overdue_spr_notification_message(message):
+    """Return True when a notification message is an overdue SPR reminder."""
+    return OVERDUE_SPR_NOTIFICATION_FRAGMENT in (message or "")
+
 
 ####################################################
 # get_flight_summary_for_member

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -4,7 +4,7 @@ import logging
 from datetime import timedelta
 
 from django.conf import settings
-from django.db.models import Count, F, Max, Q, Sum, Value
+from django.db.models import Count, Exists, F, Max, OuterRef, Q, Sum, Value
 from django.db.models.fields import DurationField
 from django.db.models.functions import Coalesce
 from django.template.loader import render_to_string
@@ -121,6 +121,42 @@ def get_instructor_overdue_spr_count(instructor, max_days=30, as_of_date=None):
         instructor=instructor,
     )
     return len(overdue.get(instructor, []))
+
+
+def get_instructor_has_overdue_sprs(instructor, max_days=30, as_of_date=None):
+    """Return True when instructor has at least one overdue SPR.
+
+    This uses a DB-side EXISTS check and avoids materializing full overdue
+    flight/report datasets in Python for request-time checks.
+    """
+    if not instructor:
+        return False
+
+    as_of = as_of_date or timezone.now().date()
+    cutoff_date = as_of - timedelta(days=max_days)
+    overdue_cutoff = as_of - timedelta(days=7)
+
+    if overdue_cutoff < cutoff_date:
+        return False
+
+    report_exists = InstructionReport.objects.filter(
+        instructor_id=OuterRef("instructor_id"),
+        student_id=OuterRef("pilot_id"),
+        report_date=OuterRef("logsheet__log_date"),
+    )
+
+    return (
+        Flight.objects.filter(
+            instructor=instructor,
+            pilot__isnull=False,
+            logsheet__finalized=True,
+            logsheet__log_date__gte=cutoff_date,
+            logsheet__log_date__lte=overdue_cutoff,
+        )
+        .annotate(has_report=Exists(report_exists))
+        .filter(has_report=False)
+        .exists()
+    )
 
 
 def is_overdue_spr_notification_message(message):

--- a/notifications/context_processors.py
+++ b/notifications/context_processors.py
@@ -14,7 +14,10 @@ def _is_stale_overdue_spr_notification(notification, overdue_spr_count):
 
 def notifications(request):
     if request.user.is_authenticated:
-        from instructors.utils import get_instructor_overdue_spr_count
+        from instructors.utils import (
+            get_instructor_overdue_spr_count,
+            is_overdue_spr_notification_message,
+        )
 
         notifications_qs = Notification.objects.filter(
             user=request.user, dismissed=False
@@ -23,7 +26,7 @@ def notifications(request):
         notifications = list(notifications_qs)
         if notifications:
             has_overdue_spr_notifications = any(
-                "overdue Student Progress Report" in (notification.message or "")
+                is_overdue_spr_notification_message(notification.message)
                 for notification in notifications
             )
             overdue_spr_count = (

--- a/notifications/context_processors.py
+++ b/notifications/context_processors.py
@@ -1,11 +1,31 @@
 from .models import Notification
 
 
+def _is_stale_overdue_spr_notification(user, notification):
+    from instructors.utils import (
+        get_instructor_overdue_spr_count,
+        is_overdue_spr_notification_message,
+    )
+
+    if not is_overdue_spr_notification_message(notification.message):
+        return False
+
+    return get_instructor_overdue_spr_count(user) == 0
+
+
 def notifications(request):
     if request.user.is_authenticated:
-        notifications = Notification.objects.filter(
+        notifications_qs = Notification.objects.filter(
             user=request.user, dismissed=False
         ).order_by("-created_at")
+
+        notifications = list(notifications_qs)
+        if notifications:
+            notifications = [
+                notification
+                for notification in notifications
+                if not _is_stale_overdue_spr_notification(request.user, notification)
+            ]
     else:
         notifications = []
     return {"notifications": notifications}

--- a/notifications/context_processors.py
+++ b/notifications/context_processors.py
@@ -1,30 +1,44 @@
 from .models import Notification
 
 
-def _is_stale_overdue_spr_notification(user, notification):
+def _is_stale_overdue_spr_notification(notification, overdue_spr_count):
     from instructors.utils import (
-        get_instructor_overdue_spr_count,
         is_overdue_spr_notification_message,
     )
 
     if not is_overdue_spr_notification_message(notification.message):
         return False
 
-    return get_instructor_overdue_spr_count(user) == 0
+    return overdue_spr_count == 0
 
 
 def notifications(request):
     if request.user.is_authenticated:
+        from instructors.utils import get_instructor_overdue_spr_count
+
         notifications_qs = Notification.objects.filter(
             user=request.user, dismissed=False
         ).order_by("-created_at")
 
         notifications = list(notifications_qs)
         if notifications:
+            has_overdue_spr_notifications = any(
+                "overdue Student Progress Report" in (notification.message or "")
+                for notification in notifications
+            )
+            overdue_spr_count = (
+                get_instructor_overdue_spr_count(request.user)
+                if has_overdue_spr_notifications
+                else None
+            )
+
             notifications = [
                 notification
                 for notification in notifications
-                if not _is_stale_overdue_spr_notification(request.user, notification)
+                if not _is_stale_overdue_spr_notification(
+                    notification,
+                    overdue_spr_count,
+                )
             ]
     else:
         notifications = []

--- a/notifications/context_processors.py
+++ b/notifications/context_processors.py
@@ -1,7 +1,7 @@
 from .models import Notification
 
 
-def _is_stale_overdue_spr_notification(notification, overdue_spr_count):
+def _is_stale_overdue_spr_notification(notification, has_overdue_sprs):
     from instructors.utils import (
         is_overdue_spr_notification_message,
     )
@@ -9,7 +9,7 @@ def _is_stale_overdue_spr_notification(notification, overdue_spr_count):
     if not is_overdue_spr_notification_message(notification.message):
         return False
 
-    return not overdue_spr_count
+    return not has_overdue_sprs
 
 
 def notifications(request):
@@ -29,7 +29,7 @@ def notifications(request):
                 is_overdue_spr_notification_message(notification.message)
                 for notification in notifications
             )
-            overdue_spr_exists = (
+            has_overdue_sprs = (
                 get_instructor_has_overdue_sprs(request.user)
                 if has_overdue_spr_notifications
                 else False
@@ -40,7 +40,7 @@ def notifications(request):
                 for notification in notifications
                 if not _is_stale_overdue_spr_notification(
                     notification,
-                    overdue_spr_exists,
+                    has_overdue_sprs,
                 )
             ]
     else:

--- a/notifications/context_processors.py
+++ b/notifications/context_processors.py
@@ -9,13 +9,13 @@ def _is_stale_overdue_spr_notification(notification, overdue_spr_count):
     if not is_overdue_spr_notification_message(notification.message):
         return False
 
-    return overdue_spr_count == 0
+    return not overdue_spr_count
 
 
 def notifications(request):
     if request.user.is_authenticated:
         from instructors.utils import (
-            get_instructor_overdue_spr_count,
+            get_instructor_has_overdue_sprs,
             is_overdue_spr_notification_message,
         )
 
@@ -29,10 +29,10 @@ def notifications(request):
                 is_overdue_spr_notification_message(notification.message)
                 for notification in notifications
             )
-            overdue_spr_count = (
-                get_instructor_overdue_spr_count(request.user)
+            overdue_spr_exists = (
+                get_instructor_has_overdue_sprs(request.user)
                 if has_overdue_spr_notifications
-                else None
+                else False
             )
 
             notifications = [
@@ -40,7 +40,7 @@ def notifications(request):
                 for notification in notifications
                 if not _is_stale_overdue_spr_notification(
                     notification,
-                    overdue_spr_count,
+                    overdue_spr_exists,
                 )
             ]
     else:


### PR DESCRIPTION
## Summary
This PR implements Issue #875 by cleaning up stale overdue SPR reminder notifications when no overdue SPRs remain.

### What changed
- Added shared overdue-SPR detection utilities in `instructors/utils.py`.
- Refactored the overdue SPR reminder command to reuse shared logic and shared escalation mapping.
- Added a post-save `InstructionReport` signal to auto-dismiss overdue SPR reminders for an instructor when their overdue count reaches zero.
- Added a notifications context-processor safety guard so stale overdue reminders are not rendered even if old rows still exist.
- Added targeted tests for:
  - dismissing final overdue reminder on completion,
  - not dismissing when overdue items still remain,
  - instructor-scoped dismissal isolation,
  - stale reminder suppression in rendered notifications context.

## Validation
- `pytest instructors/tests/test_instructor_notifications.py -q`
- `pytest notifications/tests/test_notification_models.py -q`
- `pytest instructors/tests notifications/tests -q`

All tests passed in local validation.

Fixes #875