### PR TITLE
Add daily pending SPR reminder digest

### DIFF
--- a/docs/cronjob-architecture.md
+++ b/docs/cronjob-architecture.md
@@ -102,7 +102,7 @@ Uses PostgreSQL's atomic operations:
    - ✅ `expire_ad_hoc_days.py` - **SCHEDULED DAILY**
 2. ✅ Created new notification commands:
    - ✅ `notify_aging_logsheets.py` - **FINDING REAL ISSUES**
-    - ✅ `notify_pending_sprs.py` - **FIRST DAILY SPR REMINDER DIGEST**
+   - ✅ `notify_pending_sprs.py` - **FIRST DAILY SPR REMINDER DIGEST**
    - ✅ `notify_late_sprs.py` - **MONITORING 34 FLIGHTS**
    - ✅ `report_duty_delinquents.py` - **IDENTIFIED 19 DELINQUENTS** (Issue #288 fixed recipient filtering)
    - ✅ `cleanup_old_notifications.py` - **PURGING STALE NOTIFICATIONS / PREVENTS NOTIFICATION ACCUMULATION** (Issue #290 60+ day cleanup & notification timeout)

--- a/docs/cronjob-architecture.md
+++ b/docs/cronjob-architecture.md
@@ -117,7 +117,7 @@ Uses PostgreSQL's atomic operations:
 
 ### 🕒 Active Production Schedule
 - **Daily 6:00 AM UTC**: Pre-op duty emails (for next day) ✅ **DEPLOYED**
-- **Daily 7:00 AM UTC**: Pending SPR reminder digest for previous finalized flying day ✅ **CONFIGURED**
+- **Daily 7:00 AM UTC**: Pending SPR reminder digest for the most recent finalized flying day with pending SPRs (may fall back to an older finalized day within `--max-days`) ✅ **CONFIGURED**
 - **Daily 8:00 AM UTC**: Aging logsheet notifications ✅ **DEPLOYED**
 - **Weekly Sunday 9:00 AM UTC**: Maintenance digest ✅ **DEPLOYED**
 - **Weekly Monday 10:00 AM UTC**: Late SPR notifications ✅ **DEPLOYED**

--- a/docs/cronjob-architecture.md
+++ b/docs/cronjob-architecture.md
@@ -102,6 +102,7 @@ Uses PostgreSQL's atomic operations:
    - ✅ `expire_ad_hoc_days.py` - **SCHEDULED DAILY**
 2. ✅ Created new notification commands:
    - ✅ `notify_aging_logsheets.py` - **FINDING REAL ISSUES**
+    - ✅ `notify_pending_sprs.py` - **FIRST DAILY SPR REMINDER DIGEST**
    - ✅ `notify_late_sprs.py` - **MONITORING 34 FLIGHTS**
    - ✅ `report_duty_delinquents.py` - **IDENTIFIED 19 DELINQUENTS** (Issue #288 fixed recipient filtering)
    - ✅ `cleanup_old_notifications.py` - **PURGING STALE NOTIFICATIONS / PREVENTS NOTIFICATION ACCUMULATION** (Issue #290 60+ day cleanup & notification timeout)
@@ -116,6 +117,7 @@ Uses PostgreSQL's atomic operations:
 
 ### 🕒 Active Production Schedule
 - **Daily 6:00 AM UTC**: Pre-op duty emails (for next day) ✅ **DEPLOYED**
+- **Daily 7:00 AM UTC**: Pending SPR reminder digest for previous finalized flying day ✅ **CONFIGURED**
 - **Daily 8:00 AM UTC**: Aging logsheet notifications ✅ **DEPLOYED**
 - **Weekly Sunday 9:00 AM UTC**: Maintenance digest ✅ **DEPLOYED**
 - **Weekly Monday 10:00 AM UTC**: Late SPR notifications ✅ **DEPLOYED**
@@ -125,6 +127,7 @@ Uses PostgreSQL's atomic operations:
 
 ### 📊 Recent Production Metrics
 - **Aging Logsheets**: Found 1 logsheet (11 days old), notified Todd Morris & Bob Alexander
+- **Pending SPR Reminders**: Consolidates same-day missing reports into one email per instructor after the flying day closes
 - **Late SPRs**: Checked 34 instructional flights, no overdue SPRs found
 - **Duty Delinquents**: Found 19 delinquent members, notifications sent to 4 Member Managers only
 - **Notification Cleanup**: New monthly job to purge notifications older than 60 days (both dismissed and undismissed)

--- a/instructors/docs/notifications.md
+++ b/instructors/docs/notifications.md
@@ -18,7 +18,7 @@ In addition to in-app notifications, instruction reports trigger email delivery:
 
 ## Instructor SPR Reminder Flow (Issue #887)
 
-Instructor SPR reminders now happen in two stages:
+Instructor SPR reminders now happen in three layers:
 
 - **Immediate in-app reminder on landed flight**: `logsheet.signals.notify_instructor_on_flight_created()` creates a dashboard notification when an instruction flight lands. This remains the fastest in-product cue that a report is needed.
 - **Daily consolidated email reminder**: `notify_pending_sprs` sends one email per instructor for missing Student Progress Reports from the most recent finalized flying day within its lookback window that still has pending reports. This reduces noise for instructors who flew with multiple students in one day.

--- a/instructors/docs/notifications.md
+++ b/instructors/docs/notifications.md
@@ -16,6 +16,27 @@ This document describes the notifications emitted by the `instructors` app.
 
 In addition to in-app notifications, instruction reports trigger email delivery:
 
+## Instructor SPR Reminder Flow (Issue #887)
+
+Instructor SPR reminders now happen in two stages:
+
+- **Immediate in-app reminder on landed flight**: `logsheet.signals.notify_instructor_on_flight_created()` creates a dashboard notification when an instruction flight lands. This remains the fastest in-product cue that a report is needed.
+- **Daily consolidated email reminder**: `notify_pending_sprs` sends one email per instructor for missing Student Progress Reports from the previous finalized flying day. This reduces noise for instructors who flew with multiple students in one day.
+- **Weekly overdue escalation**: `notify_late_sprs` still handles unresolved reports once they become overdue.
+
+### Pending SPR digest behavior
+
+- **Recipient**: The flight instructor
+- **Cadence**: Daily CronJob
+- **Grouping**: One email per instructor per flight date
+- **Source data**: Finalized logsheets only
+- **Content**: Student list plus direct links to each report form and the instructor dashboard
+- **Deduplication**: Uses the existing notification table to avoid resending the same day-specific reminder on reruns
+
+### Timezone note
+
+The first implementation uses a UTC Cron schedule. The job is intended to run after the previous flying day has closed, but tenant-specific timezone delivery is not yet configurable in `SiteConfiguration`.
+
 ### When emails are sent
 
 - **After instruction report submission**: When an instructor submits an instruction report (new or updated), an email is sent to the student with the full report details.

--- a/instructors/docs/notifications.md
+++ b/instructors/docs/notifications.md
@@ -21,7 +21,7 @@ In addition to in-app notifications, instruction reports trigger email delivery:
 Instructor SPR reminders now happen in two stages:
 
 - **Immediate in-app reminder on landed flight**: `logsheet.signals.notify_instructor_on_flight_created()` creates a dashboard notification when an instruction flight lands. This remains the fastest in-product cue that a report is needed.
-- **Daily consolidated email reminder**: `notify_pending_sprs` sends one email per instructor for missing Student Progress Reports from the previous finalized flying day. This reduces noise for instructors who flew with multiple students in one day.
+- **Daily consolidated email reminder**: `notify_pending_sprs` sends one email per instructor for missing Student Progress Reports from the most recent finalized flying day within its lookback window that still has pending reports. This reduces noise for instructors who flew with multiple students in one day.
 - **Weekly overdue escalation**: `notify_late_sprs` still handles unresolved reports once they become overdue.
 
 ### Pending SPR digest behavior

--- a/instructors/docs/notifications.md
+++ b/instructors/docs/notifications.md
@@ -35,7 +35,7 @@ Instructor SPR reminders now happen in two stages:
 
 ### Timezone note
 
-The first implementation uses a UTC Cron schedule. The job is intended to run after the previous flying day has closed, but tenant-specific timezone delivery is not yet configurable in `SiteConfiguration`.
+The first implementation uses a UTC Cron schedule and computes the target date from UTC (via `timezone.now().date()`), so the "previous day" boundary is always midnight UTC regardless of the server's local timezone. The job is intended to run after the previous flying day has closed, but tenant-specific timezone delivery is not yet configurable in `SiteConfiguration`.
 
 ### When emails are sent
 

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -46,10 +46,11 @@ class Command(BaseCronJobCommand):
             # Explicit --days-ago override: compute from UTC midnight.
             target_date = today - timedelta(days=options["days_ago"])
         else:
-            # Default: find the most recent finalized flying day with
-            # instructional flights so late-finalized logsheets are not
-            # silently skipped by a hard-coded "yesterday" offset.
-            target_date = (
+            # Default: find the most recent finalized flying day that still
+            # has at least one pending SPR. This ensures late-finalized
+            # logsheets are not skipped and that a newer all-reports-complete
+            # day does not shadow an older day with outstanding SPRs.
+            recent_dates = (
                 Logsheet.objects.filter(
                     finalized=True,
                     log_date__lt=today,
@@ -57,10 +58,15 @@ class Command(BaseCronJobCommand):
                 )
                 .order_by("-log_date")
                 .values_list("log_date", flat=True)
-                .first()
+                .distinct()
             )
+            target_date = None
+            for candidate_date in recent_dates:
+                if get_pending_sprs_for_date(candidate_date):
+                    target_date = candidate_date
+                    break
             if target_date is None:
-                self.log_info("No finalized logsheets with instructional flights found")
+                self.log_info("No finalized logsheets with pending SPRs found")
                 return
         self.log_info(
             f"Checking for pending SPRs from finalized flights on {target_date}"
@@ -116,7 +122,7 @@ class Command(BaseCronJobCommand):
             return False
 
         config = SiteConfiguration.objects.first()
-        canonical_base = get_canonical_url()
+        canonical_base = get_canonical_url(config)
         dashboard_url = build_absolute_url("/instructors/", canonical=canonical_base)
         pending_sprs = [
             {

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -81,7 +81,6 @@ class Command(BaseCronJobCommand):
         )
         existing = Notification.objects.filter(
             user=instructor,
-            dismissed=False,
         ).filter(
             Q(message__contains=PENDING_SPR_NOTIFICATION_FRAGMENT)
             & Q(message__contains=target_date.isoformat())

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -38,8 +38,10 @@ class Command(BaseCronJobCommand):
         )
 
     def execute_job(self, *args, **options):
+        # Compute the target date from UTC so the result is stable regardless
+        # of the Django TIME_ZONE setting or the server's local timezone.
         target_date = options.get("flight_date") or (
-            timezone.localdate() - timedelta(days=options.get("days_ago", 1))
+            timezone.now().date() - timedelta(days=options.get("days_ago", 1))
         )
         self.log_info(
             f"Checking for pending SPRs from finalized flights on {target_date}"
@@ -64,8 +66,11 @@ class Command(BaseCronJobCommand):
                 )
                 continue
 
-            if self._send_notification(instructor, spr_data, target_date):
-                notifications_sent += 1
+            try:
+                if self._send_notification(instructor, spr_data, target_date):
+                    notifications_sent += 1
+            except Exception as e:
+                self.log_error(f"Failed to notify {instructor.full_display_name}: {e}")
 
         if notifications_sent:
             self.log_success(

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -83,6 +83,10 @@ class Command(BaseCronJobCommand):
             f"Found {total_pending} pending SPRs for {total_instructors} instructor(s)"
         )
 
+        # Load global config once to avoid repeated DB queries per instructor.
+        config = SiteConfiguration.objects.first()
+        canonical_base = get_canonical_url(config)
+
         notifications_sent = 0
         for instructor, spr_data in pending_sprs.items():
             if options.get("dry_run"):
@@ -92,7 +96,9 @@ class Command(BaseCronJobCommand):
                 continue
 
             try:
-                if self._send_notification(instructor, spr_data, target_date):
+                if self._send_notification(
+                    instructor, spr_data, target_date, config, canonical_base
+                ):
                     notifications_sent += 1
             except Exception as e:
                 self.log_error(f"Failed to notify {instructor.full_display_name}: {e}")
@@ -104,7 +110,9 @@ class Command(BaseCronJobCommand):
         else:
             self.log_info("No reminders sent")
 
-    def _send_notification(self, instructor, spr_data, target_date):
+    def _send_notification(
+        self, instructor, spr_data, target_date, config, canonical_base
+    ):
         message = (
             f"You have {len(spr_data)} {PENDING_SPR_NOTIFICATION_FRAGMENT}(s) "
             f"from {target_date.isoformat()}."
@@ -121,8 +129,6 @@ class Command(BaseCronJobCommand):
             )
             return False
 
-        config = SiteConfiguration.objects.first()
-        canonical_base = get_canonical_url(config)
         dashboard_url = build_absolute_url("/instructors/", canonical=canonical_base)
         pending_sprs = [
             {
@@ -169,20 +175,27 @@ class Command(BaseCronJobCommand):
             else "noreply@manage2soar.com"
         )
 
-        if instructor.email:
-            send_mail(
-                subject=subject,
-                message=text_message,
-                from_email=from_email,
-                recipient_list=[instructor.email],
-                html_message=html_message,
-                fail_silently=False,
+        if not instructor.email:
+            self.log_info(
+                f"Skipping {instructor.full_display_name}: no email address on file"
             )
+            return False
 
+        send_mail(
+            subject=subject,
+            message=text_message,
+            from_email=from_email,
+            recipient_list=[instructor.email],
+            html_message=html_message,
+            fail_silently=False,
+        )
+
+        # Use a relative URL for the in-app notification so it stays on the
+        # current host rather than redirecting to the canonical domain.
         Notification.objects.create(
             user=instructor,
             message=message,
-            url=dashboard_url,
+            url="/instructors/",
         )
         self.log_success(
             f"Notified {instructor.full_display_name} about {len(pending_sprs)} pending SPR(s)"

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -57,7 +57,7 @@ class Command(BaseCronJobCommand):
             # has at least one pending SPR. Bounded to --max-days (default 30)
             # to avoid scanning the full Logsheet history on quiet days and
             # risking the 10-minute CronJob deadline.
-            max_days = options.get("max_days") or 30
+            max_days = options["max_days"]
             search_start = today - timedelta(days=max_days)
             recent_dates = (
                 Logsheet.objects.filter(

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -73,7 +73,26 @@ class Command(BaseCronJobCommand):
             target_date = None
             for candidate_date in recent_dates:
                 result = get_pending_sprs_for_date(candidate_date)
-                if result:
+                if not result:
+                    continue
+                # Skip this date if every eligible instructor has already
+                # received a notification for it. Without this check, the job
+                # would stall on a fully-notified newer date and never fall back
+                # to older dates that still need a first reminder (e.g., when
+                # multiple logsheets are finalized late on different days).
+                date_iso = candidate_date.isoformat()
+                already_notified_ids = set(
+                    Notification.objects.filter(user__in=result.keys())
+                    .filter(
+                        Q(message__contains=PENDING_SPR_NOTIFICATION_FRAGMENT)
+                        & Q(message__contains=date_iso)
+                    )
+                    .values_list("user_id", flat=True)
+                )
+                eligible = [
+                    instr for instr in result if instr.pk not in already_notified_ids
+                ]
+                if eligible:
                     target_date = candidate_date
                     # Reuse the already-fetched result to avoid a second query
                     # for the same date immediately after this loop.

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -154,6 +154,10 @@ class Command(BaseCronJobCommand):
     def _send_notification(
         self, instructor, spr_data, target_date, config, canonical_base
     ):
+        # Normalize email once at the start to ensure consistent handling
+        # of whitespace-only or leading/trailing-space addresses throughout.
+        email = (instructor.email or "").strip()
+
         message = (
             f"You have {len(spr_data)} {PENDING_SPR_NOTIFICATION_FRAGMENT}(s) "
             f"from {target_date.isoformat()}."
@@ -216,7 +220,7 @@ class Command(BaseCronJobCommand):
             else "noreply@manage2soar.com"
         )
 
-        if not instructor.email:
+        if not email:
             self.log_info(
                 f"Skipping {instructor.full_display_name}: no email address on file"
             )
@@ -226,7 +230,7 @@ class Command(BaseCronJobCommand):
             subject=subject,
             message=text_message,
             from_email=from_email,
-            recipient_list=[instructor.email],
+            recipient_list=[email],
             html_message=html_message,
             fail_silently=False,
         )

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -90,7 +90,10 @@ class Command(BaseCronJobCommand):
                     .values_list("user_id", flat=True)
                 )
                 eligible = [
-                    instr for instr in result if instr.pk not in already_notified_ids
+                    instr
+                    for instr in result
+                    if instr.pk not in already_notified_ids
+                    and getattr(instr, "email", "").strip()
                 ]
                 if eligible:
                     target_date = candidate_date

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -10,6 +10,7 @@ from instructors.utils import (
     PENDING_SPR_NOTIFICATION_FRAGMENT,
     get_pending_sprs_for_date,
 )
+from logsheet.models import Logsheet
 from notifications.models import Notification
 from siteconfig.models import SiteConfiguration
 from utils.email import send_mail
@@ -28,8 +29,8 @@ class Command(BaseCronJobCommand):
         parser.add_argument(
             "--days-ago",
             type=int,
-            default=1,
-            help="Send reminders for finalized flights from N days ago (default: 1)",
+            default=None,
+            help="Send reminders for finalized flights from N days ago",
         )
         parser.add_argument(
             "--flight-date",
@@ -38,11 +39,29 @@ class Command(BaseCronJobCommand):
         )
 
     def execute_job(self, *args, **options):
-        # Compute the target date from UTC so the result is stable regardless
-        # of the Django TIME_ZONE setting or the server's local timezone.
-        target_date = options.get("flight_date") or (
-            timezone.now().date() - timedelta(days=options.get("days_ago", 1))
-        )
+        today = timezone.now().date()
+        if options.get("flight_date"):
+            target_date = options["flight_date"]
+        elif options.get("days_ago") is not None:
+            # Explicit --days-ago override: compute from UTC midnight.
+            target_date = today - timedelta(days=options["days_ago"])
+        else:
+            # Default: find the most recent finalized flying day with
+            # instructional flights so late-finalized logsheets are not
+            # silently skipped by a hard-coded "yesterday" offset.
+            target_date = (
+                Logsheet.objects.filter(
+                    finalized=True,
+                    log_date__lt=today,
+                    flights__instructor__isnull=False,
+                )
+                .order_by("-log_date")
+                .values_list("log_date", flat=True)
+                .first()
+            )
+            if target_date is None:
+                self.log_info("No finalized logsheets with instructional flights found")
+                return
         self.log_info(
             f"Checking for pending SPRs from finalized flights on {target_date}"
         )
@@ -135,14 +154,14 @@ class Command(BaseCronJobCommand):
             "instructors/emails/pending_sprs_notification.txt", context
         )
 
-        default_from = getattr(settings, "DEFAULT_FROM_EMAIL", "") or ""
-        if "@" in default_from:
-            domain = default_from.split("@")[-1]
-            from_email = f"noreply@{domain}"
-        elif config and config.domain_name:
-            from_email = f"noreply@{config.domain_name}"
-        else:
-            from_email = "noreply@manage2soar.com"
+        # Let send_mail() normalise the sender via enforce_noreply_from_email()
+        # so From headers are correct even when DEFAULT_FROM_EMAIL is in
+        # "Name <addr@domain>" format.
+        from_email = getattr(settings, "DEFAULT_FROM_EMAIL", "") or (
+            f"noreply@{config.domain_name}"
+            if config and config.domain_name
+            else "noreply@manage2soar.com"
+        )
 
         if instructor.email:
             send_mail(

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -37,9 +37,16 @@ class Command(BaseCronJobCommand):
             type=lambda value: date.fromisoformat(value),
             help="Override target flight date (YYYY-MM-DD)",
         )
+        parser.add_argument(
+            "--max-days",
+            type=int,
+            default=30,
+            help="Maximum number of past days to search for pending SPRs when no date is specified (default: 30)",
+        )
 
     def execute_job(self, *args, **options):
         today = timezone.now().date()
+        pending_sprs = None  # may be pre-populated by the default discovery loop
         if options.get("flight_date"):
             target_date = options["flight_date"]
         elif options.get("days_ago") is not None:
@@ -47,13 +54,16 @@ class Command(BaseCronJobCommand):
             target_date = today - timedelta(days=options["days_ago"])
         else:
             # Default: find the most recent finalized flying day that still
-            # has at least one pending SPR. This ensures late-finalized
-            # logsheets are not skipped and that a newer all-reports-complete
-            # day does not shadow an older day with outstanding SPRs.
+            # has at least one pending SPR. Bounded to --max-days (default 30)
+            # to avoid scanning the full Logsheet history on quiet days and
+            # risking the 10-minute CronJob deadline.
+            max_days = options.get("max_days") or 30
+            search_start = today - timedelta(days=max_days)
             recent_dates = (
                 Logsheet.objects.filter(
                     finalized=True,
                     log_date__lt=today,
+                    log_date__gte=search_start,
                     flights__instructor__isnull=False,
                 )
                 .order_by("-log_date")
@@ -62,17 +72,26 @@ class Command(BaseCronJobCommand):
             )
             target_date = None
             for candidate_date in recent_dates:
-                if get_pending_sprs_for_date(candidate_date):
+                result = get_pending_sprs_for_date(candidate_date)
+                if result:
                     target_date = candidate_date
+                    # Reuse the already-fetched result to avoid a second query
+                    # for the same date immediately after this loop.
+                    pending_sprs = result
                     break
             if target_date is None:
-                self.log_info("No finalized logsheets with pending SPRs found")
+                self.log_info(
+                    f"No finalized logsheets with pending SPRs found in the last {max_days} days"
+                )
                 return
         self.log_info(
             f"Checking for pending SPRs from finalized flights on {target_date}"
         )
 
-        pending_sprs = get_pending_sprs_for_date(target_date)
+        # Use the result cached during date discovery; fall back to an explicit
+        # query when a date was supplied via --flight-date or --days-ago.
+        if pending_sprs is None:
+            pending_sprs = get_pending_sprs_for_date(target_date)
         if not pending_sprs:
             self.log_info("No pending SPRs found")
             return

--- a/instructors/management/commands/notify_pending_sprs.py
+++ b/instructors/management/commands/notify_pending_sprs.py
@@ -1,0 +1,161 @@
+from datetime import date, timedelta
+
+from django.conf import settings
+from django.db.models import Q
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django.utils import timezone
+
+from instructors.utils import (
+    PENDING_SPR_NOTIFICATION_FRAGMENT,
+    get_pending_sprs_for_date,
+)
+from notifications.models import Notification
+from siteconfig.models import SiteConfiguration
+from utils.email import send_mail
+from utils.email_helpers import get_absolute_club_logo_url
+from utils.management.commands.base_cronjob import BaseCronJobCommand
+from utils.url_helpers import build_absolute_url, get_canonical_url
+
+
+class Command(BaseCronJobCommand):
+    help = "Notify instructors about pending SPRs from a finalized flying day"
+    job_name = "notify_pending_sprs"
+    max_execution_time = timedelta(minutes=10)
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--days-ago",
+            type=int,
+            default=1,
+            help="Send reminders for finalized flights from N days ago (default: 1)",
+        )
+        parser.add_argument(
+            "--flight-date",
+            type=lambda value: date.fromisoformat(value),
+            help="Override target flight date (YYYY-MM-DD)",
+        )
+
+    def execute_job(self, *args, **options):
+        target_date = options.get("flight_date") or (
+            timezone.localdate() - timedelta(days=options.get("days_ago", 1))
+        )
+        self.log_info(
+            f"Checking for pending SPRs from finalized flights on {target_date}"
+        )
+
+        pending_sprs = get_pending_sprs_for_date(target_date)
+        if not pending_sprs:
+            self.log_info("No pending SPRs found")
+            return
+
+        total_instructors = len(pending_sprs)
+        total_pending = sum(len(sprs) for sprs in pending_sprs.values())
+        self.log_info(
+            f"Found {total_pending} pending SPRs for {total_instructors} instructor(s)"
+        )
+
+        notifications_sent = 0
+        for instructor, spr_data in pending_sprs.items():
+            if options.get("dry_run"):
+                self.log_info(
+                    f"Would notify {instructor.full_display_name} about {len(spr_data)} pending SPR(s) from {target_date}"
+                )
+                continue
+
+            if self._send_notification(instructor, spr_data, target_date):
+                notifications_sent += 1
+
+        if notifications_sent:
+            self.log_success(
+                f"Sent pending SPR reminders to {notifications_sent} instructor(s)"
+            )
+        else:
+            self.log_info("No reminders sent")
+
+    def _send_notification(self, instructor, spr_data, target_date):
+        message = (
+            f"You have {len(spr_data)} {PENDING_SPR_NOTIFICATION_FRAGMENT}(s) "
+            f"from {target_date.isoformat()}."
+        )
+        existing = Notification.objects.filter(
+            user=instructor,
+            dismissed=False,
+        ).filter(
+            Q(message__contains=PENDING_SPR_NOTIFICATION_FRAGMENT)
+            & Q(message__contains=target_date.isoformat())
+        )
+        if existing.exists():
+            self.log_info(
+                f"Skipping duplicate pending SPR reminder for {instructor.full_display_name} on {target_date}"
+            )
+            return False
+
+        config = SiteConfiguration.objects.first()
+        canonical_base = get_canonical_url()
+        dashboard_url = build_absolute_url("/instructors/", canonical=canonical_base)
+        pending_sprs = [
+            {
+                "student_name": spr["student"].full_display_name,
+                "report_url": build_absolute_url(
+                    reverse(
+                        "instructors:fill_instruction_report",
+                        args=[spr["student"].pk, target_date],
+                    ),
+                    canonical=canonical_base,
+                ),
+            }
+            for spr in spr_data
+        ]
+
+        context = {
+            "instructor_name": instructor.full_display_name,
+            "flight_date": target_date.strftime("%A, %B %d, %Y"),
+            "pending_sprs": pending_sprs,
+            "pending_count": len(pending_sprs),
+            "club_name": config.club_name if config else "Soaring Club",
+            "club_logo_url": get_absolute_club_logo_url(config),
+            "dashboard_url": dashboard_url,
+            "site_url": canonical_base,
+        }
+
+        subject = (
+            "Student Progress Report Reminder - "
+            f"{len(pending_sprs)} Pending Report(s) from {target_date.strftime('%B %d, %Y')}"
+        )
+        html_message = render_to_string(
+            "instructors/emails/pending_sprs_notification.html", context
+        )
+        text_message = render_to_string(
+            "instructors/emails/pending_sprs_notification.txt", context
+        )
+
+        default_from = getattr(settings, "DEFAULT_FROM_EMAIL", "") or ""
+        if "@" in default_from:
+            domain = default_from.split("@")[-1]
+            from_email = f"noreply@{domain}"
+        elif config and config.domain_name:
+            from_email = f"noreply@{config.domain_name}"
+        else:
+            from_email = "noreply@manage2soar.com"
+
+        if instructor.email:
+            send_mail(
+                subject=subject,
+                message=text_message,
+                from_email=from_email,
+                recipient_list=[instructor.email],
+                html_message=html_message,
+                fail_silently=False,
+            )
+
+        Notification.objects.create(
+            user=instructor,
+            message=message,
+            url=dashboard_url,
+        )
+        self.log_success(
+            f"Notified {instructor.full_display_name} about {len(pending_sprs)} pending SPR(s)"
+        )
+        return True

--- a/instructors/templates/instructors/emails/pending_sprs_notification.html
+++ b/instructors/templates/instructors/emails/pending_sprs_notification.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!--[if mso]>
+  <style type="text/css">
+    table { border-collapse: collapse; }
+    td { padding: 0; }
+  </style>
+  <![endif]-->
+  <title>Student Progress Report Reminder</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f5f5f5;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f5;">
+    <tr>
+      <td align="center" style="padding: 20px 10px;">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+          <tr>
+            <td style="background-color: #2c5282; padding: 24px; text-align: center;">
+              {% if club_logo_url %}
+              <img src="{{ club_logo_url }}" alt="{{ club_name }}" style="max-height: 60px; max-width: 200px; height: auto; margin-bottom: 12px;">
+              {% endif %}
+              <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: 600;">
+                Student Progress Report Reminder
+              </h1>
+              <p style="margin: 8px 0 0 0; color: #bee3f8; font-size: 16px;">
+                {{ flight_date }}
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding: 24px 24px 16px 24px;">
+              <p style="margin: 0; color: #2d3748; font-size: 16px; line-height: 1.5;">
+                Hello {{ instructor_name }},
+              </p>
+              <p style="margin: 12px 0 0 0; color: #4a5568; font-size: 15px; line-height: 1.5;">
+                You have <strong>{{ pending_count }}</strong> Student Progress Report(s) still to complete from <strong>{{ flight_date }}</strong>.
+                This reminder groups the outstanding reports into a single message for the day.
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding: 0 24px 16px 24px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #ebf8ff; border-radius: 6px; border-left: 4px solid #3182ce;">
+                <tr>
+                  <td style="padding: 16px;">
+                    <h2 style="margin: 0 0 12px 0; color: #2c5282; font-size: 18px; font-weight: 600;">
+                      Reports Still Needed
+                    </h2>
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      {% for spr in pending_sprs %}
+                      <tr>
+                        <td style="padding: 10px 0; color: #2d3748; font-size: 15px; border-bottom: 1px solid #bee3f8;">
+                          <strong>{{ spr.student_name }}</strong>
+                        </td>
+                        <td style="padding: 10px 0; text-align: right; border-bottom: 1px solid #bee3f8; white-space: nowrap;">
+                          <a href="{{ spr.report_url }}" style="color: #3182ce; text-decoration: none; font-size: 14px; font-weight: 600;">Open report form</a>
+                        </td>
+                      </tr>
+                      {% endfor %}
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding: 0 24px 24px 24px;">
+              <p style="margin: 0 0 20px 0; color: #4a5568; font-size: 15px; line-height: 1.5;">
+                Filing these reports promptly keeps student training records current and avoids escalation into the overdue reminder process.
+              </p>
+              <div style="text-align: center;">
+                <a href="{{ dashboard_url }}" style="display: inline-block; background-color: #3182ce; color: #ffffff; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 15px;">
+                  Open Instructor Dashboard
+                </a>
+              </div>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color: #f7fafc; padding: 20px 24px; text-align: center; border-top: 1px solid #e2e8f0;">
+              <p style="margin: 0; color: #718096; font-size: 13px;">
+                This is an automated message from {{ club_name }}.
+              </p>
+              {% if site_url %}
+              <p style="margin: 8px 0 0 0;">
+                <a href="{{ site_url }}" style="color: #3182ce; text-decoration: none; font-size: 13px;">{{ site_url }}</a>
+              </p>
+              {% endif %}
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/instructors/templates/instructors/emails/pending_sprs_notification.txt
+++ b/instructors/templates/instructors/emails/pending_sprs_notification.txt
@@ -11,7 +11,7 @@ REPORTS STILL NEEDED
 --------------------
 {% for spr in pending_sprs %}
 - {{ spr.student_name }}
-	Open report form: {{ spr.report_url }}
+  Open report form: {{ spr.report_url }}
 {% endfor %}
 
 Filing these reports promptly keeps student training records current and helps

--- a/instructors/templates/instructors/emails/pending_sprs_notification.txt
+++ b/instructors/templates/instructors/emails/pending_sprs_notification.txt
@@ -1,0 +1,24 @@
+Student Progress Report Reminder
+{{ club_name }}
+{{ flight_date }}
+
+Hello {{ instructor_name }},
+
+You have {{ pending_count }} Student Progress Report(s) still to complete from {{ flight_date }}.
+This reminder groups the outstanding reports into a single message for the day.
+
+REPORTS STILL NEEDED
+--------------------
+{% for spr in pending_sprs %}
+- {{ spr.student_name }}
+	Open report form: {{ spr.report_url }}
+{% endfor %}
+
+Filing these reports promptly keeps student training records current and helps
+avoid escalation into the overdue reminder process.
+
+Open instructor dashboard: {{ dashboard_url }}
+
+---
+This is an automated message from {{ club_name }}.
+{{ site_url }}

--- a/instructors/tests/test_pending_spr_reminders.py
+++ b/instructors/tests/test_pending_spr_reminders.py
@@ -149,6 +149,40 @@ def test_notify_pending_sprs_sends_one_email_per_instructor_and_dedupes_reruns(
     DEFAULT_FROM_EMAIL="noreply@test.com",
     SITE_URL="https://test.manage2soar.com",
 )
+def test_notify_pending_sprs_dedupes_even_after_notification_is_dismissed(
+    site_config, airfield, instructor, student_one
+):
+    target_date = date(2026, 4, 25)
+    logsheet = Logsheet.objects.create(
+        log_date=target_date,
+        airfield=airfield,
+        created_by=instructor,
+        finalized=True,
+    )
+    create_flight(logsheet, student_one, instructor, 10)
+
+    mail.outbox.clear()
+    Notification.objects.all().delete()
+
+    call_command("notify_pending_sprs", f"--flight-date={target_date.isoformat()}")
+
+    notification = Notification.objects.get(user=instructor)
+    notification.dismissed = True
+    notification.save(update_fields=["dismissed"])
+
+    call_command("notify_pending_sprs", f"--flight-date={target_date.isoformat()}")
+
+    assert len(mail.outbox) == 1
+    assert Notification.objects.filter(user=instructor).count() == 1
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    EMAIL_DEV_MODE=False,
+    DEFAULT_FROM_EMAIL="noreply@test.com",
+    SITE_URL="https://test.manage2soar.com",
+)
 def test_notify_pending_sprs_ignores_non_finalized_logsheets(
     site_config, airfield, instructor, student_one
 ):

--- a/instructors/tests/test_pending_spr_reminders.py
+++ b/instructors/tests/test_pending_spr_reminders.py
@@ -267,3 +267,76 @@ def test_notify_pending_sprs_picks_up_late_finalized_logsheet(
     assert mail.outbox[0].to == [instructor.email]
     assert flight_date.strftime("%B %d, %Y") in mail.outbox[0].subject
     assert Notification.objects.filter(user=instructor).count() == 1
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    EMAIL_DEV_MODE=False,
+    DEFAULT_FROM_EMAIL="noreply@test.com",
+    SITE_URL="https://test.manage2soar.com",
+)
+def test_notify_pending_sprs_skips_fully_notified_date_and_falls_back_to_older(
+    site_config, airfield, instructor, student_one, student_two
+):
+    """If the most recent finalized date with pending SPRs already has
+    notifications for all its instructors, the command should skip that date
+    and process the next older date that still has un-notified pending SPRs.
+
+    Scenario:
+      - newer_date (2 days ago): pending SPR, but notification ALREADY sent
+      - older_date (4 days ago): pending SPR, NO notification sent yet
+      → command should email for older_date, not newer_date
+    """
+    from django.utils import timezone
+
+    from instructors.utils import PENDING_SPR_NOTIFICATION_FRAGMENT
+
+    today = timezone.now().date()
+    newer_date = today - timedelta(days=2)
+    older_date = today - timedelta(days=4)
+
+    # Set up newer_date logsheet with a pending SPR for instructor
+    newer_logsheet = Logsheet.objects.create(
+        log_date=newer_date,
+        airfield=airfield,
+        created_by=instructor,
+        finalized=True,
+    )
+    create_flight(newer_logsheet, student_one, instructor, 10)
+
+    # Set up older_date logsheet with a pending SPR for instructor
+    older_logsheet = Logsheet.objects.create(
+        log_date=older_date,
+        airfield=airfield,
+        created_by=instructor,
+        finalized=True,
+    )
+    create_flight(older_logsheet, student_two, instructor, 10)
+
+    # Pre-seed a notification for newer_date so the command treats it as
+    # already handled for this instructor.
+    Notification.objects.create(
+        user=instructor,
+        message=(
+            f"You have 1 {PENDING_SPR_NOTIFICATION_FRAGMENT}(s) "
+            f"from {newer_date.isoformat()}."
+        ),
+        url="/instructors/",
+    )
+
+    mail.outbox.clear()
+
+    call_command("notify_pending_sprs")
+
+    # Should have emailed for older_date (the first un-notified date)
+    assert (
+        len(mail.outbox) == 1
+    ), "Expected one email for older_date; newer_date should have been skipped"
+    assert older_date.strftime("%B %d, %Y") in mail.outbox[0].subject
+    assert mail.outbox[0].to == [instructor.email]
+    # Notification for older_date should now exist
+    assert Notification.objects.filter(
+        user=instructor,
+        message__contains=older_date.isoformat(),
+    ).exists()

--- a/instructors/tests/test_pending_spr_reminders.py
+++ b/instructors/tests/test_pending_spr_reminders.py
@@ -1,4 +1,4 @@
-from datetime import date, time
+from datetime import date, time, timedelta
 
 import pytest
 from django.core import mail
@@ -219,7 +219,9 @@ def test_notify_pending_sprs_picks_up_late_finalized_logsheet(
     finalized 2+ days after the flights are still picked up."""
     # Logsheet dated 3 days ago but finalized late (today) — simulates a
     # real scenario where the DO closes out after a delay.
-    flight_date = date(2026, 4, 23)  # 3 days before the mock today
+    from django.utils import timezone
+
+    flight_date = timezone.now().date() - timedelta(days=3)
     logsheet = Logsheet.objects.create(
         log_date=flight_date,
         airfield=airfield,
@@ -237,5 +239,5 @@ def test_notify_pending_sprs_picks_up_late_finalized_logsheet(
 
     assert len(mail.outbox) == 1
     assert mail.outbox[0].to == [instructor.email]
-    assert "April 23, 2026" in mail.outbox[0].subject
+    assert flight_date.strftime("%B %d, %Y") in mail.outbox[0].subject
     assert Notification.objects.filter(user=instructor).count() == 1

--- a/instructors/tests/test_pending_spr_reminders.py
+++ b/instructors/tests/test_pending_spr_reminders.py
@@ -340,3 +340,77 @@ def test_notify_pending_sprs_skips_fully_notified_date_and_falls_back_to_older(
         user=instructor,
         message__contains=older_date.isoformat(),
     ).exists()
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    EMAIL_DEV_MODE=False,
+    DEFAULT_FROM_EMAIL="noreply@test.com",
+    SITE_URL="https://test.manage2soar.com",
+)
+def test_notify_pending_sprs_skips_emailless_date_and_falls_back_to_older(
+    site_config, airfield, student_one
+):
+    """If the most recent finalized date only has pending SPRs for instructors
+    without an email address, the command should skip that date and fall back
+    to an older date whose instructors *do* have an email address.
+
+    Scenario:
+      - newer_date (2 days ago): pending SPR for an email-less instructor
+      - older_date (4 days ago): pending SPR for an instructor with an email
+      → command should email for older_date, skipping newer_date entirely
+    """
+    from django.utils import timezone
+
+    today = timezone.now().date()
+    newer_date = today - timedelta(days=2)
+    older_date = today - timedelta(days=4)
+
+    # Instructor without an email address (should be skipped)
+    emailless_instructor = Member.objects.create(
+        username="noemail_inst",
+        first_name="No",
+        last_name="Email",
+        email="",
+        membership_status="Full Member",
+    )
+    # Instructor with a valid email (should receive the reminder)
+    emailable_instructor = Member.objects.create(
+        username="email_inst",
+        first_name="Has",
+        last_name="Email",
+        email="has@example.com",
+        membership_status="Full Member",
+    )
+
+    # newer_date: pending SPR, but instructor has no email
+    newer_logsheet = Logsheet.objects.create(
+        log_date=newer_date,
+        airfield=airfield,
+        created_by=emailless_instructor,
+        finalized=True,
+    )
+    create_flight(newer_logsheet, student_one, emailless_instructor, 10)
+
+    # older_date: pending SPR for an emailable instructor
+    older_logsheet = Logsheet.objects.create(
+        log_date=older_date,
+        airfield=airfield,
+        created_by=emailable_instructor,
+        finalized=True,
+    )
+    create_flight(older_logsheet, student_one, emailable_instructor, 10)
+
+    mail.outbox.clear()
+    Notification.objects.all().delete()
+
+    call_command("notify_pending_sprs")
+
+    # Should email for older_date only (newer_date's instructor has no email)
+    assert len(mail.outbox) == 1, (
+        "Expected one email for older_date; newer_date should have been skipped "
+        "because its instructor has no email address"
+    )
+    assert older_date.strftime("%B %d, %Y") in mail.outbox[0].subject
+    assert mail.outbox[0].to == [emailable_instructor.email]

--- a/instructors/tests/test_pending_spr_reminders.py
+++ b/instructors/tests/test_pending_spr_reminders.py
@@ -104,6 +104,32 @@ def test_get_pending_sprs_for_date_groups_students_and_excludes_existing_reports
 
 
 @pytest.mark.django_db
+def test_get_pending_sprs_for_date_deduplicates_multiple_flights_for_same_student(
+    airfield, instructor, student_one
+):
+    """Multiple flights on the same day for the same instructor/student pair
+    should produce exactly one pending SPR entry, not one per flight."""
+    target_date = date(2026, 4, 25)
+    logsheet = Logsheet.objects.create(
+        log_date=target_date,
+        airfield=airfield,
+        created_by=instructor,
+        finalized=True,
+    )
+    # Same student flew twice with the same instructor on the same day.
+    create_flight(logsheet, student_one, instructor, 10)
+    create_flight(logsheet, student_one, instructor, 14)
+
+    pending = get_pending_sprs_for_date(target_date)
+
+    assert list(pending.keys()) == [instructor]
+    assert (
+        len(pending[instructor]) == 1
+    ), "Expected exactly one pending entry for a student who flew twice on the same day"
+    assert pending[instructor][0]["student"] == student_one
+
+
+@pytest.mark.django_db
 @override_settings(
     EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
     EMAIL_DEV_MODE=False,

--- a/instructors/tests/test_pending_spr_reminders.py
+++ b/instructors/tests/test_pending_spr_reminders.py
@@ -202,3 +202,40 @@ def test_notify_pending_sprs_ignores_non_finalized_logsheets(
 
     assert len(mail.outbox) == 0
     assert Notification.objects.count() == 0
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    EMAIL_DEV_MODE=False,
+    DEFAULT_FROM_EMAIL="noreply@test.com",
+    SITE_URL="https://test.manage2soar.com",
+)
+def test_notify_pending_sprs_picks_up_late_finalized_logsheet(
+    site_config, airfield, instructor, student_one
+):
+    """Without --flight-date, the command should find the most recent finalized
+    flying day regardless of when the logsheet was finalized, so logsheets
+    finalized 2+ days after the flights are still picked up."""
+    # Logsheet dated 3 days ago but finalized late (today) — simulates a
+    # real scenario where the DO closes out after a delay.
+    flight_date = date(2026, 4, 23)  # 3 days before the mock today
+    logsheet = Logsheet.objects.create(
+        log_date=flight_date,
+        airfield=airfield,
+        created_by=instructor,
+        finalized=True,
+    )
+    create_flight(logsheet, student_one, instructor, 10)
+
+    mail.outbox.clear()
+    Notification.objects.all().delete()
+
+    # Run without --flight-date; should auto-discover flight_date as the
+    # most recent finalized instructional flying day.
+    call_command("notify_pending_sprs")
+
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].to == [instructor.email]
+    assert "April 23, 2026" in mail.outbox[0].subject
+    assert Notification.objects.filter(user=instructor).count() == 1

--- a/instructors/tests/test_pending_spr_reminders.py
+++ b/instructors/tests/test_pending_spr_reminders.py
@@ -1,0 +1,170 @@
+from datetime import date, time
+
+import pytest
+from django.core import mail
+from django.core.management import call_command
+from django.test import override_settings
+
+from instructors.models import InstructionReport
+from instructors.utils import get_pending_sprs_for_date
+from logsheet.models import Airfield, Flight, Logsheet
+from members.models import Member
+from notifications.models import Notification
+from siteconfig.models import SiteConfiguration
+
+
+@pytest.fixture
+def site_config(db):
+    return SiteConfiguration.objects.create(
+        club_name="Test Soaring Club",
+        club_nickname="Test Club",
+        domain_name="test.manage2soar.com",
+        club_abbreviation="TSC",
+        duty_officer_title="Duty Officer",
+        assistant_duty_officer_title="Assistant DO",
+        towpilot_title="Tow Pilot",
+        instructor_title="Instructor",
+    )
+
+
+@pytest.fixture
+def airfield(db):
+    return Airfield.objects.create(identifier="TST", name="Test Field")
+
+
+@pytest.fixture
+def instructor(db):
+    return Member.objects.create(
+        username="inst",
+        first_name="Chris",
+        last_name="Instructor",
+        email="chris@example.com",
+        membership_status="Full Member",
+    )
+
+
+@pytest.fixture
+def student_one(db):
+    return Member.objects.create(
+        username="student1",
+        first_name="Alice",
+        last_name="Student",
+        email="alice@example.com",
+        membership_status="Student",
+    )
+
+
+@pytest.fixture
+def student_two(db):
+    return Member.objects.create(
+        username="student2",
+        first_name="Bob",
+        last_name="Student",
+        email="bob@example.com",
+        membership_status="Student",
+    )
+
+
+def create_flight(logsheet, pilot, instructor, launch_hour):
+    return Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        instructor=instructor,
+        launch_time=time(launch_hour, 0),
+        landing_time=time(launch_hour, 30),
+        flight_type="dual",
+    )
+
+
+@pytest.mark.django_db
+def test_get_pending_sprs_for_date_groups_students_and_excludes_existing_reports(
+    airfield, instructor, student_one, student_two
+):
+    target_date = date(2026, 4, 25)
+    logsheet = Logsheet.objects.create(
+        log_date=target_date,
+        airfield=airfield,
+        created_by=instructor,
+        finalized=True,
+    )
+    create_flight(logsheet, student_one, instructor, 10)
+    create_flight(logsheet, student_two, instructor, 11)
+    InstructionReport.objects.create(
+        student=student_two,
+        instructor=instructor,
+        report_date=target_date,
+        report_text="Completed already",
+    )
+
+    pending = get_pending_sprs_for_date(target_date)
+
+    assert list(pending.keys()) == [instructor]
+    assert len(pending[instructor]) == 1
+    assert pending[instructor][0]["student"] == student_one
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    EMAIL_DEV_MODE=False,
+    DEFAULT_FROM_EMAIL="noreply@test.com",
+    SITE_URL="https://test.manage2soar.com",
+)
+def test_notify_pending_sprs_sends_one_email_per_instructor_and_dedupes_reruns(
+    site_config, airfield, instructor, student_one, student_two
+):
+    target_date = date(2026, 4, 25)
+    logsheet = Logsheet.objects.create(
+        log_date=target_date,
+        airfield=airfield,
+        created_by=instructor,
+        finalized=True,
+    )
+    create_flight(logsheet, student_one, instructor, 10)
+    create_flight(logsheet, student_two, instructor, 11)
+
+    mail.outbox.clear()
+    Notification.objects.all().delete()
+
+    call_command("notify_pending_sprs", f"--flight-date={target_date.isoformat()}")
+
+    assert len(mail.outbox) == 1
+    email = mail.outbox[0]
+    assert email.to == ["chris@example.com"]
+    assert "2 Pending Report(s)" in email.subject
+    assert "Alice Student" in email.body
+    assert "Bob Student" in email.body
+    assert Notification.objects.filter(user=instructor).count() == 1
+
+    call_command("notify_pending_sprs", f"--flight-date={target_date.isoformat()}")
+
+    assert len(mail.outbox) == 1
+    assert Notification.objects.filter(user=instructor).count() == 1
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    EMAIL_DEV_MODE=False,
+    DEFAULT_FROM_EMAIL="noreply@test.com",
+    SITE_URL="https://test.manage2soar.com",
+)
+def test_notify_pending_sprs_ignores_non_finalized_logsheets(
+    site_config, airfield, instructor, student_one
+):
+    target_date = date(2026, 4, 25)
+    logsheet = Logsheet.objects.create(
+        log_date=target_date,
+        airfield=airfield,
+        created_by=instructor,
+        finalized=False,
+    )
+    create_flight(logsheet, student_one, instructor, 10)
+
+    mail.outbox.clear()
+    Notification.objects.all().delete()
+
+    call_command("notify_pending_sprs", f"--flight-date={target_date.isoformat()}")
+
+    assert len(mail.outbox) == 0
+    assert Notification.objects.count() == 0

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -28,6 +28,7 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 OVERDUE_SPR_NOTIFICATION_FRAGMENT = "overdue Student Progress Report"
+PENDING_SPR_NOTIFICATION_FRAGMENT = "pending Student Progress Report"
 
 
 def get_spr_escalation_level(days_overdue):
@@ -114,6 +115,67 @@ def get_overdue_sprs(max_days=30, as_of_date=None, instructor=None):
     return overdue_by_instructor
 
 
+def get_pending_sprs_for_date(flight_date, instructor=None):
+    """Return pending SPR data grouped by instructor for a specific flight date.
+
+    A flight is considered pending when its logsheet is finalized, it has both a
+    pilot and instructor, and no InstructionReport exists for the same
+    instructor, student, and flight date. Multiple flights for the same
+    instructor/student/date are consolidated into a single reminder entry.
+    """
+    flights_qs = Flight.objects.filter(
+        instructor__isnull=False,
+        pilot__isnull=False,
+        logsheet__finalized=True,
+        logsheet__log_date=flight_date,
+    )
+
+    if instructor is not None:
+        flights_qs = flights_qs.filter(instructor=instructor)
+
+    flights = list(
+        flights_qs.select_related("instructor", "pilot", "logsheet").order_by(
+            "instructor", "pilot"
+        )
+    )
+
+    if not flights:
+        return {}
+
+    report_qs = InstructionReport.objects.filter(report_date=flight_date)
+    if instructor is not None:
+        report_qs = report_qs.filter(instructor=instructor)
+    else:
+        report_qs = report_qs.filter(
+            instructor_id__in={flight.instructor_id for flight in flights}
+        )
+
+    existing_reports = set(
+        report_qs.values_list("instructor_id", "student_id", "report_date")
+    )
+
+    pending_by_instructor = {}
+    seen = set()
+    for flight in flights:
+        report_key = (flight.instructor_id, flight.pilot_id, flight_date)
+        if report_key in seen:
+            continue
+        seen.add(report_key)
+
+        if report_key in existing_reports:
+            continue
+
+        pending_by_instructor.setdefault(flight.instructor, []).append(
+            {
+                "flight": flight,
+                "student": flight.pilot,
+                "flight_date": flight_date,
+            }
+        )
+
+    return pending_by_instructor
+
+
 def get_instructor_overdue_spr_count(instructor, max_days=30, as_of_date=None):
     """Return overdue SPR count for a single instructor."""
     overdue = get_overdue_sprs(
@@ -163,6 +225,11 @@ def get_instructor_has_overdue_sprs(instructor, max_days=30, as_of_date=None):
 def is_overdue_spr_notification_message(message):
     """Return True when a notification message is an overdue SPR reminder."""
     return OVERDUE_SPR_NOTIFICATION_FRAGMENT in (message or "")
+
+
+def is_pending_spr_notification_message(message):
+    """Return True when a notification message is a pending SPR reminder."""
+    return PENDING_SPR_NOTIFICATION_FRAGMENT in (message or "")
 
 
 ####################################################

--- a/instructors/utils.py
+++ b/instructors/utils.py
@@ -227,11 +227,6 @@ def is_overdue_spr_notification_message(message):
     return OVERDUE_SPR_NOTIFICATION_FRAGMENT in (message or "")
 
 
-def is_pending_spr_notification_message(message):
-    """Return True when a notification message is a pending SPR reminder."""
-    return PENDING_SPR_NOTIFICATION_FRAGMENT in (message or "")
-
-
 ####################################################
 # get_flight_summary_for_member
 #

--- a/k8s-cronjobs.yaml
+++ b/k8s-cronjobs.yaml
@@ -159,8 +159,8 @@ spec:
                 secretName: gcp-sa-key
 
 ---
-# Daily: Pending SPR reminder digest (7:00 AM UTC, previous finalized flying day)
-# UTC-first schedule until tenant-specific timezone configuration is available.
+# Daily: Pending SPR reminder digest (7:00 AM UTC, most recent finalized flying day with pending SPRs,
+# which may be older than the immediately previous finalized day if more recent days have no pending reports)
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/k8s-cronjobs.yaml
+++ b/k8s-cronjobs.yaml
@@ -159,6 +159,59 @@ spec:
                 secretName: gcp-sa-key
 
 ---
+# Daily: Pending SPR reminder digest (7:00 AM UTC, previous finalized flying day)
+# UTC-first schedule until tenant-specific timezone configuration is available.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: notify-pending-sprs
+  namespace: default
+spec:
+  schedule: "0 7 * * *" # Daily at 7:00 AM UTC
+  timeZone: "UTC"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600 # 10 minute timeout
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: notify-pending-sprs
+              image: gcr.io/skyline-soaring-storage/skylinesoaring:latest
+              command:
+                - python
+                - manage.py
+                - notify_pending_sprs
+                - --verbosity=1
+              workingDir: /app
+              env:
+                - name: GOOGLE_APPLICATION_CREDENTIALS
+                  value: /app/gcp-credentials.json
+              envFrom:
+                - secretRef:
+                    name: manage2soar-env
+              volumeMounts:
+                - name: gcp-sa-key
+                  mountPath: /app/gcp-credentials.json
+                  subPath: gcp-credentials.json
+                  readOnly: true
+              resources:
+                requests:
+                  memory: "64Mi"
+                  cpu: "50m"
+                limits:
+                  memory: "128Mi"
+                  cpu: "100m"
+          volumes:
+            - name: gcp-sa-key
+              secret:
+                secretName: gcp-sa-key
+
+---
 # Daily: Instructor Summary Emails (6:00 AM UTC, 48 hours ahead)
 # Sends summary to instructors about students requesting instruction
 apiVersion: batch/v1

--- a/utils/README_CronJobs.md
+++ b/utils/README_CronJobs.md
@@ -39,11 +39,11 @@ All CronJob commands inherit from `BaseCronJobCommand` which provides:
 - **Note**: Existing command, converted to use new framework
 
 #### `notify_pending_sprs` (7:00 AM UTC)
-- **Purpose**: Send one consolidated reminder email per instructor for missing Student Progress Reports from the previous finalized flying day
+- **Purpose**: Send one consolidated reminder email per instructor for missing Student Progress Reports from the most recent finalized flying day with pending reports, scanning back up to `--max-days`
 - **Recipients**: Flight instructors with missing reports
 - **Frequency**: Daily
 - **Timeout**: 10 minutes
-- **Note**: UTC-first schedule until tenant-specific timezone support exists
+- **Note**: UTC-first schedule until tenant-specific timezone support exists; by default the command looks back only within its `--max-days` bound
 
 #### `expire_ad_hoc_days` (3:00 AM UTC = 10 PM EST / 11 PM EDT)
 - **Purpose**: Expire unconfirmed ad-hoc duty assignments for today (runs at night-before deadline)

--- a/utils/README_CronJobs.md
+++ b/utils/README_CronJobs.md
@@ -38,6 +38,13 @@ All CronJob commands inherit from `BaseCronJobCommand` which provides:
 - **Timeout**: 10 minutes
 - **Note**: Existing command, converted to use new framework
 
+#### `notify_pending_sprs` (7:00 AM UTC)
+- **Purpose**: Send one consolidated reminder email per instructor for missing Student Progress Reports from the previous finalized flying day
+- **Recipients**: Flight instructors with missing reports
+- **Frequency**: Daily
+- **Timeout**: 10 minutes
+- **Note**: UTC-first schedule until tenant-specific timezone support exists
+
 #### `expire_ad_hoc_days` (3:00 AM UTC = 10 PM EST / 11 PM EDT)
 - **Purpose**: Expire unconfirmed ad-hoc duty assignments for today (runs at night-before deadline)
 - **Target**: Ad-hoc duty slots


### PR DESCRIPTION
## Summary

Adds a first-pass instructor reminder flow for missing Student Progress Reports (SPRs) so instructors receive one consolidated reminder after the previous finalized flying day instead of waiting for the weekly overdue escalation.

Fixes #887

## What Changed

- Added `get_pending_sprs_for_date(...)` in `instructors/utils.py` to find missing SPRs for a specific finalized flight date, grouped by instructor and deduped per student/date.
- Added a new `notify_pending_sprs` management command that sends one email per instructor and creates a matching in-app notification.
- Added new HTML and plaintext email templates for the pending SPR reminder, styled to match the system's existing outbound emails.
- Added focused tests for:
  - grouping and excluding already-filed reports
  - one-email-per-instructor behavior for multiple students on the same day
  - rerun dedupe behavior
  - ignoring non-finalized logsheets
- Added Kubernetes CronJob wiring and documentation for the new daily reminder flow.

## Validation

Validated with:

- `python -m pytest instructors/tests/test_pending_spr_reminders.py -q`
- `python -m pytest instructors/tests/test_instruction_report_email.py instructors/tests/test_instructor_notifications.py instructors/tests/test_instructor_emails.py instructors/tests/test_pending_spr_reminders.py logsheet/tests/test_signals.py -q`

## Notes

- This is intentionally a UTC-first implementation for the daily digest schedule.
- Broader club-specific timezone design is deferred to #888 so we do not keep encoding East Coast assumptions piecemeal.
- The existing landed-flight in-app reminder and weekly overdue escalation remain in place; this change adds the missing first reminder layer.
