### PR TITLE
Harden hh tenant IaC onboarding and safe SSL certificate rotation

### DIFF
--- a/infrastructure/ansible/playbooks/gcp-database.yml
+++ b/infrastructure/ansible/playbooks/gcp-database.yml
@@ -49,6 +49,7 @@
   become: false
   tags: [gcp-provision]
   vars_files:
+    - ../group_vars/all.yml
     - ../group_vars/gcp_provisioner/vars.yml
     - ../group_vars/gcp_provisioner/vault.yml
 
@@ -180,6 +181,7 @@
   gather_facts: true
   tags: [configure]
   vars_files:
+    - ../group_vars/all.yml
     - ../group_vars/gcp_provisioner/vars.yml
     - ../group_vars/gcp_provisioner/vault.yml
 

--- a/infrastructure/ansible/playbooks/gcp-database.yml
+++ b/infrastructure/ansible/playbooks/gcp-database.yml
@@ -12,8 +12,10 @@
 #      - Service account JSON key file
 #
 #   3. Copy and configure inventory/gcp_database.yml from .example
-#   4. Copy and configure group_vars/gcp_database/ with vars.yml and vault.yml
-#   5. Set up vault password file: ~/.ansible_vault_pass
+#   4. Create shared vars file group_vars/all.yml from group_vars/all.yml.example
+#      (required for centralized admin_ssh_ips and related shared settings)
+#   5. Copy and configure group_vars/gcp_database/ with vars.yml and vault.yml
+#   6. Set up vault password file: ~/.ansible_vault_pass
 #
 # Usage:
 #   # Create VM and configure database

--- a/infrastructure/ansible/playbooks/update-ssl-cert.yml
+++ b/infrastructure/ansible/playbooks/update-ssl-cert.yml
@@ -89,7 +89,7 @@
       run_once: true
       changed_when: false
       when: not ansible_check_mode
-      tags: [gke-auth]
+      tags: [always, gke-auth]
 
     - name: Read currently attached Gateway certificate annotation
       ansible.builtin.command:

--- a/infrastructure/ansible/playbooks/update-ssl-cert.yml
+++ b/infrastructure/ansible/playbooks/update-ssl-cert.yml
@@ -2,12 +2,23 @@
 # Update SSL Certificate with New Domains
 #
 # This playbook updates the Google-managed SSL certificate to include
-# all domains defined in the inventory configuration (gke_tenants.domains).
-# It deletes the existing certificate and creates a new one with all domains.
+# all domains defined in the inventory configuration (gke_tenants/domains).
+#
+# SAFE ROTATION (no delete-first):
+# 1) Create/use a NEW certificate name
+# 2) Attach old+new certs on Gateway during provisioning
+# 3) After new cert is ACTIVE, trim Gateway to new cert only
+# 4) Optionally delete old cert later
 #
 # Usage:
 #   ansible-playbook -i inventory/gcp_app.yml \
 #     --vault-password-file ~/.ansible_vault_pass \
+#     playbooks/update-ssl-cert.yml
+#
+#   # Recommended: provide a NEW cert name for rotation
+#   ansible-playbook -i inventory/gcp_app.yml \
+#     --vault-password-file ~/.ansible_vault_pass \
+#     -e "ssl_target_cert_name=manage2soar-ssl-cert-v5" \
 #     playbooks/update-ssl-cert.yml
 
 - name: Update SSL Certificate for GKE Cluster
@@ -43,6 +54,25 @@
       delegate_to: localhost
       tags: [confirm]
 
+    - name: Determine target SSL certificate name
+      ansible.builtin.set_fact:
+        target_ssl_cert_name: "{{ ssl_target_cert_name | default(gke_ssl_cert_name) }}"
+      run_once: true
+      delegate_to: localhost
+      tags: [always]
+
+    - name: Read currently attached Gateway certificate annotation
+      ansible.builtin.command:
+        cmd: >
+          kubectl get gateway {{ gke_app_name }}-gateway -n default
+          --output "jsonpath={.spec.listeners[?(@.name=='https')].tls.options['networking.gke.io/pre-shared-certs']}"
+      register: current_gateway_certs
+      changed_when: false
+      failed_when: false
+      delegate_to: localhost
+      run_once: true
+      tags: [confirm]
+
     - name: Confirm SSL certificate update
       ansible.builtin.pause:
         prompt: |
