### PR TITLE
Fix dynamic role labels and styling in calendar agenda/table

### DIFF
--- a/duty_roster/templates/duty_roster/_calendar_agenda.html
+++ b/duty_roster/templates/duty_roster/_calendar_agenda.html
@@ -184,37 +184,11 @@
                 {% with dynamic_roles=dynamic_role_assignments_by_date|dict_get:day %}
                   {% for dynamic_role in dynamic_roles %}
                     <div class="col-md-6 mb-3">
-                      {% if dynamic_role.legacy_role_key == "towpilot" %}
-                        <div class="duty-role-card bg-danger bg-opacity-10 border border-danger rounded p-3">
-                          <h6 class="text-danger mb-2">
-                            <i class="bi bi-airplane me-2" aria-hidden="true"></i>
-                            {{ dynamic_role.label }}
-                          </h6>
-                      {% elif dynamic_role.legacy_role_key == "instructor" %}
-                        <div class="duty-role-card bg-success bg-opacity-10 border border-success rounded p-3">
-                          <h6 class="text-success mb-2">
-                            <i class="bi bi-mortarboard me-2" aria-hidden="true"></i>
-                            {{ dynamic_role.label }}
-                          </h6>
-                      {% elif dynamic_role.legacy_role_key == "duty_officer" %}
-                        <div class="duty-role-card duty-role-card-do rounded p-3">
-                          <h6 class="mb-2">
-                            <i class="bi bi-clipboard-check me-2" aria-hidden="true"></i>
-                            {{ dynamic_role.label }}
-                          </h6>
-                      {% elif dynamic_role.legacy_role_key == "assistant_duty_officer" %}
-                        <div class="duty-role-card bg-secondary bg-opacity-10 border border-secondary rounded p-3">
-                          <h6 class="text-secondary mb-2">
-                            <i class="bi bi-person-badge me-2" aria-hidden="true"></i>
-                            {{ dynamic_role.label }}
-                          </h6>
-                      {% else %}
-                        <div class="duty-role-card bg-info bg-opacity-10 border border-info rounded p-3">
-                          <h6 class="text-info-emphasis mb-2">
-                            <i class="bi bi-diagram-3 me-2" aria-hidden="true"></i>
-                            {{ dynamic_role.label }}
-                          </h6>
-                      {% endif %}
+                      <div class="duty-role-card {{ dynamic_role.card_class }} rounded p-3">
+                        <h6 class="{% if dynamic_role.heading_class %}{{ dynamic_role.heading_class }} {% endif %}mb-2">
+                          <i class="{{ dynamic_role.icon_class }} me-2" aria-hidden="true"></i>
+                          {{ dynamic_role.label }}
+                        </h6>
                         <p class="mb-0 fw-bold">{{ dynamic_role.member.full_display_name }}</p>
                         {% if dynamic_role.member.phone and user.is_authenticated and user.is_active_member and not dynamic_role.member.redact_contact %}
                           <small class="text-muted">{{ dynamic_role.member.phone }}</small>

--- a/duty_roster/templates/duty_roster/_calendar_agenda.html
+++ b/duty_roster/templates/duty_roster/_calendar_agenda.html
@@ -68,7 +68,7 @@
                   <div class="col-md-6 mb-3">
                     <div class="duty-role-card bg-success bg-opacity-10 border border-success rounded p-3">
                       <h6 class="text-success mb-2">
-                        <i class="fas fa-graduation-cap me-2"></i>
+                        <i class="bi bi-mortarboard me-2" aria-hidden="true"></i>
                         {{ config.instructor_title|default:'Instructor' }}
                       </h6>
                       <p class="mb-0 fw-bold">{{ assignment.instructor.full_display_name }}</p>
@@ -155,7 +155,7 @@
                   <div class="col-md-6 mb-3">
                     <div class="duty-role-card bg-success bg-opacity-10 border border-success rounded p-3">
                       <h6 class="text-success mb-2">
