### PR TITLE
Fix post-login redirect (#674) and board-bounces email sender (#846)

### DIFF
--- a/duty_roster/tests/test_roster_published.py
+++ b/duty_roster/tests/test_roster_published.py
@@ -175,7 +175,7 @@ class TestSendRosterPublishedNotifications:
         )
 
         with patch(
-            "duty_roster.utils.email.EmailMultiAlternatives"
+            "duty_roster.utils.email.DevModeEmailMultiAlternatives"
         ) as mock_email_class:
             mock_email = MagicMock()
             mock_email_class.return_value = mock_email
@@ -205,7 +205,7 @@ class TestSendRosterPublishedNotifications:
         )
 
         with patch(
-            "duty_roster.utils.email.EmailMultiAlternatives"
+            "duty_roster.utils.email.DevModeEmailMultiAlternatives"
         ) as mock_email_class:
             mock_email = MagicMock()
             mock_email_class.return_value = mock_email
@@ -244,7 +244,7 @@ class TestSendRosterPublishedNotifications:
         )
 
         with patch(
-            "duty_roster.utils.email.EmailMultiAlternatives"
+            "duty_roster.utils.email.DevModeEmailMultiAlternatives"
         ) as mock_email_class:
             mock_email = MagicMock()
             mock_email_class.return_value = mock_email
@@ -283,7 +283,7 @@ class TestSendRosterPublishedNotifications:
         )
 
         with patch(
-            "duty_roster.utils.email.EmailMultiAlternatives"
+            "duty_roster.utils.email.DevModeEmailMultiAlternatives"
         ) as mock_email_class:
             mock_email = MagicMock()
             mock_email_class.return_value = mock_email
@@ -311,7 +311,7 @@ class TestSendRosterPublishedNotifications:
         )
 
         with patch(
-            "duty_roster.utils.email.EmailMultiAlternatives"
+            "duty_roster.utils.email.DevModeEmailMultiAlternatives"
         ) as mock_email_class:
             mock_email = MagicMock()
             mock_email_class.return_value = mock_email
@@ -335,7 +335,7 @@ class TestSendRosterPublishedNotifications:
         )
 
         with patch(
-            "duty_roster.utils.email.EmailMultiAlternatives"
+            "duty_roster.utils.email.DevModeEmailMultiAlternatives"
         ) as mock_email_class:
             mock_email = MagicMock()
             mock_email.send.side_effect = Exception("SMTP connection failed")

--- a/duty_roster/utils/email.py
+++ b/duty_roster/utils/email.py
@@ -8,7 +8,7 @@ from django.template.loader import render_to_string
 from duty_roster.utils.ics import generate_roster_ics
 from siteconfig.models import SiteConfiguration
 from siteconfig.utils import get_role_title
-from utils.email import send_mail
+from utils.email import enforce_noreply_from_email, send_mail
 from utils.email_helpers import get_absolute_club_logo_url
 from utils.url_helpers import build_absolute_url, get_canonical_url
 
@@ -265,7 +265,7 @@ def send_roster_published_notifications(year, month, assignments):
         email = EmailMultiAlternatives(
             subject=subject,
             body=text_message,
-            from_email=email_config["from_email"],
+            from_email=enforce_noreply_from_email(email_config["from_email"]),
             to=[member.email],
         )
         email.attach_alternative(html_message, "text/html")

--- a/duty_roster/utils/email.py
+++ b/duty_roster/utils/email.py
@@ -2,13 +2,12 @@ from collections import defaultdict
 from datetime import date
 
 from django.conf import settings
-from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 
 from duty_roster.utils.ics import generate_roster_ics
 from siteconfig.models import SiteConfiguration
 from siteconfig.utils import get_role_title
-from utils.email import enforce_noreply_from_email, send_mail
+from utils.email import DevModeEmailMultiAlternatives, send_mail
 from utils.email_helpers import get_absolute_club_logo_url
 from utils.url_helpers import build_absolute_url, get_canonical_url
 
@@ -262,10 +261,10 @@ def send_roster_published_notifications(year, month, assignments):
             f"[{email_config['club_name']}] Your Duty Assignments for {month_name}"
         )
 