@@ -50,7 +80,8 @@
           ========================================
           SSL Certificate Update Plan
           ========================================
-          Current certificate: {{ gke_ssl_cert_name }}
+          Current certificate annotation: {{ (current_gateway_certs.stdout | default('') | trim) | default('none') }}
+          Target certificate: {{ target_ssl_cert_name }}
 
           Domains to include in new certificate:
           {% for domain in all_tenant_domains %}
@@ -58,13 +89,14 @@
           {% endfor %}
 
           This will:
-          1. Delete existing certificate ({{ gke_ssl_cert_name }})
-          2. Create new certificate with {{ all_tenant_domains | length }} domain(s)
+          1. Create/update target certificate ({{ target_ssl_cert_name }})
+          2. Update Gateway to reference BOTH old and new certs during provisioning
           3. Trigger Google Certificate Manager provisioning (5-10 minutes)
-          4. Update Gateway to reference new certificate
+          4. Keep existing tenants on valid TLS while the new cert provisions
+          5. Leave cleanup as a separate explicit step (cert-cleanup)
 
-          IMPORTANT: Existing sites will continue to work during provisioning.
-          The Gateway will use the old certificate until the new one is ACTIVE.
+          IMPORTANT: This is the safer, non-disruptive path.
+          No delete-first operation is performed.
 
           Press ENTER to continue or Ctrl+C to abort...
 
@@ -83,33 +115,14 @@
       changed_when: false
       tags: [gke-auth]
 
-    - name: Delete old SSL certificate
-      ansible.builtin.command:
-        cmd: >
-          gcloud compute ssl-certificates delete {{ gke_ssl_cert_name }}
-          --global
-          --project={{ gcp_project }}
-          --quiet
-      register: ssl_cert_delete
-      changed_when: ssl_cert_delete.rc == 0
-      failed_when: false  # Don't fail if certificate doesn't exist
-      delegate_to: localhost
-      run_once: true
-      tags: [ssl-cert]
-
-    - name: Display deletion result
-      ansible.builtin.debug:
-        msg: |
-          {{ 'Certificate deleted successfully' if ssl_cert_delete.rc == 0 else 'Certificate did not exist or was already deleted' }}
-      run_once: true
-      tags: [ssl-cert]
-
     # Import SSL certificate and Gateway tasks from gke-deploy role
     - name: Import ingress tasks to recreate SSL certificate and update Gateway
       ansible.builtin.import_role:
         name: gke-deploy
         tasks_from: ingress
       vars:
+        # Rotate to target cert name while preserving existing cert references.
+        gke_ssl_cert_name: "{{ target_ssl_cert_name }}"
         # Skip unnecessary tasks - only run TLS and Gateway
         gke_build_image: false
         gke_push_image: false
@@ -120,7 +133,7 @@
     - name: Wait for certificate provisioning to start
       ansible.builtin.command:
         cmd: >
-          gcloud compute ssl-certificates describe {{ gke_ssl_cert_name }}
+          gcloud compute ssl-certificates describe {{ target_ssl_cert_name }}
           --global
           --project={{ gcp_project }}
           --format="value(managed.status)"
@@ -138,11 +151,11 @@
           ========================================
           SSL Certificate Provisioning Started
           ========================================
-          Certificate: {{ gke_ssl_cert_name }}
+          Target certificate: {{ target_ssl_cert_name }}
           Status: {{ ssl_cert_status.stdout | trim }}
 
           Monitor provisioning with:
-            gcloud compute ssl-certificates describe {{ gke_ssl_cert_name }} \
+            gcloud compute ssl-certificates describe {{ target_ssl_cert_name }} \
               --global --project={{ gcp_project }} \
               --format="yaml(managed.domainStatus)"
 
@@ -156,13 +169,16 @@
           1. Verify DNS records point to Gateway IP: {{ gke_gateway_ip | default('34.13.120.184') }}
           2. Wait for all domains to show ACTIVE status
           3. Test each domain with: curl -I https://<your-domain>
-          4. Update HTTPRoutes to include new domains (see below)
+          4. Trim Gateway cert annotation to target cert only:
+             ansible-playbook -i inventory/gcp_app.yml \
+               --vault-password-file ~/.ansible_vault_pass \
+               -e "gke_ssl_cert_name={{ target_ssl_cert_name }}" \
+               playbooks/gcp-app-deploy.yml --tags cert-cleanup
+          5. After cleanup, optionally delete old cert(s) not in use.
 