-                        <i class="fas fa-graduation-cap me-2"></i>
+                        <i class="bi bi-mortarboard me-2" aria-hidden="true"></i>
                         {{ config.surge_instructor_title|default:'Surge Instructor' }}
                       </h6>
                       <p class="mb-0 fw-bold">{{ assignment.surge_instructor.full_display_name }}</p>

--- a/duty_roster/templates/duty_roster/_calendar_agenda.html
+++ b/duty_roster/templates/duty_roster/_calendar_agenda.html
@@ -184,11 +184,37 @@
                 {% with dynamic_roles=dynamic_role_assignments_by_date|dict_get:day %}
                   {% for dynamic_role in dynamic_roles %}
                     <div class="col-md-6 mb-3">
-                      <div class="duty-role-card bg-info bg-opacity-10 border border-info rounded p-3">
-                        <h6 class="text-info-emphasis mb-2">
-                          <i class="bi bi-diagram-3 me-2" aria-hidden="true"></i>
-                          {{ dynamic_role.label }}
-                        </h6>
+                      {% if dynamic_role.legacy_role_key == "towpilot" %}
+                        <div class="duty-role-card bg-danger bg-opacity-10 border border-danger rounded p-3">
+                          <h6 class="text-danger mb-2">
+                            <i class="bi bi-airplane me-2" aria-hidden="true"></i>
+                            {{ dynamic_role.label }}
+                          </h6>
+                      {% elif dynamic_role.legacy_role_key == "instructor" %}
+                        <div class="duty-role-card bg-success bg-opacity-10 border border-success rounded p-3">
+                          <h6 class="text-success mb-2">
+                            <i class="bi bi-mortarboard me-2" aria-hidden="true"></i>
+                            {{ dynamic_role.label }}
+                          </h6>
+                      {% elif dynamic_role.legacy_role_key == "duty_officer" %}
+                        <div class="duty-role-card duty-role-card-do rounded p-3">
+                          <h6 class="mb-2">
+                            <i class="bi bi-clipboard-check me-2" aria-hidden="true"></i>
+                            {{ dynamic_role.label }}
+                          </h6>
+                      {% elif dynamic_role.legacy_role_key == "assistant_duty_officer" %}
+                        <div class="duty-role-card bg-secondary bg-opacity-10 border border-secondary rounded p-3">
+                          <h6 class="text-secondary mb-2">
+                            <i class="bi bi-person-badge me-2" aria-hidden="true"></i>
+                            {{ dynamic_role.label }}
+                          </h6>
+                      {% else %}
+                        <div class="duty-role-card bg-info bg-opacity-10 border border-info rounded p-3">
+                          <h6 class="text-info-emphasis mb-2">
+                            <i class="bi bi-diagram-3 me-2" aria-hidden="true"></i>
+                            {{ dynamic_role.label }}
+                          </h6>
+                      {% endif %}
                         <p class="mb-0 fw-bold">{{ dynamic_role.member.full_display_name }}</p>
                         {% if dynamic_role.member.phone and user.is_authenticated and user.is_active_member and not dynamic_role.member.redact_contact %}
                           <small class="text-muted">{{ dynamic_role.member.phone }}</small>

--- a/duty_roster/templates/duty_roster/_calendar_table.html
+++ b/duty_roster/templates/duty_roster/_calendar_table.html
@@ -130,17 +130,7 @@
                   {% endif %}
                   {% with dynamic_roles=dynamic_role_assignments_by_date|dict_get:day %}
                     {% for dynamic_role in dynamic_roles %}
