### PR TITLE
Fix broken closeout images in ops summary emails

### DIFF
--- a/logsheet/tests/test_finalization_email.py
+++ b/logsheet/tests/test_finalization_email.py
@@ -161,6 +161,14 @@ class TestSanitizeCloseoutHtml(SimpleTestCase):
         )
         assert 'src="https://club.example.com/media/tinymce/photo.jpg"' in result
 
+    def test_protocol_relative_untrusted_img_source_is_removed(self):
+        html = '<p><img src="//evil.example.com/tracker.png" alt="x"></p>'
+        result = sanitize_closeout_html_for_email(
+            html, site_url="https://club.example.com"
+        )
+        assert "evil.example.com" not in result
+        assert "tracker.png" not in result
+
     def test_background_url_is_stripped_from_inline_style(self):
         html = (
             '<p style="background:url(https://evil.example.com/bg.png);'

--- a/logsheet/tests/test_finalization_email.py
+++ b/logsheet/tests/test_finalization_email.py
@@ -123,6 +123,33 @@ class TestSanitizeCloseoutHtml(SimpleTestCase):
         assert "evil.example.com" not in result
         assert "tracker.png" not in result
 
+    def test_trusted_same_origin_img_source_is_preserved(self):
+        html = '<p><img src="https://club.example.com/media/tinymce/photo.jpg" alt="x"></p>'
+        result = sanitize_closeout_html_for_email(
+            html, site_url="https://club.example.com"
+        )
+        assert 'src="https://club.example.com/media/tinymce/photo.jpg"' in result
+
+    @override_settings(
+        MEDIA_URL="https://storage.googleapis.com/demo-bucket/ssc/media/"
+    )
+    def test_media_storage_host_img_source_is_preserved(self):
+        html = '<p><img src="https://storage.googleapis.com/demo-bucket/ssc/media/tinymce/photo.jpg" alt="x"></p>'
+        result = sanitize_closeout_html_for_email(
+            html, site_url="https://club.example.com"
+        )
+        assert (
+            'src="https://storage.googleapis.com/demo-bucket/ssc/media/tinymce/photo.jpg"'
+            in result
+        )
+
+    def test_relative_media_img_source_is_absolutized(self):
+        html = '<p><img src="/media/tinymce/photo.jpg" alt="x"></p>'
+        result = sanitize_closeout_html_for_email(
+            html, site_url="https://club.example.com"
+        )
+        assert 'src="https://club.example.com/media/tinymce/photo.jpg"' in result
+
     def test_background_url_is_stripped_from_inline_style(self):
         html = (
             '<p style="background:url(https://evil.example.com/bg.png);'
@@ -273,6 +300,22 @@ class TestGetFinalizationEmailContext:
         assert "All clear." in ctx["safety_issues_html"]
         assert "Good day." in ctx["operations_summary_html"]
         assert ctx["equipment_issues_html"] == ""
+
+    def test_closeout_context_preserves_embedded_images(self):
+        closeout = self.logsheet.closeout
+        closeout.equipment_issues = (
+            '<p><img src="/media/tinymce/photo.jpg" width="480" height="640"></p>'
+        )
+        closeout.save()
+
+        ctx = get_finalization_email_context(
+            self.logsheet, site_url="https://club.example.com"
+        )
+
+        assert (
+            'src="https://club.example.com/media/tinymce/photo.jpg"'
+            in ctx["equipment_issues_html"]
+        )
 
     def test_flights_list_is_empty_when_no_flights(self):
         ctx = get_finalization_email_context(self.logsheet)

--- a/logsheet/tests/test_finalization_email.py
+++ b/logsheet/tests/test_finalization_email.py
@@ -143,6 +143,17 @@ class TestSanitizeCloseoutHtml(SimpleTestCase):
             in result
         )
 
+    @override_settings(
+        MEDIA_URL="https://storage.googleapis.com/demo-bucket/ssc/media/"
+    )
+    def test_other_storage_bucket_img_source_is_removed(self):
+        html = '<p><img src="https://storage.googleapis.com/other-bucket/ssc/media/tinymce/tracker.png" alt="x"></p>'
+        result = sanitize_closeout_html_for_email(
+            html, site_url="https://club.example.com"
+        )
+        assert "other-bucket" not in result
+        assert "tracker.png" not in result
+
     def test_relative_media_img_source_is_absolutized(self):
         html = '<p><img src="/media/tinymce/photo.jpg" alt="x"></p>'
         result = sanitize_closeout_html_for_email(

--- a/logsheet/utils/finalization_email.py
+++ b/logsheet/utils/finalization_email.py
@@ -151,20 +151,31 @@ def _make_pdf_link_from_embed(match, site_url):
     )
 
 
-def _trusted_email_image_hosts(site_url=None):
-    """Return allowed hosts for inline images rendered into member emails."""
-    trusted_hosts = {
-        "img.youtube.com",
-        "i.ytimg.com",
+def _trusted_email_image_prefixes(site_url=None):
+    """Return allowed URL prefixes for inline images rendered into member emails."""
+    trusted_prefixes = {
+        "https://img.youtube.com/",
+        "https://i.ytimg.com/",
     }
 
     for candidate in (site_url, getattr(settings, "MEDIA_URL", "") or ""):
         parsed = urlparse(candidate)
-        hostname = (parsed.hostname or "").lower()
-        if parsed.scheme in ("http", "https") and hostname:
-            trusted_hosts.add(str(hostname))
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            continue
 
-    return trusted_hosts
+        path = (
+            parsed.path.rstrip("/")
+            if isinstance(parsed.path, str)
+            else parsed.path.decode("utf-8", errors="ignore").rstrip("/")
+        )
+        prefix = f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+        if path:
+            prefix = f"{prefix}{path}/"
+        else:
+            prefix = f"{prefix}/"
+        trusted_prefixes.add(prefix)
+
+    return trusted_prefixes
 
 
 def _normalize_img_src_for_email(raw_url, site_url=None):
@@ -175,6 +186,19 @@ def _normalize_img_src_for_email(raw_url, site_url=None):
     if not parsed.scheme and raw_url.startswith("/") and site_url:
         return build_absolute_url(raw_url, canonical=site_url)
     return raw_url
+
+
+def _normalized_absolute_url_for_compare(raw_url):
+    """Normalize absolute URLs for prefix comparison in trusted image checks."""
+    parsed = urlparse(raw_url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return ""
+
+    path = parsed.path or "/"
+    normalized = f"{parsed.scheme.lower()}://{parsed.netloc.lower()}{path}"
+    if parsed.query:
+        normalized = f"{normalized}?{parsed.query}"
+    return normalized
 
 
 def _normalize_img_tags_for_email(html, site_url=None):
@@ -238,7 +262,7 @@ _EMAIL_ALLOWED_TAGS = [
 
 def _email_allowed_attribute(site_url=None):
     """Return a bleach attribute filter for email-bound HTML."""
-    trusted_image_hosts = _trusted_email_image_hosts(site_url)
+    trusted_image_prefixes = _trusted_email_image_prefixes(site_url)
 
     def _allow(tag, name, value):
         # Global attributes permitted on every element
@@ -248,9 +272,10 @@ def _email_allowed_attribute(site_url=None):
             return name in ("href", "target", "rel")
         if tag == "img":
             if name == "src":
-                parsed = urlparse(value)
-                return parsed.scheme in ("http", "https") and (
-                    (parsed.hostname or "").lower() in trusted_image_hosts
+                normalized_value = _normalized_absolute_url_for_compare(value)
+                return bool(normalized_value) and any(
+                    normalized_value.startswith(prefix)
+                    for prefix in trusted_image_prefixes
                 )
             return name in ("alt", "width", "height", "style")
         if tag in ("td", "th"):
@@ -329,17 +354,21 @@ def sanitize_closeout_html_for_email(html, site_url=None):
     - YouTube ``<iframe>`` → linked thumbnail image
     - Google Docs PDF viewer ``<iframe>`` → styled "View PDF" link
     - Bare ``<embed>``/``<object>`` for .pdf files → styled "View PDF" link
+    - Relative ``img[src]`` values → absolute first-party URLs when ``site_url`` is set
 
-    Relative PDF URLs (e.g. ``/media/uploads/doc.pdf``) are converted to
-    absolute using ``site_url`` so they resolve correctly in email clients.
-    In production, pass the canonical site origin (an absolute site URL);
-    ``get_finalization_email_context`` already provides this via its
-    resolved ``site_url`` argument.
+    Relative PDF URLs (e.g. ``/media/uploads/doc.pdf``) and relative image URLs
+    (e.g. ``/media/tinymce/photo.jpg``) are converted to absolute using
+    ``site_url`` so they resolve correctly in email clients. The follow-on
+    Bleach sanitization only preserves ``img[src]`` values that match trusted
+    URL prefixes: the canonical site origin, the configured ``MEDIA_URL``
+    prefix, and the specific YouTube thumbnail prefixes used by embed
+    replacements.
 
     Args:
         html (str): Raw HTML from a TinyMCE HTMLField.
         site_url (str | None): Canonical site origin used to absolutise
-            relative PDF URLs.  When ``None``, relative URLs are left as-is.
+            relative PDF and image URLs. When ``None``, relative URLs are left
+            as-is.
 
     Returns:
         str: HTML safe for rendering inside an email.
@@ -352,10 +381,10 @@ def sanitize_closeout_html_for_email(html, site_url=None):
     )
     html = _PDF_EMBED_RE.sub(lambda m: _make_pdf_link_from_embed(m, site_url), html)
     html = _normalize_img_tags_for_email(html, site_url)
-    # Allowlist-sanitize the remaining HTML.  Unknown tags are stripped
-    # (strip=True), img[src] is restricted to trusted CDN hosts only (see
-    # _email_allowed_attribute), and the CSS shorthand "background" is
-    # excluded to prevent url()-based beacons.
+    # Allowlist-sanitize the remaining HTML. Unknown tags are stripped
+    # (strip=True), img[src] is kept only for trusted URL prefixes after
+    # normalization, and the CSS shorthand "background" is excluded to
+    # prevent url()-based beacons.
     html = _bleach_clean_email_html(html, site_url=site_url)
     return html
 

--- a/logsheet/utils/finalization_email.py
+++ b/logsheet/utils/finalization_email.py
@@ -74,6 +74,11 @@ _ANCHOR_TAG_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+_IMG_SRC_RE = re.compile(
+    r'(<img\b[^>]*\bsrc=["\'])([^"\']+)(["\'][^>]*>)',
+    re.IGNORECASE | re.DOTALL,
+)
+
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
@@ -146,6 +151,42 @@ def _make_pdf_link_from_embed(match, site_url):
     )
 
 
+def _trusted_email_image_hosts(site_url=None):
+    """Return allowed hosts for inline images rendered into member emails."""
+    trusted_hosts = {
+        "img.youtube.com",
+        "i.ytimg.com",
+    }
+
+    for candidate in (site_url, getattr(settings, "MEDIA_URL", "") or ""):
+        parsed = urlparse(candidate)
+        hostname = (parsed.hostname or "").lower()
+        if parsed.scheme in ("http", "https") and hostname:
+            trusted_hosts.add(str(hostname))
+
+    return trusted_hosts
+
+
+def _normalize_img_src_for_email(raw_url, site_url=None):
+    """Normalize image URLs so relative first-party images work in emails."""
+    parsed = urlparse(raw_url)
+    if parsed.scheme in ("http", "https"):
+        return raw_url
+    if not parsed.scheme and raw_url.startswith("/") and site_url:
+        return build_absolute_url(raw_url, canonical=site_url)
+    return raw_url
+
+
+def _normalize_img_tags_for_email(html, site_url=None):
+    """Normalize img src attributes before Bleach allowlist filtering."""
+
+    def _replace(match):
+        normalized_src = _normalize_img_src_for_email(match.group(2), site_url)
+        return f"{match.group(1)}{normalized_src}{match.group(3)}"
+
+    return _IMG_SRC_RE.sub(_replace, html)
+
+
 # Bleach allowlist for closeout HTML rendered inside emails.
 # Permits common formatting and table tags produced by TinyMCE while
 # stripping any script, object, or embed elements not already handled by
@@ -195,36 +236,36 @@ _EMAIL_ALLOWED_TAGS = [
 ]
 
 
-def _email_allowed_attribute(tag, name, value):
-    """
-    Callable bleach attribute filter for email-bound HTML.
+def _email_allowed_attribute(site_url=None):
+    """Return a bleach attribute filter for email-bound HTML."""
+    trusted_image_hosts = _trusted_email_image_hosts(site_url)
 
-    Restricts ``img[src]`` to trusted image CDN hosts so that remote tracking
-    pixels embedded in TinyMCE content cannot reach member inboxes.
-
-    Attributes are allowlisted per tag (plus a small global set); any attribute
-    not explicitly permitted is rejected.
-    """
-    # Global attributes permitted on every element
-    if name in ("style", "class", "title"):
-        return True
-    if tag == "a":
-        return name in ("href", "target", "rel")
-    if tag == "img":
-        if name == "src":
-            # Only allow images served from trusted CDN hosts (e.g. YouTube
-            # thumbnails added by the embed-replacement functions above).
-            parsed = urlparse(value)
-            return parsed.scheme in ("http", "https") and (parsed.hostname or "") in (
-                "img.youtube.com",
-                "i.ytimg.com",
+    def _allow(tag, name, value):
+        # Global attributes permitted on every element
+        if name in ("style", "class", "title"):
+            return True
+        if tag == "a":
+            return name in ("href", "target", "rel")
+        if tag == "img":
+            if name == "src":
+                parsed = urlparse(value)
+                return parsed.scheme in ("http", "https") and (
+                    (parsed.hostname or "").lower() in trusted_image_hosts
+                )
+            return name in ("alt", "width", "height", "style")
+        if tag in ("td", "th"):
+            return name in ("colspan", "rowspan", "align", "valign", "style")
+        if tag == "table":
+            return name in (
+                "border",
+                "cellpadding",
+                "cellspacing",
+                "width",
+                "style",
             )
-        return name in ("alt", "width", "height", "style")
-    if tag in ("td", "th"):
-        return name in ("colspan", "rowspan", "align", "valign", "style")
-    if tag == "table":
-        return name in ("border", "cellpadding", "cellspacing", "width", "style")
-    return False
+        return False
+
+    return _allow
 
 
 _EMAIL_CSS_SANITIZER = CSSSanitizer(
@@ -268,12 +309,12 @@ _EMAIL_CSS_SANITIZER = CSSSanitizer(
 )
 
 
-def _bleach_clean_email_html(html: str) -> str:
+def _bleach_clean_email_html(html: str, site_url=None) -> str:
     """Run bleach allowlist sanitization on HTML intended for email delivery."""
     return bleach.clean(
         html,
         tags=_EMAIL_ALLOWED_TAGS,
-        attributes=_email_allowed_attribute,
+        attributes=_email_allowed_attribute(site_url),
         css_sanitizer=_EMAIL_CSS_SANITIZER,
         strip=True,
     )
@@ -310,11 +351,12 @@ def sanitize_closeout_html_for_email(html, site_url=None):
         lambda m: _make_pdf_link_from_gdocs_params(m.group(1), site_url), html
     )
     html = _PDF_EMBED_RE.sub(lambda m: _make_pdf_link_from_embed(m, site_url), html)
+    html = _normalize_img_tags_for_email(html, site_url)
     # Allowlist-sanitize the remaining HTML.  Unknown tags are stripped
     # (strip=True), img[src] is restricted to trusted CDN hosts only (see
     # _email_allowed_attribute), and the CSS shorthand "background" is
     # excluded to prevent url()-based beacons.
-    html = _bleach_clean_email_html(html)
+    html = _bleach_clean_email_html(html, site_url=site_url)
     return html
 
 

--- a/logsheet/utils/finalization_email.py
+++ b/logsheet/utils/finalization_email.py
@@ -183,7 +183,14 @@ def _normalize_img_src_for_email(raw_url, site_url=None):
     parsed = urlparse(raw_url)
     if parsed.scheme in ("http", "https"):
         return raw_url
-    if not parsed.scheme and raw_url.startswith("/") and site_url:
+    # Protocol-relative URLs (e.g. //evil.example.com/...) must not be
+    # absolutized onto site_url; leave them for Bleach to strip.
+    if (
+        not parsed.scheme
+        and not raw_url.startswith("//")
+        and raw_url.startswith("/")
+        and site_url
+    ):
         return build_absolute_url(raw_url, canonical=site_url)
     return raw_url
 


### PR DESCRIPTION
## Summary

Fixes broken embedded images in logsheet ops summary emails by preserving trusted first-party closeout images during email HTML sanitization.

Fixes #886

## Problem

The closeout page rendered embedded TinyMCE images correctly, but the outbound ops summary email dropped the `src` attribute from `<img>` tags while leaving width and height behind. That produced broken image placeholders in the email body.

The root cause was the finalization email sanitizer in `logsheet/utils/finalization_email.py`: it allowed `<img>` tags, but only preserved `img[src]` for a narrow YouTube thumbnail allowlist.

## What Changed

- Added image URL normalization before Bleach sanitization so relative first-party media URLs can be converted to absolute URLs for email clients.
- Expanded trusted image handling to allow:
  - same-origin image URLs derived from the canonical site URL
  - configured media-storage hosts (for production storage-backed TinyMCE uploads)
  - existing YouTube thumbnail hosts
- Kept blocking arbitrary external image hosts so remote tracker images are still removed.
- Added regression tests for:
  - same-origin embedded images
  - storage-host embedded images
  - relative `/media/...` image URLs
  - end-to-end closeout context rendering
  - continued stripping of untrusted external tracker images

## Validation

Validated with:

- `python -m pytest logsheet/tests/test_finalization_email.py -q`

## Notes

This PR intentionally fixes the email sanitization layer rather than the template layer, because the template was already rendering sanitized closeout HTML correctly; the breakage was in the sanitizer's `img[src]` allowlist.
