### PR TITLE
fix: disable adjacent weekend spacing in DutyRosterScheduler tests

### DIFF
--- a/duty_roster/tests/test_ortools_scheduler.py
+++ b/duty_roster/tests/test_ortools_scheduler.py
@@ -358,7 +358,7 @@ class ORToolsHardConstraintsTests(TestCase):
         # Verify avoidance is in data
         self.assertIn((self.member1.id, self.member2.id), data.avoidances)
 
-        scheduler = DutyRosterScheduler(data)
+        scheduler = DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -412,7 +412,7 @@ class ORToolsHardConstraintsTests(TestCase):
             role_scarcity={role: {"scarcity_score": 1.0} for role in self.test_roles},
             earliest_duty_day=three_dates[0],
         )
-        scheduler = DutyRosterScheduler(data)
+        scheduler = DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -1162,7 +1162,7 @@ class ORToolsSoftConstraintsTests(TestCase):
         )
 
         data = extract_scheduling_data(year=2026, month=3, roles=self.test_roles)
-        scheduler = DutyRosterScheduler(data)
+        scheduler = DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -1237,7 +1237,7 @@ class ORToolsSoftConstraintsTests(TestCase):
         data = extract_scheduling_data(
             year=2026, month=3, roles=["instructor", "towpilot"]
         )
-        scheduler = DutyRosterScheduler(data)
+        scheduler = DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -1280,7 +1280,7 @@ class ORToolsSoftConstraintsTests(TestCase):
         )
 
         data = extract_scheduling_data(year=2026, month=3, roles=self.test_roles)
-        scheduler = DutyRosterScheduler(data)
+        scheduler = DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution

--- a/duty_roster/tests/test_ortools_scheduler.py
+++ b/duty_roster/tests/test_ortools_scheduler.py
@@ -40,6 +40,33 @@ from members.models import Member
 from siteconfig.models import SiteConfiguration
 
 
+class ORToolsSchedulerTestBase(TestCase):
+    """
+    Base test class for OR-Tools scheduler tests.
+
+    Provides shared helper methods for creating schedulers with specific
+    configurations to isolate constraint behavior.
+    """
+
+    def _create_scheduler_without_adjacent_weekend_spacing(self, data):
+        """
+        Helper to create a scheduler without enforcing adjacent-weekend spacing.
+
+        This disables the adjacent-weekend spacing hard constraint gating in
+        DutyRosterScheduler._add_constraints(). Note that this does NOT disable
+        the separate weekend-spacing soft objective terms (lag penalties), which
+        are controlled independently.
+
+        Hard-constraint tests use this to isolate specific constraints without
+        interference from the adjacent-weekend spacing hard constraint.
+
+        Soft-constraint tests use this to isolate preference/affinity/staleness
+        weighting without the adjacent-weekend spacing hard constraint making
+        the problem infeasible.
+        """
+        return DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
+
+
 class ORToolsSchedulerBasicTests(TestCase):
     """Test basic OR-Tools scheduler functionality."""
 
@@ -170,7 +197,7 @@ class ORToolsSchedulerBasicTests(TestCase):
         self.assertGreater(len(towpilot1_vars), 0)
 
 
-class ORToolsHardConstraintsTests(TestCase):
+class ORToolsHardConstraintsTests(ORToolsSchedulerTestBase):
     """Test individual hard constraints."""
 
     def setUp(self):
@@ -252,16 +279,6 @@ class ORToolsHardConstraintsTests(TestCase):
             "duty_officer",
             "assistant_duty_officer",
         ]
-
-    def _create_scheduler_without_weekend_spacing(self, data):
-        """
-        Helper to create a scheduler with adjacent-weekend spacing disabled.
-
-        Many constraint tests use this configuration to isolate the specific
-        constraint being tested without interference from the adjacent-weekend
-        soft constraint, keeping the problem feasible and the test focused.
-        """
-        return DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
 
     def test_role_qualification_constraint(self):
         """Test that members are only assigned to roles they're qualified for."""