-                      {% if dynamic_role.legacy_role_key == "towpilot" %}
-                        <span class="duty-badge badge-tow-pilot"><i class="bi bi-airplane" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
-                      {% elif dynamic_role.legacy_role_key == "instructor" %}
-                        <span class="duty-badge badge-instructor"><i class="bi bi-mortarboard" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
-                      {% elif dynamic_role.legacy_role_key == "duty_officer" %}
-                        <span class="duty-badge badge-duty-officer"><i class="bi bi-clipboard-check" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
-                      {% elif dynamic_role.legacy_role_key == "assistant_duty_officer" %}
-                        <span class="duty-badge badge-assistant-duty-officer"><i class="bi bi-person-badge" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
-                      {% else %}
-                        <span class="duty-badge badge-dynamic-role"><i class="bi bi-diagram-3" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
-                      {% endif %}
+                      <span class="duty-badge {{ dynamic_role.badge_class }}"><i class="{{ dynamic_role.icon_class }}" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
                     {% endfor %}
                   {% endwith %}
                 </div>

--- a/duty_roster/templates/duty_roster/_calendar_table.html
+++ b/duty_roster/templates/duty_roster/_calendar_table.html
@@ -130,7 +130,17 @@
                   {% endif %}
                   {% with dynamic_roles=dynamic_role_assignments_by_date|dict_get:day %}
                     {% for dynamic_role in dynamic_roles %}
-                      <span class="duty-badge badge-dynamic-role"><i class="bi bi-diagram-3" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
+                      {% if dynamic_role.legacy_role_key == "towpilot" %}
+                        <span class="duty-badge badge-tow-pilot"><i class="bi bi-airplane" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
+                      {% elif dynamic_role.legacy_role_key == "instructor" %}
+                        <span class="duty-badge badge-instructor"><i class="bi bi-mortarboard" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
+                      {% elif dynamic_role.legacy_role_key == "duty_officer" %}
+                        <span class="duty-badge badge-duty-officer"><i class="bi bi-clipboard-check" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
+                      {% elif dynamic_role.legacy_role_key == "assistant_duty_officer" %}
+                        <span class="duty-badge badge-assistant-duty-officer"><i class="bi bi-person-badge" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
+                      {% else %}
+                        <span class="duty-badge badge-dynamic-role"><i class="bi bi-diagram-3" aria-hidden="true"></i> {{ dynamic_role.label }}: {{ dynamic_role.member.last_name }}</span>
+                      {% endif %}
                     {% endfor %}
                   {% endwith %}
                 </div>

--- a/duty_roster/tests/test_calendar_dynamic_roles.py
+++ b/duty_roster/tests/test_calendar_dynamic_roles.py
@@ -309,6 +309,102 @@ def test_calendar_agenda_shows_dynamic_role_card(client):
 
 
 @pytest.mark.django_db