-          HTTPRoute Update:
-          Run the full deployment to update HTTPRoutes with new domains:
-            ansible-playbook -i inventory/gcp_app.yml \
-              --vault-password-file ~/.ansible_vault_pass \
-              playbooks/gcp-app-deploy.yml
+          IMPORTANT:
+          Persist the target cert name in your IaC vars for future deploys:
+            group_vars/gcp_app/vars.yml -> gke_ssl_cert_name: "{{ target_ssl_cert_name }}"
           ========================================
       run_once: true
       tags: [verify]

--- a/infrastructure/ansible/playbooks/update-ssl-cert.yml
+++ b/infrastructure/ansible/playbooks/update-ssl-cert.yml
@@ -88,6 +88,7 @@
       delegate_to: localhost
       run_once: true
       changed_when: false
+      when: not ansible_check_mode
       tags: [gke-auth]
 
     - name: Read currently attached Gateway certificate annotation

--- a/infrastructure/ansible/playbooks/update-ssl-cert.yml
+++ b/infrastructure/ansible/playbooks/update-ssl-cert.yml
@@ -33,7 +33,7 @@
         all_tenant_domains: >-
           {%- set domains = [] -%}
           {%- if gke_multi_tenant | default(false) | bool -%}
-            {%- for tenant in gke_tenants -%}
+            {%- for tenant in (gke_tenants | default([])) -%}
               {%- if tenant.domains is defined -%}
                 {%- for domain in tenant.domains -%}
                   {%- set _ = domains.append(domain) -%}
@@ -44,12 +44,30 @@
             {%- endfor -%}
           {%- else -%}
             {%- if gke_domains is defined -%}
-              {%- set domains = gke_domains -%}
+              {%- if gke_domains is string -%}
+                {%- set _ = domains.append(gke_domains) -%}
+              {%- else -%}
+                {%- for domain in gke_domains -%}
+                  {%- set _ = domains.append(domain) -%}
+                {%- endfor -%}
+              {%- endif -%}
             {%- elif gke_domain is defined -%}
               {%- set _ = domains.append(gke_domain) -%}
             {%- endif -%}
           {%- endif -%}
           {{ domains | unique | list }}
+      run_once: true
+      delegate_to: localhost
+      tags: [always]
+
+    - name: Validate multi-tenant domain source configuration
+      ansible.builtin.assert:
+        that:
+          - (gke_tenants | default([]) | length) > 0
+        fail_msg: |
+          gke_multi_tenant is enabled but gke_tenants is not configured.
+          Define gke_tenants in inventory/group_vars so certificate domains can be collected.
+      when: gke_multi_tenant | default(false) | bool
       run_once: true
       delegate_to: localhost
       tags: [always]

--- a/infrastructure/ansible/playbooks/update-ssl-cert.yml
+++ b/infrastructure/ansible/playbooks/update-ssl-cert.yml
@@ -56,7 +56,7 @@
 
     - name: Determine target SSL certificate name
       ansible.builtin.set_fact:
-        target_ssl_cert_name: "{{ ssl_target_cert_name | default(gke_ssl_cert_name) }}"
+        target_ssl_cert_name: "{{ ssl_target_cert_name | default(gke_ssl_cert_name | default(gke_app_name ~ '-ssl-cert')) }}"
       run_once: true
       delegate_to: localhost
       tags: [always]
@@ -80,7 +80,7 @@
           ========================================
           SSL Certificate Update Plan
           ========================================
-          Current certificate annotation: {{ (current_gateway_certs.stdout | default('') | trim) | default('none') }}
+          Current certificate annotation: {{ (current_gateway_certs.stdout | default('', true) | trim) | default('none', true) }}
           Target certificate: {{ target_ssl_cert_name }}
 
           Domains to include in new certificate:

--- a/infrastructure/ansible/playbooks/update-ssl-cert.yml
+++ b/infrastructure/ansible/playbooks/update-ssl-cert.yml
@@ -61,6 +61,17 @@
       delegate_to: localhost
       tags: [always]
 