@@ -368,7 +385,7 @@ class ORToolsHardConstraintsTests(TestCase):
         # Verify avoidance is in data
         self.assertIn((self.member1.id, self.member2.id), data.avoidances)
 
-        scheduler = self._create_scheduler_without_weekend_spacing(data)
+        scheduler = self._create_scheduler_without_adjacent_weekend_spacing(data)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -422,7 +439,7 @@ class ORToolsHardConstraintsTests(TestCase):
             role_scarcity={role: {"scarcity_score": 1.0} for role in self.test_roles},
             earliest_duty_day=three_dates[0],
         )
-        scheduler = self._create_scheduler_without_weekend_spacing(data)
+        scheduler = self._create_scheduler_without_adjacent_weekend_spacing(data)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -1128,7 +1145,7 @@ class ORToolsHardConstraintsTests(TestCase):
         )
 
 
-class ORToolsSoftConstraintsTests(TestCase):
+class ORToolsSoftConstraintsTests(ORToolsSchedulerTestBase):
     """Test soft constraints (objective function optimization)."""
 
     def setUp(self):
@@ -1157,17 +1174,6 @@ class ORToolsSoftConstraintsTests(TestCase):
         self.test_dates = [date(2026, 3, 1), date(2026, 3, 8)]
         self.test_roles = ["instructor"]
 
-    def _create_scheduler_without_weekend_spacing(self, data):
-        """
-        Helper to create a scheduler with adjacent-weekend spacing disabled.
-
-        Soft-constraint tests use this to isolate preference/affinity/staleness
-        weighting without the adjacent-weekend soft constraint influencing the
-        objective outcomes, ensuring the test focuses on the specific weight
-        being asserted.
-        """
-        return DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
-
     def test_preference_weighting(self):
         """Test that higher preferences are honored in objective function."""
         # member1 has 100% preference, member2 has 50%
@@ -1183,9 +1189,9 @@ class ORToolsSoftConstraintsTests(TestCase):
         )
 
         data = extract_scheduling_data(year=2026, month=3, roles=self.test_roles)
-        # Disable adjacent-weekend spacing so this test isolates preference
-        # weighting without a separate soft constraint changing the objective.
-        scheduler = self._create_scheduler_without_weekend_spacing(data)
+        # Disable adjacent-weekend spacing hard constraint so this test isolates
+        # preference weighting without interference from spacing feasibility.
+        scheduler = self._create_scheduler_without_adjacent_weekend_spacing(data)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -1260,9 +1266,9 @@ class ORToolsSoftConstraintsTests(TestCase):
         data = extract_scheduling_data(
             year=2026, month=3, roles=["instructor", "towpilot"]
         )
-        # Disable adjacent-weekend spacing so this test isolates pairing-affinity
-        # weighting without interference from the adjacent-weekend constraint.
-        scheduler = self._create_scheduler_without_weekend_spacing(data)
+        # Disable adjacent-weekend spacing hard constraint so this test isolates
+        # pairing-affinity weighting without interference from spacing feasibility.
+        scheduler = self._create_scheduler_without_adjacent_weekend_spacing(data)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -1305,9 +1311,9 @@ class ORToolsSoftConstraintsTests(TestCase):
         )
 
         data = extract_scheduling_data(year=2026, month=3, roles=self.test_roles)
-        # Disable adjacent-weekend spacing so this test isolates staleness-based
-        # weighting without interference from the adjacent-weekend constraint.
-        scheduler = self._create_scheduler_without_weekend_spacing(data)
+        # Disable adjacent-weekend spacing hard constraint so this test isolates
+        # staleness-based weighting without interference from spacing feasibility.
+        scheduler = self._create_scheduler_without_adjacent_weekend_spacing(data)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution

--- a/duty_roster/tests/test_ortools_scheduler.py
+++ b/duty_roster/tests/test_ortools_scheduler.py
@@ -253,6 +253,16 @@ class ORToolsHardConstraintsTests(TestCase):
             "assistant_duty_officer",
         ]
 