+def test_calendar_month_mapped_dynamic_tow_role_uses_display_name_and_tow_badge(client):
+    _ensure_full_member_status()
+
+    viewer = _make_member("dynamic_table_tow_styling_viewer")
+    dynamic_member = _make_member("dynamic_table_tow_styling_assigned")
+
+    site_config = SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="example.org",
+        club_abbreviation="TC",
+        enable_dynamic_duty_roles=True,
+        towpilot_title="Tow Captain",
+    )
+    role_definition = DutyRoleDefinition.objects.create(
+        site_configuration=site_config,
+        key="am_tow",
+        display_name="AM Tow",
+        legacy_role_key="towpilot",
+        is_active=True,
+        sort_order=10,
+    )
+
+    duty_date = date.today() + timedelta(days=16)
+    assignment = DutyAssignment.objects.create(date=duty_date)
+    DutyAssignmentRole.objects.create(
+        assignment=assignment,
+        role_key="am_tow",
+        member=dynamic_member,
+        role_definition=role_definition,
+        legacy_role_key="towpilot",
+    )
+
+    client.force_login(viewer)
+    response = client.get(
+        reverse(
+            "duty_roster:duty_calendar_month",
+            kwargs={"year": duty_date.year, "month": duty_date.month},
+        )
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "AM Tow:" in content
+    assert "badge-tow-pilot" in content
+    assert "bi bi-airplane" in content
+
+
+@pytest.mark.django_db
+def test_calendar_agenda_mapped_dynamic_tow_role_uses_display_name_and_tow_card(client):
+    _ensure_full_member_status()
+
+    viewer = _make_member("dynamic_agenda_tow_styling_viewer")
+    dynamic_member = _make_member("dynamic_agenda_tow_styling_assigned")
+
+    site_config = SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="example.org",
+        club_abbreviation="TC",
+        enable_dynamic_duty_roles=True,
+        towpilot_title="Tow Captain",
+    )
+    role_definition = DutyRoleDefinition.objects.create(
+        site_configuration=site_config,
+        key="am_tow",
+        display_name="AM Tow",
+        legacy_role_key="towpilot",
+        is_active=True,
+        sort_order=10,
+    )
+
+    duty_date = date.today() + timedelta(days=17)
+    assignment = DutyAssignment.objects.create(date=duty_date)
+    DutyAssignmentRole.objects.create(
+        assignment=assignment,
+        role_key="am_tow",
+        member=dynamic_member,
+        role_definition=role_definition,
+        legacy_role_key="towpilot",
+    )
+
+    client.force_login(viewer)
+    response = client.get(
+        reverse(
+            "duty_roster:duty_calendar_month",
+            kwargs={"year": duty_date.year, "month": duty_date.month},
+        )
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "AM Tow" in content
+    assert "bg-danger bg-opacity-10 border border-danger" in content
+    assert "bi bi-airplane me-2" in content
+
+
+@pytest.mark.django_db
 def test_calendar_day_modal_shows_dynamic_role_assignment_card_for_assigned_member(
     client,
 ):

--- a/duty_roster/tests/test_calendar_dynamic_roles.py
+++ b/duty_roster/tests/test_calendar_dynamic_roles.py
@@ -1,12 +1,21 @@
 from datetime import date, timedelta
 
 import pytest
+from django.core.cache import cache
 from django.urls import reverse
 
 from duty_roster.models import DutyAssignment, DutyAssignmentRole, DutyRoleDefinition
 from duty_roster.utils.role_resolution import RoleResolutionService
+from duty_roster.views import _get_dynamic_role_assignments
 from members.models import Member
 from siteconfig.models import MembershipStatus, SiteConfiguration
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
 
 
 def _ensure_full_member_status():
@@ -351,9 +360,11 @@ def test_calendar_month_mapped_dynamic_tow_role_uses_display_name_and_tow_badge(
 
     assert response.status_code == 200
     content = response.content.decode("utf-8")
-    assert "AM Tow:" in content
-    assert "badge-tow-pilot" in content
-    assert "bi bi-airplane" in content
+    expected_badge = (
+        f'<span class="duty-badge badge-tow-pilot"><i class="bi bi-airplane" '
+        f'aria-hidden="true"></i> AM Tow: {dynamic_member.last_name}</span>'
+    )
+    assert expected_badge in content
 
 
 @pytest.mark.django_db
@@ -402,6 +413,75 @@ def test_calendar_agenda_mapped_dynamic_tow_role_uses_display_name_and_tow_card(
     assert "AM Tow" in content
     assert "bg-danger bg-opacity-10 border border-danger" in content
     assert "bi bi-airplane me-2" in content
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    (
+        "legacy_role_key",
+        "expected_badge_class",
+        "expected_heading_class",
+        "expected_icon_class",
+    ),
+    [
+        ("instructor", "badge-instructor", "text-success", "bi bi-mortarboard"),
+        ("duty_officer", "badge-duty-officer", "", "bi bi-clipboard-check"),
+        (
+            "assistant_duty_officer",
+            "badge-assistant-duty-officer",
+            "text-secondary",
+            "bi bi-person-badge",
+        ),
+        ("surge_towpilot", "badge-tow-pilot", "text-danger", "bi bi-airplane"),
+        ("surge_instructor", "badge-instructor", "text-success", "bi bi-mortarboard"),
+        ("commercial_pilot", "badge-tow-pilot", "text-danger", "bi bi-airplane"),
+    ],
+)
+def test_dynamic_role_assignments_apply_presentation_for_mapped_legacy_roles(
+    legacy_role_key,
+    expected_badge_class,
+    expected_heading_class,
+    expected_icon_class,
+):
+    _ensure_full_member_status()
+
+    dynamic_member = _make_member(f"dynamic_role_presentation_{legacy_role_key}")
+    site_config = SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="example.org",
+        club_abbreviation="TC",
+        enable_dynamic_duty_roles=True,
+    )
+    role_definition = DutyRoleDefinition.objects.create(
+        site_configuration=site_config,
+        key=f"role_{legacy_role_key}",
+        display_name=f"Role {legacy_role_key}",
+        legacy_role_key=legacy_role_key,
+        is_active=True,
+        sort_order=10,
+    )
+
+    assignment = DutyAssignment.objects.create(date=date.today() + timedelta(days=18))
+    DutyAssignmentRole.objects.create(
+        assignment=assignment,
+        role_key=role_definition.key,
+        member=dynamic_member,
+        role_definition=role_definition,
+        legacy_role_key=legacy_role_key,
+    )
+
+    dynamic_roles = _get_dynamic_role_assignments(
+        assignment,
+        site_config,
+        enabled_roles=[role_definition.key],
+        role_labels_by_key={role_definition.key: role_definition.display_name},
+    )
+
+    assert len(dynamic_roles) == 1
+    dynamic_role = dynamic_roles[0]
+    assert dynamic_role["badge_class"] == expected_badge_class
+    assert dynamic_role["heading_class"] == expected_heading_class
+    assert dynamic_role["icon_class"] == expected_icon_class
 
 
 @pytest.mark.django_db

--- a/duty_roster/tests/test_calendar_dynamic_roles.py
+++ b/duty_roster/tests/test_calendar_dynamic_roles.py
@@ -424,7 +424,12 @@ def test_calendar_agenda_mapped_dynamic_tow_role_uses_display_name_and_tow_card(
         "expected_icon_class",
     ),
     [
-        ("instructor", "badge-instructor", "text-success", "bi bi-mortarboard"),
+        (
+            "instructor",
+            "badge-instructor",
+            "text-success",
+            "fas fa-graduation-cap",
+        ),
         ("duty_officer", "badge-duty-officer", "", "bi bi-clipboard-check"),
         (
             "assistant_duty_officer",
@@ -433,7 +438,12 @@ def test_calendar_agenda_mapped_dynamic_tow_role_uses_display_name_and_tow_card(
             "bi bi-person-badge",
         ),
         ("surge_towpilot", "badge-tow-pilot", "text-danger", "bi bi-airplane"),
-        ("surge_instructor", "badge-instructor", "text-success", "bi bi-mortarboard"),
+        (
+            "surge_instructor",
+            "badge-instructor",
+            "text-success",
+            "fas fa-graduation-cap",
+        ),
         ("commercial_pilot", "badge-tow-pilot", "text-danger", "bi bi-airplane"),
     ],
 )

--- a/duty_roster/tests/test_calendar_dynamic_roles.py
+++ b/duty_roster/tests/test_calendar_dynamic_roles.py
@@ -323,6 +323,8 @@ def test_calendar_month_mapped_dynamic_tow_role_uses_display_name_and_tow_badge(
 
     viewer = _make_member("dynamic_table_tow_styling_viewer")
     dynamic_member = _make_member("dynamic_table_tow_styling_assigned")
+    dynamic_member.last_name = "Towerson"
+    dynamic_member.save(update_fields=["last_name"])
 
     site_config = SiteConfiguration.objects.create(
         club_name="Test Club",

--- a/duty_roster/tests/test_calendar_dynamic_roles.py
+++ b/duty_roster/tests/test_calendar_dynamic_roles.py
@@ -428,7 +428,7 @@ def test_calendar_agenda_mapped_dynamic_tow_role_uses_display_name_and_tow_card(
             "instructor",
             "badge-instructor",
             "text-success",
-            "fas fa-graduation-cap",
+            "bi bi-mortarboard",
         ),
         ("duty_officer", "badge-duty-officer", "", "bi bi-clipboard-check"),
         (
@@ -442,7 +442,7 @@ def test_calendar_agenda_mapped_dynamic_tow_role_uses_display_name_and_tow_card(
             "surge_instructor",
             "badge-instructor",
             "text-success",
-            "fas fa-graduation-cap",
+            "bi bi-mortarboard",
         ),
         ("commercial_pilot", "badge-tow-pilot", "text-danger", "bi bi-airplane"),
     ],

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -100,6 +100,66 @@ def calendar_refresh_response(year, month):
     return HttpResponse(headers={"HX-Trigger": json.dumps(trigger_data)})
 
 
+_DEFAULT_DYNAMIC_ROLE_PRESENTATION = {
+    "badge_class": "badge-dynamic-role",
+    "card_class": "bg-info bg-opacity-10 border border-info",
+    "heading_class": "text-info-emphasis",
+    "icon_class": "bi bi-diagram-3",
+}
+
+_DYNAMIC_ROLE_PRESENTATION_BY_LEGACY_KEY = {
+    "towpilot": {
+        "badge_class": "badge-tow-pilot",
+        "card_class": "bg-danger bg-opacity-10 border border-danger",
+        "heading_class": "text-danger",
+        "icon_class": "bi bi-airplane",
+    },
+    "surge_towpilot": {
+        "badge_class": "badge-tow-pilot",
+        "card_class": "bg-danger bg-opacity-10 border border-danger",
+        "heading_class": "text-danger",
+        "icon_class": "bi bi-airplane",
+    },
+    "commercial_pilot": {
+        "badge_class": "badge-tow-pilot",
+        "card_class": "bg-danger bg-opacity-10 border border-danger",
+        "heading_class": "text-danger",
+        "icon_class": "bi bi-airplane",
+    },
+    "instructor": {
+        "badge_class": "badge-instructor",
+        "card_class": "bg-success bg-opacity-10 border border-success",
+        "heading_class": "text-success",
+        "icon_class": "bi bi-mortarboard",
+    },
+    "surge_instructor": {
+        "badge_class": "badge-instructor",
+        "card_class": "bg-success bg-opacity-10 border border-success",
+        "heading_class": "text-success",
+        "icon_class": "bi bi-mortarboard",
+    },
+    "duty_officer": {
+        "badge_class": "badge-duty-officer",
+        "card_class": "duty-role-card-do",
+        "heading_class": "",
+        "icon_class": "bi bi-clipboard-check",
+    },
+    "assistant_duty_officer": {
+        "badge_class": "badge-assistant-duty-officer",
+        "card_class": "bg-secondary bg-opacity-10 border border-secondary",
+        "heading_class": "text-secondary",
+        "icon_class": "bi bi-person-badge",
+    },
+}
+
+
+def _get_dynamic_role_presentation(legacy_role_key):
+    presentation = _DYNAMIC_ROLE_PRESENTATION_BY_LEGACY_KEY.get(legacy_role_key)
+    if presentation is None:
+        presentation = _DEFAULT_DYNAMIC_ROLE_PRESENTATION
+    return presentation.copy()
+
+
 def _get_dynamic_role_assignments(
     assignment,
     site_config,
@@ -157,6 +217,7 @@ def _get_dynamic_role_assignments(
             if assigned_legacy_member != member:
                 swap_role_code = None
 
+        presentation = _get_dynamic_role_presentation(legacy_role_key)
         dynamic_role_assignments.append(
             {
                 "key": role_key,
@@ -164,6 +225,7 @@ def _get_dynamic_role_assignments(
                 "member": member,
                 "legacy_role_key": legacy_role_key,
                 "swap_role_code": swap_role_code,
+                **presentation,
             }
         )
 

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -130,13 +130,13 @@ _DYNAMIC_ROLE_PRESENTATION_BY_LEGACY_KEY = {
         "badge_class": "badge-instructor",
         "card_class": "bg-success bg-opacity-10 border border-success",
         "heading_class": "text-success",
-        "icon_class": "bi bi-mortarboard",
+        "icon_class": "fas fa-graduation-cap",
     },
     "surge_instructor": {
         "badge_class": "badge-instructor",
         "card_class": "bg-success bg-opacity-10 border border-success",
         "heading_class": "text-success",
-        "icon_class": "bi bi-mortarboard",
+        "icon_class": "fas fa-graduation-cap",
     },
     "duty_officer": {
         "badge_class": "badge-duty-officer",

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -882,11 +882,10 @@ def duty_calendar_view(request, year=None, month=None):
         for role_key in enabled_role_keys:
             role_def = role_definitions_by_key.get(role_key)
             if role_def:
-                role_labels_by_key[role_key] = (
-                    get_role_title(role_def.legacy_role_key)
-                    if role_def.legacy_role_key
-                    else role_def.display_name
-                )
+                # Calendar month/agenda should display the configured dynamic
+                # role label (for example "AM Tow"), even when the role maps
+                # to a legacy role for eligibility.
+                role_labels_by_key[role_key] = role_def.display_name
             else:
                 role_labels_by_key[role_key] = get_role_title(role_key)
     dynamic_role_assignments_by_date = {

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -130,13 +130,13 @@ _DYNAMIC_ROLE_PRESENTATION_BY_LEGACY_KEY = {
         "badge_class": "badge-instructor",
         "card_class": "bg-success bg-opacity-10 border border-success",
         "heading_class": "text-success",
-        "icon_class": "fas fa-graduation-cap",
+        "icon_class": "bi bi-mortarboard",
     },
     "surge_instructor": {
         "badge_class": "badge-instructor",
         "card_class": "bg-success bg-opacity-10 border border-success",
         "heading_class": "text-success",
-        "icon_class": "fas fa-graduation-cap",
+        "icon_class": "bi bi-mortarboard",
     },
     "duty_officer": {
         "badge_class": "badge-duty-officer",


### PR DESCRIPTION
## Summary
Fixes duty roster calendar rendering for dynamic AM/PM role definitions so agenda and month table display the expected labels, role colors, and icons.

## What changed
- Preserve configured dynamic role `display_name` (e.g., `AM Tow`) in calendar month/agenda context instead of replacing with legacy terminology.
- In agenda cards, map dynamic roles with legacy mappings to role-specific visual treatment:
  - Tow mapped roles: red card + airplane icon
  - Instructor mapped roles: green card + mortarboard icon
  - Duty Officer / ADO mapped roles: matching DO/ADO styling and icons
  - Non-legacy dynamic roles keep generic dynamic styling.
- In month table badges, apply the same role-specific mapped styling and icon behavior.
- Added regression tests for mapped dynamic tow role rendering in both month table and agenda views.

## Files changed
- `duty_roster/views.py`
- `duty_roster/templates/duty_roster/_calendar_agenda.html`
- `duty_roster/templates/duty_roster/_calendar_table.html`
- `duty_roster/tests/test_calendar_dynamic_roles.py`

## Validation
- `pytest duty_roster/tests/test_calendar_dynamic_roles.py -q`
- Result: `11 passed`

## Notes
This addresses the UI behavior where mapped dynamic tow/instructor roles appeared as generic blue dynamic entries and AM/PM labels were not shown as configured.