+    - name: Get GKE cluster credentials
+      ansible.builtin.command:
+        cmd: >
+          gcloud container clusters get-credentials {{ gke_cluster_name }}
+          --zone {{ gke_cluster_zone }}
+          --project {{ gcp_project }}
+      delegate_to: localhost
+      run_once: true
+      changed_when: false
+      tags: [gke-auth]
+
     - name: Read currently attached Gateway certificate annotation
       ansible.builtin.command:
         cmd: >
@@ -79,7 +90,7 @@
           gcloud compute ssl-certificates describe {{ target_ssl_cert_name }}
           --global
           --project={{ gcp_project }}
-          --format="json(managed.domains)"
+          --format="json"
       register: target_cert_domains_json
       changed_when: false
       failed_when: false
@@ -153,17 +164,6 @@
       delegate_to: localhost
       run_once: true
       tags: [confirm]
-
-    - name: Get GKE cluster credentials
-      ansible.builtin.command:
-        cmd: >
-          gcloud container clusters get-credentials {{ gke_cluster_name }}
-          --zone {{ gke_cluster_zone }}
-          --project {{ gcp_project }}
-      delegate_to: localhost
-      run_once: true
-      changed_when: false
-      tags: [gke-auth]
 
     # Import SSL certificate and Gateway tasks from gke-deploy role
     - name: Import ingress tasks to recreate SSL certificate and update Gateway

--- a/infrastructure/ansible/playbooks/update-ssl-cert.yml
+++ b/infrastructure/ansible/playbooks/update-ssl-cert.yml
@@ -216,7 +216,7 @@
             PROVISIONING → FAILED_NOT_VISIBLE (DNS issue)
 
           Next steps:
-          1. Verify DNS records point to Gateway IP: {{ gke_gateway_ip | default('34.13.120.184') }}
+          1. Verify DNS records point to Gateway IP: {{ gke_gateway_ip | default('unknown') }}
           2. Wait for all domains to show ACTIVE status
           3. Test each domain with: curl -I https://<your-domain>
           4. Trim Gateway cert annotation to target cert only:

--- a/infrastructure/ansible/playbooks/update-ssl-cert.yml
+++ b/infrastructure/ansible/playbooks/update-ssl-cert.yml
@@ -52,7 +52,7 @@
           {{ domains | unique | list }}
       run_once: true
       delegate_to: localhost
-      tags: [confirm]
+      tags: [always]
 
     - name: Determine target SSL certificate name
       ansible.builtin.set_fact:
@@ -73,6 +73,54 @@
       run_once: true
       tags: [confirm]
 
+    - name: Read existing target cert domains (if cert exists)
+      ansible.builtin.command:
+        cmd: >
+          gcloud compute ssl-certificates describe {{ target_ssl_cert_name }}
+          --global
+          --project={{ gcp_project }}
+          --format="json(managed.domains)"
+      register: target_cert_domains_json
+      changed_when: false
+      failed_when: false
+      delegate_to: localhost
+      run_once: true
+      tags: [always]
+
+    - name: Parse existing target cert domains
+      ansible.builtin.set_fact:
+        target_cert_domains: "{{ ((target_cert_domains_json.stdout | default('{}')) | from_json).managed.domains | default([]) | sort }}"
+      when: target_cert_domains_json.rc == 0
+      run_once: true
+      delegate_to: localhost
+      tags: [always]
+
+    - name: Fail when target cert exists with a different domain set
+      ansible.builtin.fail:
+        msg: |
+          Target certificate {{ target_ssl_cert_name }} already exists, but its managed domains do not match
+          the desired domain set for this rotation.
+
+          Existing domains:
+          {% for d in (target_cert_domains | default([])) %}
+            - {{ d }}
+          {% endfor %}
+
+          Desired domains:
+          {% for d in (all_tenant_domains | default([]) | sort) %}
+            - {{ d }}
+          {% endfor %}
+
+          Compute Engine managed SSL cert domains are immutable.
+          Choose a new cert name via:
+            -e "ssl_target_cert_name={{ target_ssl_cert_name }}-vNEXT"
+      when:
+        - target_cert_domains_json.rc == 0
+        - (target_cert_domains | default([]) | sort) != (all_tenant_domains | default([]) | sort)
+      run_once: true
+      delegate_to: localhost
+      tags: [always]
+
     - name: Confirm SSL certificate update
       ansible.builtin.pause:
         prompt: |