+    def _create_scheduler_without_weekend_spacing(self, data):
+        """
+        Helper to create a scheduler with adjacent-weekend spacing disabled.
+
+        Many constraint tests use this configuration to isolate the specific
+        constraint being tested without interference from the adjacent-weekend
+        soft constraint, keeping the problem feasible and the test focused.
+        """
+        return DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
+
     def test_role_qualification_constraint(self):
         """Test that members are only assigned to roles they're qualified for."""
         data = SchedulingData(
@@ -358,7 +368,7 @@ class ORToolsHardConstraintsTests(TestCase):
         # Verify avoidance is in data
         self.assertIn((self.member1.id, self.member2.id), data.avoidances)
 
-        scheduler = DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
+        scheduler = self._create_scheduler_without_weekend_spacing(data)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -412,7 +422,7 @@ class ORToolsHardConstraintsTests(TestCase):
             role_scarcity={role: {"scarcity_score": 1.0} for role in self.test_roles},
             earliest_duty_day=three_dates[0],
         )
-        scheduler = DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
+        scheduler = self._create_scheduler_without_weekend_spacing(data)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -1147,6 +1157,17 @@ class ORToolsSoftConstraintsTests(TestCase):
         self.test_dates = [date(2026, 3, 1), date(2026, 3, 8)]
         self.test_roles = ["instructor"]
 
+    def _create_scheduler_without_weekend_spacing(self, data):
+        """
+        Helper to create a scheduler with adjacent-weekend spacing disabled.
+
+        Soft-constraint tests use this to isolate preference/affinity/staleness
+        weighting without the adjacent-weekend soft constraint influencing the
+        objective outcomes, ensuring the test focuses on the specific weight
+        being asserted.
+        """
+        return DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
+
     def test_preference_weighting(self):
         """Test that higher preferences are honored in objective function."""
         # member1 has 100% preference, member2 has 50%
@@ -1162,7 +1183,9 @@ class ORToolsSoftConstraintsTests(TestCase):
         )
 
         data = extract_scheduling_data(year=2026, month=3, roles=self.test_roles)
-        scheduler = DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
+        # Disable adjacent-weekend spacing so this test isolates preference
+        # weighting without a separate soft constraint changing the objective.
+        scheduler = self._create_scheduler_without_weekend_spacing(data)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -1237,7 +1260,9 @@ class ORToolsSoftConstraintsTests(TestCase):
         data = extract_scheduling_data(
             year=2026, month=3, roles=["instructor", "towpilot"]
         )
-        scheduler = DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
+        # Disable adjacent-weekend spacing so this test isolates pairing-affinity
+        # weighting without interference from the adjacent-weekend constraint.
+        scheduler = self._create_scheduler_without_weekend_spacing(data)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution
@@ -1280,7 +1305,9 @@ class ORToolsSoftConstraintsTests(TestCase):
         )
 
         data = extract_scheduling_data(year=2026, month=3, roles=self.test_roles)
-        scheduler = DutyRosterScheduler(data, enforce_adjacent_weekend_spacing=False)
+        # Disable adjacent-weekend spacing so this test isolates staleness-based
+        # weighting without interference from the adjacent-weekend constraint.
+        scheduler = self._create_scheduler_without_weekend_spacing(data)
         result = scheduler.solve(timeout_seconds=5.0)
 
         # Assert solver found a solution

--- a/duty_roster/tests/test_ortools_scheduler.py
+++ b/duty_roster/tests/test_ortools_scheduler.py
@@ -53,7 +53,7 @@ class ORToolsSchedulerTestBase(TestCase):
         Helper to create a scheduler without enforcing adjacent-weekend spacing.
 
         This disables the adjacent-weekend spacing hard constraint gating in
-        DutyRosterScheduler._add_constraints(). Note that this does NOT disable
+        DutyRosterScheduler._add_hard_constraints(). Note that this does NOT disable
         the separate weekend-spacing soft objective terms (lag penalties), which
         are controlled independently.
 


### PR DESCRIPTION
A small fix for some pytests that were failing. 