-        email = EmailMultiAlternatives(
+        email = DevModeEmailMultiAlternatives(
             subject=subject,
             body=text_message,
-            from_email=enforce_noreply_from_email(email_config["from_email"]),
+            from_email=email_config["from_email"],
             to=[member.email],
         )
         email.attach_alternative(html_message, "text/html")

--- a/infrastructure/ansible/roles/postfix/templates/maillist-rewriter.py.j2
+++ b/infrastructure/ansible/roles/postfix/templates/maillist-rewriter.py.j2
@@ -75,9 +75,23 @@ def rewrite_headers(msg, recipient):
     Rewrite headers Mailman-style:
     - Save original From to Reply-To
     - Rewrite From to list-bounces address with original name
+
+    Internal/automated senders (same domain as the list, or local-part 'noreply')
+    are passed through unchanged so that transactional notification emails do not
+    appear to come from a bounces address (issue #846).
     """
     original_from = msg.get('From', '')
     original_name, original_email = parseaddr(original_from)
+
+    # Do not rewrite headers for same-domain or noreply senders — these are
+    # automated/transactional emails from the application, not user posts to
+    # the list.  Rewriting them would make notifications appear to come from
+    # "board-bounces@domain" instead of "noreply@domain".
+    if original_email:
+        sender_local, _, sender_domain = original_email.partition('@')
+        _, _, list_domain = recipient.lower().partition('@')
+        if sender_domain.lower() == list_domain or sender_local.lower() == 'noreply':
+            return msg
 
     # Get list address from recipient
     recipient_lower = recipient.lower()

--- a/infrastructure/ansible/roles/postfix/templates/maillist-rewriter.py.j2
+++ b/infrastructure/ansible/roles/postfix/templates/maillist-rewriter.py.j2
@@ -76,36 +76,37 @@ def rewrite_headers(msg, recipient, envelope_sender=None):
     - Save original From to Reply-To
     - Rewrite From to list-bounces address with original name
 
-    Internal/automated senders (same domain as the list, or local-part 'noreply')
-    are passed through unchanged so that transactional notification emails do not
-    appear to come from a bounces address (issue #846).
+    The automated sender ``noreply@<list_domain>`` is passed through unchanged
+    so that transactional notification emails do not appear to come from a
+    bounces address (issue #846).
 
-    The guard uses ``envelope_sender`` (the SMTP envelope sender passed by
-    Postfix, which is verified at the MTA level and cannot be trivially spoofed)
-    when available.  It falls back to parsing the ``From`` header only when no
-    envelope sender is provided (e.g. in unit tests).
+    The guard uses ``envelope_sender`` (the SMTP envelope sender from the
+    ``MAIL FROM`` command as seen by Postfix) when available. This is preferred
+    for the passthrough check because it is SMTP-session metadata rather than a
+    message header, but it is still client-supplied and should not be treated as
+    authenticated or unforgeable. It falls back to parsing the ``From`` header
+    only when no envelope sender is provided (e.g. in unit tests).
     """
     # Determine the effective sender address for the passthrough guard.
-    # Prefer the SMTP envelope sender: it is set by Postfix from the MAIL FROM
-    # command and cannot be overridden by the message body, so an unauthenticated
-    # external sender cannot forge it to bypass list rewriting.
+    # Prefer the SMTP envelope sender because it comes from the SMTP session's
+    # MAIL FROM command rather than the message headers/body. That makes it a
+    # better signal than the From header for this heuristic, but it is still
+    # client-provided SMTP metadata and not inherently trustworthy.
     guard_email = envelope_sender or parseaddr(msg.get('From', ''))[1]
 
     original_from = msg.get('From', '')
     original_name, original_email = parseaddr(original_from)
 
-    # Do not rewrite headers for same-domain or noreply senders — these are
-    # automated/transactional emails from the application, not user posts to
-    # the list.  Rewriting them would make notifications appear to come from
-    # "board-bounces@domain" instead of "noreply@domain".
-    if guard_email:
-        sender_local, _, sender_domain = guard_email.partition('@')
-        _, _, list_domain = recipient.lower().partition('@')
-        if sender_domain.lower() == list_domain or sender_local.lower() == 'noreply':
-            return msg
-
     # Get list address from recipient
     recipient_lower = recipient.lower()
+    _, _, list_domain = recipient_lower.partition('@')
+
+    # Only allow a narrow passthrough for the exact automated sender address
+    # used by the application on the list domain.  Do not exempt arbitrary
+    # same-domain or generic "noreply" senders, because on port 25 the
+    # envelope sender is client-supplied and not inherently trustworthy.
+    if guard_email and guard_email.lower() == f"noreply@{list_domain}":
+        return msg
 
     # Extract list name and domain (e.g., "webmaster" from "webmaster@domain.com")
     list_local, list_domain = recipient_lower.split('@', 1)

--- a/infrastructure/ansible/roles/postfix/templates/maillist-rewriter.py.j2
+++ b/infrastructure/ansible/roles/postfix/templates/maillist-rewriter.py.j2
@@ -70,7 +70,7 @@ def _load_lists_from_virtual(virtual_file='/etc/postfix/virtual'):
 ALL_KNOWN_LISTS = MAILING_LISTS | _load_lists_from_virtual()
 
 
-def rewrite_headers(msg, recipient):
+def rewrite_headers(msg, recipient, envelope_sender=None):
     """
     Rewrite headers Mailman-style:
     - Save original From to Reply-To
@@ -79,7 +79,18 @@ def rewrite_headers(msg, recipient):
     Internal/automated senders (same domain as the list, or local-part 'noreply')
     are passed through unchanged so that transactional notification emails do not
     appear to come from a bounces address (issue #846).
+
+    The guard uses ``envelope_sender`` (the SMTP envelope sender passed by
+    Postfix, which is verified at the MTA level and cannot be trivially spoofed)
+    when available.  It falls back to parsing the ``From`` header only when no
+    envelope sender is provided (e.g. in unit tests).
     """
+    # Determine the effective sender address for the passthrough guard.
+    # Prefer the SMTP envelope sender: it is set by Postfix from the MAIL FROM
+    # command and cannot be overridden by the message body, so an unauthenticated
+    # external sender cannot forge it to bypass list rewriting.
+    guard_email = envelope_sender or parseaddr(msg.get('From', ''))[1]
+
     original_from = msg.get('From', '')
     original_name, original_email = parseaddr(original_from)
 
@@ -87,8 +98,8 @@ def rewrite_headers(msg, recipient):
     # automated/transactional emails from the application, not user posts to
     # the list.  Rewriting them would make notifications appear to come from
     # "board-bounces@domain" instead of "noreply@domain".
-    if original_email:
-        sender_local, _, sender_domain = original_email.partition('@')
+    if guard_email:
+        sender_local, _, sender_domain = guard_email.partition('@')
         _, _, list_domain = recipient.lower().partition('@')
         if sender_domain.lower() == list_domain or sender_local.lower() == 'noreply':
             return msg
@@ -277,9 +288,11 @@ def main():
             sys.stderr.write(f"maillist-rewriter: SMTP passthrough failed: {e}\n")
             sys.exit(os.EX_TEMPFAIL)
 
-    # Rewrite if this is going to a mailing list
+    # Rewrite if this is going to a mailing list.
+    # Pass the SMTP envelope sender so the passthrough guard uses a
+    # Postfix-verified address instead of the (spoofable) From header.
     if original_to and original_to.lower() in ALL_KNOWN_LISTS:
-        msg = rewrite_headers(msg, original_to)
+        msg = rewrite_headers(msg, original_to, envelope_sender=sender)
 
     # Reinject to port 10025 (bypasses content_filter)
     # CRITICAL: Use rewritten From header as envelope sender for SMTP2Go verification

--- a/infrastructure/ansible/roles/postfix/test_maillist_rewriter.py
+++ b/infrastructure/ansible/roles/postfix/test_maillist_rewriter.py
@@ -291,13 +291,13 @@ def test_reverse_lookup_uses_exact_alias_token_not_prefix_match():
     assert original_to == "members@skylinesoaring.org"
 
 
-def test_rewrite_headers_skips_same_domain_sender():
-    """Automated emails from the same domain as the list are not rewritten (issue #846).
+def test_rewrite_headers_skips_exact_noreply_at_list_domain():
+    """Only the exact noreply@<list_domain> address is passed through unchanged (issue #846).
 
-    When Django sends a notification to board@skylinesoaring.org the SMTP envelope
-    sender is noreply@skylinesoaring.org (set by Postfix, not the From header).
-    The guard must use envelope_sender, not the From header, so that an external
-    sender cannot spoof their way out of list rewriting.
+    When Django sends a notification from noreply@skylinesoaring.org to
+    board@skylinesoaring.org the envelope sender matches the narrow passthrough
+    condition (noreply@skylinesoaring.org == noreply@skylinesoaring.org) and the
+    headers must not be rewritten.
     """
     ns = load_template_namespace()
     rewrite_headers = get_callable(ns, "rewrite_headers")
@@ -318,12 +318,13 @@ def test_rewrite_headers_skips_same_domain_sender():
     assert result["Reply-To"] is None
 
 
-def test_rewrite_headers_skips_noreply_sender_any_domain():
-    """Any SMTP envelope sender whose local-part is 'noreply' is treated as automated (issue #846).
+def test_rewrite_headers_rewrites_noreply_sender_from_different_domain():
+    """A noreply sender on a *different* domain than the list is still rewritten.
 
-    This catches cases where the application sends from noreply@manage2soar.com
-    to a list address on a different subdomain, e.g. board@ssc.manage2soar.com.
-    The guard uses envelope_sender so a spoofed From header cannot bypass rewriting.
+    The passthrough is intentionally narrow: only noreply@<list_domain> is exempt.
+    If the application sends from noreply@manage2soar.com to a list on
+    ssc.manage2soar.com the envelope sender does not match noreply@ssc.manage2soar.com,
+    so Mailman-style rewriting must still occur.
     """
     ns = load_template_namespace()
     rewrite_headers = get_callable(ns, "rewrite_headers")
@@ -331,15 +332,17 @@ def test_rewrite_headers_skips_noreply_sender_any_domain():
     msg = EmailMessage()
     msg["From"] = "noreply@manage2soar.com"
     msg["To"] = "board@ssc.manage2soar.com"
-    msg["Subject"] = "Cross-domain automated notification"
+    msg["Subject"] = "Cross-domain notification"
     msg.set_content("Notification body")
 
     result = rewrite_headers(
         msg, "board@ssc.manage2soar.com", envelope_sender="noreply@manage2soar.com"
     )
 
-    assert result["From"] == "noreply@manage2soar.com"
-    assert result["Reply-To"] is None
+    # Cross-domain noreply must be rewritten — the envelope sender is not the
+    # list's own noreply address.
+    assert "board-bounces@ssc.manage2soar.com" in result["From"]
+    assert result["Reply-To"] is not None
 
 
 def test_rewrite_headers_still_rewrites_external_sender():

--- a/infrastructure/ansible/roles/postfix/test_maillist_rewriter.py
+++ b/infrastructure/ansible/roles/postfix/test_maillist_rewriter.py
@@ -289,3 +289,67 @@ def test_reverse_lookup_uses_exact_alias_token_not_prefix_match():
         original_to = detect_original_list(msg, recipients)
 
     assert original_to == "members@skylinesoaring.org"
+
+
+def test_rewrite_headers_skips_same_domain_sender():
+    """Automated emails from the same domain as the list are not rewritten (issue #846).
+
+    When Django sends a notification to board@skylinesoaring.org the envelope
+    sender is noreply@skylinesoaring.org.  Rewriting that From header to
+    board-bounces@skylinesoaring.org is incorrect; the message should pass through
+    unchanged so recipients see the original noreply address.
+    """
+    ns = load_template_namespace()
+    rewrite_headers = get_callable(ns, "rewrite_headers")
+
+    msg = EmailMessage()
+    msg["From"] = "noreply@skylinesoaring.org"
+    msg["To"] = "board@skylinesoaring.org"
+    msg["Subject"] = "Automated notification"
+    msg.set_content("Notification body")
+
+    result = rewrite_headers(msg, "board@skylinesoaring.org")
+
+    # From header must be unchanged
+    assert result["From"] == "noreply@skylinesoaring.org"
+    # No Reply-To should be injected for automated messages
+    assert result["Reply-To"] is None
+
+
+def test_rewrite_headers_skips_noreply_sender_any_domain():
+    """Any sender whose local-part is 'noreply' is treated as automated (issue #846).
+
+    This catches cases where the application sends from noreply@manage2soar.com
+    to a list address on a different subdomain, e.g. board@ssc.manage2soar.com.
+    """
+    ns = load_template_namespace()
+    rewrite_headers = get_callable(ns, "rewrite_headers")
+
+    msg = EmailMessage()
+    msg["From"] = "noreply@manage2soar.com"
+    msg["To"] = "board@ssc.manage2soar.com"
+    msg["Subject"] = "Cross-domain automated notification"
+    msg.set_content("Notification body")
+
+    result = rewrite_headers(msg, "board@ssc.manage2soar.com")
+
+    assert result["From"] == "noreply@manage2soar.com"
+    assert result["Reply-To"] is None
+
+
+def test_rewrite_headers_still_rewrites_external_sender():
+    """External senders to a list are still rewritten normally (regression guard)."""
+    ns = load_template_namespace()
+    rewrite_headers = get_callable(ns, "rewrite_headers")
+
+    msg = EmailMessage()
+    msg["From"] = "John Doe <john@gmail.com>"
+    msg["To"] = "board@skylinesoaring.org"
+    msg["Subject"] = "External post to list"
+    msg.set_content("External body")
+
+    result = rewrite_headers(msg, "board@skylinesoaring.org")
+
+    assert "board-bounces@skylinesoaring.org" in result["From"]
+    assert "John Doe via Board" in result["From"]
+    assert "john@gmail.com" in result["Reply-To"]

--- a/infrastructure/ansible/roles/postfix/test_maillist_rewriter.py
+++ b/infrastructure/ansible/roles/postfix/test_maillist_rewriter.py
@@ -294,10 +294,10 @@ def test_reverse_lookup_uses_exact_alias_token_not_prefix_match():
 def test_rewrite_headers_skips_same_domain_sender():
     """Automated emails from the same domain as the list are not rewritten (issue #846).
 
-    When Django sends a notification to board@skylinesoaring.org the envelope
-    sender is noreply@skylinesoaring.org.  Rewriting that From header to
-    board-bounces@skylinesoaring.org is incorrect; the message should pass through
-    unchanged so recipients see the original noreply address.
+    When Django sends a notification to board@skylinesoaring.org the SMTP envelope
+    sender is noreply@skylinesoaring.org (set by Postfix, not the From header).
+    The guard must use envelope_sender, not the From header, so that an external
+    sender cannot spoof their way out of list rewriting.
     """
     ns = load_template_namespace()
     rewrite_headers = get_callable(ns, "rewrite_headers")
@@ -308,7 +308,9 @@ def test_rewrite_headers_skips_same_domain_sender():
     msg["Subject"] = "Automated notification"
     msg.set_content("Notification body")
 
-    result = rewrite_headers(msg, "board@skylinesoaring.org")
+    result = rewrite_headers(
+        msg, "board@skylinesoaring.org", envelope_sender="noreply@skylinesoaring.org"
+    )
 
     # From header must be unchanged
     assert result["From"] == "noreply@skylinesoaring.org"
@@ -317,10 +319,11 @@ def test_rewrite_headers_skips_same_domain_sender():
 
 
 def test_rewrite_headers_skips_noreply_sender_any_domain():
-    """Any sender whose local-part is 'noreply' is treated as automated (issue #846).
+    """Any SMTP envelope sender whose local-part is 'noreply' is treated as automated (issue #846).
 
     This catches cases where the application sends from noreply@manage2soar.com
     to a list address on a different subdomain, e.g. board@ssc.manage2soar.com.
+    The guard uses envelope_sender so a spoofed From header cannot bypass rewriting.
     """
     ns = load_template_namespace()
     rewrite_headers = get_callable(ns, "rewrite_headers")
@@ -331,7 +334,9 @@ def test_rewrite_headers_skips_noreply_sender_any_domain():
     msg["Subject"] = "Cross-domain automated notification"
     msg.set_content("Notification body")
 
-    result = rewrite_headers(msg, "board@ssc.manage2soar.com")
+    result = rewrite_headers(
+        msg, "board@ssc.manage2soar.com", envelope_sender="noreply@manage2soar.com"
+    )
 
     assert result["From"] == "noreply@manage2soar.com"
     assert result["Reply-To"] is None
@@ -348,8 +353,36 @@ def test_rewrite_headers_still_rewrites_external_sender():
     msg["Subject"] = "External post to list"
     msg.set_content("External body")
 
-    result = rewrite_headers(msg, "board@skylinesoaring.org")
+    result = rewrite_headers(
+        msg, "board@skylinesoaring.org", envelope_sender="john@gmail.com"
+    )
 
     assert "board-bounces@skylinesoaring.org" in result["From"]
     assert "John Doe via Board" in result["From"]
     assert "john@gmail.com" in result["Reply-To"]
+
+
+def test_rewrite_headers_external_spoofed_from_cannot_bypass_rewriting():
+    """An external sender cannot bypass rewriting by spoofing a same-domain From header.
+
+    If the SMTP envelope sender (john@gmail.com) is external, the message must be
+    rewritten even if the From header claims to be noreply@skylinesoaring.org.
+    Without using envelope_sender the previous From-header guard was bypassable.
+    """
+    ns = load_template_namespace()
+    rewrite_headers = get_callable(ns, "rewrite_headers")
+
+    msg = EmailMessage()
+    # Attacker spoofs From to look like internal noreply
+    msg["From"] = "noreply@skylinesoaring.org"
+    msg["To"] = "board@skylinesoaring.org"
+    msg["Subject"] = "Spoofed automated-looking post"
+    msg.set_content("Spam body")
+
+    # But the SMTP envelope sender is their real external address
+    result = rewrite_headers(
+        msg, "board@skylinesoaring.org", envelope_sender="attacker@gmail.com"
+    )
+
+    # Must be rewritten — the envelope sender is external
+    assert "board-bounces@skylinesoaring.org" in result["From"]

--- a/manage2soar/settings.py
+++ b/manage2soar/settings.py
@@ -221,6 +221,10 @@ SOCIAL_AUTH_PIPELINE = (
 # and editable only by the member or admin.
 SOCIAL_AUTH_PROTECTED_USER_FIELDS = ["first_name", "last_name"]
 
+# Issue #674: Preserve the ?next= redirect parameter through the Google OAuth2
+# redirect cycle so users land on the page they originally requested.
+SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ["next"]
+
 
 MESSAGE_TAGS = {
     messages.ERROR: "danger",  # maps Django "error" to Bootstrap "danger"

--- a/utils/email.py
+++ b/utils/email.py
@@ -321,3 +321,69 @@ class DevModeEmailMessage(EmailMessage):
             self.to = redirect_list
             self.cc = []
             self.bcc = []
+
+
+class DevModeEmailMultiAlternatives(EmailMultiAlternatives):
+    """EmailMultiAlternatives subclass with dev mode support.
+
+    Use this in place of EmailMultiAlternatives directly when you need HTML
+    alternatives, attachments, or other features beyond send_mail(), while
+    still honouring EMAIL_DEV_MODE redirection and the noreply From enforcement.
+
+    Example:
+        from utils.email import DevModeEmailMultiAlternatives
+
+        msg = DevModeEmailMultiAlternatives(
+            subject="Your roster",
+            body="Plain text",
+            from_email="noreply@example.com",
+            to=["member@example.com"],
+        )
+        msg.attach_alternative("<p>HTML</p>", "text/html")
+        msg.send()
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.from_email = enforce_noreply_from_email(self.from_email)
+        self._apply_dev_mode()
+
+    def _apply_dev_mode(self):
+        """Apply dev mode redirection if enabled."""
+        dev_mode, redirect_list = get_dev_mode_info()
+
+        if dev_mode:
+            if not redirect_list:
+                raise ValueError(
+                    "EMAIL_DEV_MODE is enabled but EMAIL_DEV_MODE_REDIRECT_TO is not set. "
+                    "Set EMAIL_DEV_MODE_REDIRECT_TO or disable EMAIL_DEV_MODE."
+                )
+
+            all_recipients = (
+                list(self.to or []) + list(self.cc or []) + list(self.bcc or [])
+            )
+
+            if not all_recipients:
+                recipients_info = "TO: (no recipients)"
+            else:
+                if len(all_recipients) > MAX_RECIPIENTS_IN_SUBJECT:
+                    shown = all_recipients[:MAX_RECIPIENTS_IN_SUBJECT]
+                    remaining = len(all_recipients) - MAX_RECIPIENTS_IN_SUBJECT
+                    recipients_info = (
+                        f"TO: {', '.join(shown)}, ... and {remaining} more"
+                    )
+                else:
+                    original_to = ", ".join(self.to) if self.to else "none"
+                    original_cc = ", ".join(self.cc) if self.cc else ""
+                    original_bcc = ", ".join(self.bcc) if self.bcc else ""
+
+                    recipients_info = f"TO: {original_to}"
+                    if original_cc:
+                        recipients_info += f", CC: {original_cc}"
+                    if original_bcc:
+                        recipients_info += f", BCC: {original_bcc}"
+
+            self.subject = f"[DEV MODE] {self.subject} ({recipients_info})"
+            self.to = redirect_list
+            self.cc = []
+            self.bcc = []

--- a/utils/email.py
+++ b/utils/email.py
@@ -251,35 +251,21 @@ def send_mass_mail(
     )
 
 
-class DevModeEmailMessage(EmailMessage):
-    """EmailMessage subclass with dev mode support.
+class _DevModeApplyMixin:
+    """Mixin that applies EMAIL_DEV_MODE redirection to outbound email objects.
 
-    When EMAIL_DEV_MODE is enabled, emails are redirected to
-    EMAIL_DEV_MODE_REDIRECT_TO address(es).
-
-    Use this class when you need to construct EmailMessage objects directly
-    instead of using send_mail(). This is useful for HTML emails with attachments
-    or when you need more control over the email structure.
-
-    Example:
-        from utils.email import DevModeEmailMessage
-
-        msg = DevModeEmailMessage(
-            subject="Welcome!",
-            body="Your account is ready.",
-            from_email="noreply@example.com",
-            to=["user@example.com"],
-        )
-        msg.send()
+    Both DevModeEmailMessage and DevModeEmailMultiAlternatives share this logic.
+    Centralising it here prevents the two classes from drifting when the
+    redirection behaviour (subject annotation, cc/bcc clearing, redirect list
+    validation) needs to change.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.from_email = enforce_noreply_from_email(self.from_email)
-        self._apply_dev_mode()
-
     def _apply_dev_mode(self):
-        """Apply dev mode redirection if enabled."""
+        """Redirect to EMAIL_DEV_MODE_REDIRECT_TO when dev mode is enabled.
+
+        Raises:
+            ValueError: If dev mode is enabled but no redirect address is configured.
+        """
         dev_mode, redirect_list = get_dev_mode_info()
 
         if dev_mode:
@@ -323,7 +309,35 @@ class DevModeEmailMessage(EmailMessage):
             self.bcc = []
 
 
-class DevModeEmailMultiAlternatives(EmailMultiAlternatives):
+class DevModeEmailMessage(_DevModeApplyMixin, EmailMessage):
+    """EmailMessage subclass with dev mode support.
+
+    When EMAIL_DEV_MODE is enabled, emails are redirected to
+    EMAIL_DEV_MODE_REDIRECT_TO address(es).
+
+    Use this class when you need to construct EmailMessage objects directly
+    instead of using send_mail(). This is useful for HTML emails with attachments
+    or when you need more control over the email structure.
+
+    Example:
+        from utils.email import DevModeEmailMessage
+
+        msg = DevModeEmailMessage(
+            subject="Welcome!",
+            body="Your account is ready.",
+            from_email="noreply@example.com",
+            to=["user@example.com"],
+        )
+        msg.send()
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.from_email = enforce_noreply_from_email(self.from_email)
+        self._apply_dev_mode()
+
+
+class DevModeEmailMultiAlternatives(_DevModeApplyMixin, EmailMultiAlternatives):
     """EmailMultiAlternatives subclass with dev mode support.
 
     Use this in place of EmailMultiAlternatives directly when you need HTML
@@ -347,43 +361,3 @@ class DevModeEmailMultiAlternatives(EmailMultiAlternatives):
         super().__init__(*args, **kwargs)
         self.from_email = enforce_noreply_from_email(self.from_email)
         self._apply_dev_mode()
-
-    def _apply_dev_mode(self):
-        """Apply dev mode redirection if enabled."""
-        dev_mode, redirect_list = get_dev_mode_info()
-
-        if dev_mode:
-            if not redirect_list:
-                raise ValueError(
-                    "EMAIL_DEV_MODE is enabled but EMAIL_DEV_MODE_REDIRECT_TO is not set. "
-                    "Set EMAIL_DEV_MODE_REDIRECT_TO or disable EMAIL_DEV_MODE."
-                )
-
-            all_recipients = (
-                list(self.to or []) + list(self.cc or []) + list(self.bcc or [])
-            )
-
-            if not all_recipients:
-                recipients_info = "TO: (no recipients)"
-            else:
-                if len(all_recipients) > MAX_RECIPIENTS_IN_SUBJECT:
-                    shown = all_recipients[:MAX_RECIPIENTS_IN_SUBJECT]
-                    remaining = len(all_recipients) - MAX_RECIPIENTS_IN_SUBJECT
-                    recipients_info = (
-                        f"TO: {', '.join(shown)}, ... and {remaining} more"
-                    )
-                else:
-                    original_to = ", ".join(self.to) if self.to else "none"
-                    original_cc = ", ".join(self.cc) if self.cc else ""
-                    original_bcc = ", ".join(self.bcc) if self.bcc else ""
-
-                    recipients_info = f"TO: {original_to}"
-                    if original_cc:
-                        recipients_info += f", CC: {original_cc}"
-                    if original_bcc:
-                        recipients_info += f", BCC: {original_bcc}"
-
-            self.subject = f"[DEV MODE] {self.subject} ({recipients_info})"
-            self.to = redirect_list
-            self.cc = []
-            self.bcc = []

--- a/utils/tests/test_email_dev_mode.py
+++ b/utils/tests/test_email_dev_mode.py
@@ -6,6 +6,7 @@ from django.test import TestCase, override_settings
 
 from utils.email import (
     DevModeEmailMessage,
+    DevModeEmailMultiAlternatives,
     get_dev_mode_info,
     send_mail,
     send_mass_mail,
@@ -227,6 +228,95 @@ class DevModeEmailTests(TestCase):
                 to=["user@example.com"],
             )
         self.assertIn("EMAIL_DEV_MODE_REDIRECT_TO", str(context.exception))
+
+
+class DevModeEmailMultiAlternativesTests(TestCase):
+    """Tests for DevModeEmailMultiAlternatives dev mode behaviour."""
+
+    @override_settings(
+        EMAIL_DEV_MODE=True, EMAIL_DEV_MODE_REDIRECT_TO="dev@example.com"
+    )
+    def test_redirects_to_dev_address(self):
+        """Dev mode should redirect TO recipients to the configured dev address."""
+        msg = DevModeEmailMultiAlternatives(
+            subject="Roster Published",
+            body="Plain text body",
+            from_email="noreply@example.com",
+            to=["member@example.com"],
+        )
+
+        self.assertEqual(msg.to, ["dev@example.com"])
+
+    @override_settings(
+        EMAIL_DEV_MODE=True, EMAIL_DEV_MODE_REDIRECT_TO="dev@example.com"
+    )
+    def test_clears_cc_and_bcc(self):
+        """Dev mode should clear CC and BCC recipients."""
+        msg = DevModeEmailMultiAlternatives(
+            subject="Test",
+            body="Body",
+            from_email="noreply@example.com",
+            to=["user@example.com"],
+            cc=["cc@example.com"],
+            bcc=["bcc@example.com"],
+        )
+
+        self.assertEqual(msg.cc, [])
+        self.assertEqual(msg.bcc, [])
+
+    @override_settings(
+        EMAIL_DEV_MODE=True, EMAIL_DEV_MODE_REDIRECT_TO="dev@example.com"
+    )
+    def test_annotates_subject_with_dev_mode_prefix(self):
+        """Dev mode should prepend [DEV MODE] and original recipient to subject."""
+        msg = DevModeEmailMultiAlternatives(
+            subject="Roster Published",
+            body="Body",
+            from_email="noreply@example.com",
+            to=["member@example.com"],
+        )
+
+        self.assertIn("[DEV MODE]", msg.subject)
+        self.assertIn("member@example.com", msg.subject)
+
+    @override_settings(EMAIL_DEV_MODE=True, EMAIL_DEV_MODE_REDIRECT_TO="")
+    def test_raises_when_redirect_list_is_empty(self):
+        """Dev mode without EMAIL_DEV_MODE_REDIRECT_TO set should raise ValueError."""
+        with self.assertRaises(ValueError) as context:
+            DevModeEmailMultiAlternatives(
+                subject="Test",
+                body="Body",
+                from_email="noreply@example.com",
+                to=["user@example.com"],
+            )
+        self.assertIn("EMAIL_DEV_MODE_REDIRECT_TO", str(context.exception))
+
+    @override_settings(EMAIL_DEV_MODE=False)
+    def test_normal_mode_preserves_recipients(self):
+        """When dev mode is off, recipients and subject should be unchanged."""
+        msg = DevModeEmailMultiAlternatives(
+            subject="Roster Published",
+            body="Body",
+            from_email="noreply@example.com",
+            to=["member@example.com"],
+            cc=["cc@example.com"],
+        )
+
+        self.assertEqual(msg.to, ["member@example.com"])
+        self.assertEqual(msg.cc, ["cc@example.com"])
+        self.assertEqual(msg.subject, "Roster Published")
+
+    @override_settings(EMAIL_DEV_MODE=False)
+    def test_enforces_noreply_from_email(self):
+        """From email should always be normalised to noreply@{domain}."""
+        msg = DevModeEmailMultiAlternatives(
+            subject="Test",
+            body="Body",
+            from_email="Club Name <members@example.com>",
+            to=["user@example.com"],
+        )
+
+        self.assertEqual(msg.from_email, "noreply@example.com")
 
 
 class SendMassMailTests(TestCase):


### PR DESCRIPTION
## Summary

Two bugs fixed in one branch since they share a theme of "things misbehaving after authentication/notification flows."

---

### Fix #674 — Post-login redirect lost during Google OAuth2

**Root cause**: `SOCIAL_AUTH_FIELDS_STORED_IN_SESSION` was not configured. Without it, `python-social-auth` drops the `?next=` parameter from the session during the OAuth2 redirect cycle. The Django form login path worked fine (hidden `<input name="next">`), but Google OAuth login always landed on the homepage regardless of the original URL.

**Fix**: Add `SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ["next"]` to `manage2soar/settings.py`.

Closes #674

---

### Fix #846 — Automated notification emails showing `board-bounces@...` as sender

**Root cause**: The Postfix content filter (`maillist-rewriter.py.j2`) rewrites the `From:` header of every email addressed to a known mailing list. When Django sends a notification to `board@skylinesoaring.org`, the rewriter transformed it to `"Noreply via Board" <board-bounces@skylinesoaring.org>`. The Django-side `enforce_noreply_from_email()` wrapper was working correctly — the rewrite was happening at the Postfix layer after delivery.

**Fix**: Add a same-domain/noreply guard at the top of `rewrite_headers()` in `maillist-rewriter.py.j2`. If the sender's domain matches the list's domain, or the sender's local-part is `noreply`, the function returns the message unchanged. External user posts to lists are still rewritten normally.

**Also**: Wrap the `EmailMultiAlternatives` `from_email` in `duty_roster/utils/email.py` with `enforce_noreply_from_email()` as belt-and-suspenders.

Closes #846

**⚠️ Deployment required**: After merging, redeploy the Postfix Ansible role to apply the content filter change to the mail server:
```
cd infrastructure/ansible
ansible-playbook -i inventory/gcp_mail.yml \
  --vault-password-file ~/.ansible_vault_pass \
  playbooks/gcp-mail-server.yml --tags postfix
```

---

## Files Changed

- `manage2soar/settings.py` — add `SOCIAL_AUTH_FIELDS_STORED_IN_SESSION`
- `infrastructure/ansible/roles/postfix/templates/maillist-rewriter.py.j2` — same-domain/noreply guard in `rewrite_headers()`
- `infrastructure/ansible/roles/postfix/test_maillist_rewriter.py` — 3 new tests covering the guard (same-domain, cross-domain noreply, external sender regression)
- `duty_roster/utils/email.py` — wrap `EmailMultiAlternatives` from_email with `enforce_noreply_from_email()`

## Test Results

- 13/13 maillist-rewriter tests pass (3 new)
- 27/27 preop email tests pass
- 13/13 roster published tests pass