@@ -89,11 +137,13 @@
           {% endfor %}
 
           This will:
-          1. Create/update target certificate ({{ target_ssl_cert_name }})
+          1. Create a new Compute Engine managed SSL cert (or reuse one with identical domains): {{ target_ssl_cert_name }}
           2. Update Gateway to reference BOTH old and new certs during provisioning
-          3. Trigger Google Certificate Manager provisioning (5-10 minutes)
+          3. Trigger Google-managed certificate provisioning (5-10 minutes)
           4. Keep existing tenants on valid TLS while the new cert provisions
           5. Leave cleanup as a separate explicit step (cert-cleanup)
+
+          Note: Managed cert domains are immutable. If domain set changed, use a NEW cert name.
 
           IMPORTANT: This is the safer, non-disruptive path.
           No delete-first operation is performed.

--- a/infrastructure/ansible/roles/postfix/templates/virtual_domains.j2
+++ b/infrastructure/ansible/roles/postfix/templates/virtual_domains.j2
@@ -5,12 +5,9 @@
 # DO NOT EDIT MANUALLY - changes will be overwritten
 
 {% for club in club_domains %}
-{# Legacy format: club.prefix.mail_domain #}
-{{ club.prefix }}.{{ mail_domain }}    OK
-{# Additional domains (if configured) #}
-{% if club.domains is defined %}
-{% for domain in club.domains %}
+{# Merge legacy and explicit domains, then deduplicate #}
+{% set tenant_domains = ([club.prefix ~ '.' ~ mail_domain] + (club.domains | default([]))) | unique %}
+{% for domain in tenant_domains %}
 {{ domain }}    OK
 {% endfor %}
-{% endif %}
 {% endfor %}

--- a/infrastructure/ansible/roles/postfix/templates/virtual_domains.j2
+++ b/infrastructure/ansible/roles/postfix/templates/virtual_domains.j2
@@ -6,7 +6,11 @@
 
 {% for club in club_domains %}
 {# Merge legacy and explicit domains, then deduplicate #}
-{% set tenant_domains = ([club.prefix ~ '.' ~ mail_domain] + (club.domains | default([]))) | unique %}
+{% set explicit_domains = club.domains | default([]) %}
+{% if explicit_domains is string %}
+{% set explicit_domains = [explicit_domains] %}
+{% endif %}
+{% set tenant_domains = ([club.prefix ~ '.' ~ mail_domain] + explicit_domains) | unique %}
 {% for domain in tenant_domains %}
 {{ domain }}    OK
 {% endfor %}


### PR DESCRIPTION
## Summary
This PR captures the IaC hardening done while onboarding the new `hh` tenant (Harris Hill Soaring), with a focus on avoiding cross-tenant disruption during TLS updates.

## What changed (3 files)

### 1) `infrastructure/ansible/playbooks/gcp-database.yml`
- Added shared vars import from `group_vars/all.yml` in both database play phases.
- Why: `admin_ssh_ips` is defined centrally in `all.yml`; without importing it, database playbook evaluation could fail with undefined variable errors during firewall source resolution.

### 2) `infrastructure/ansible/roles/postfix/templates/virtual_domains.j2`
- Fixed duplicate domain rendering by merging legacy `prefix.mail_domain` with explicit `club.domains`, then applying `unique` before writing entries.
- Why: tenants that explicitly included `prefix.mail_domain` were generating duplicate rows in `/etc/postfix/virtual_domains`.

### 3) `infrastructure/ansible/playbooks/update-ssl-cert.yml`
- Reworked cert update flow to safe rotation (no delete-first).
- Added target cert support via `ssl_target_cert_name` and wired rotation through ingress/gateway tasks that can preserve existing cert references during provisioning.
- Updated runbook-style messaging to guide post-rotation cleanup (`--tags cert-cleanup`) and persistence of the new cert name in vars.
- Made target cert derivation tagged `always` so `--skip-tags confirm` dry-runs do not fail due to missing variable initialization.

## Operational context
- New tenant `hh` was onboarded and validated end-to-end.
- SSL for `hh.manage2soar.com` was provisioned successfully using the safe rotation approach.

## Validation performed
- Ansible syntax checks on updated playbooks.
- Dry-run checks (`--check --diff`) during iteration.
- Full playbook runs completed without errors for database/app/mail and cert rotation path.
