### PR TITLE
Add ForeFlight logbook CSV export on My Logbook page

### DIFF
--- a/instructors/templates/instructors/logbook.html
+++ b/instructors/templates/instructors/logbook.html
@@ -14,7 +14,9 @@
 <div class="mb-3">
   <a href="{% url 'instructors:member_logbook_export_csv_member' member.id %}" class="btn btn-success">Export as CSV (Excel/Google Sheets)</a>
   <a href="{% url 'instructors:member_logbook_export_foreflight_member' member.id %}" class="btn btn-info">Export to ForeFlight</a>
-  <small class="text-warning d-block mt-2">⚠️ <strong>Caution:</strong> Do not re-import previously imported entries into ForeFlight to avoid duplicates.</small>
+  <div class="alert alert-warning text-dark mt-2 mb-0" role="alert">
+    ⚠️ <strong>Caution:</strong> Do not re-import previously imported entries into ForeFlight to avoid duplicates.
+  </div>
 </div>
 
 <!-- Show All Years Button -->

--- a/instructors/templates/instructors/logbook.html
+++ b/instructors/templates/instructors/logbook.html
@@ -11,7 +11,11 @@
 <div id="top"></div>
 <h2>Logbook for {{ member.full_display_name }}</h2>
 
-<a href="{% url 'instructors:member_logbook_export_csv_member' member.id %}" class="btn btn-success mb-3">Export as CSV (Excel/Google Sheets)</a>
+<div class="mb-3">
+  <a href="{% url 'instructors:member_logbook_export_csv_member' member.id %}" class="btn btn-success">Export as CSV (Excel/Google Sheets)</a>
+  <a href="{% url 'instructors:member_logbook_export_foreflight_member' member.id %}" class="btn btn-info">Export to ForeFlight</a>
+  <small class="text-warning d-block mt-2">⚠️ <strong>Caution:</strong> Do not re-import previously imported entries into ForeFlight to avoid duplicates.</small>
+</div>
 
 <!-- Show All Years Button -->
 <form method="post" action="{% url 'instructors:logbook_loading' %}" id="show-all-years-form" style="margin-bottom: 1em;">

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -814,3 +814,38 @@ def test_foreflight_csv_has_aircraft_and_flights_sections(client):
     assert "Sailplane" in content
     assert "2-33" in content
     assert "Glider" in content
+
+
+@pytest.mark.django_db
+def test_foreflight_csv_handles_flight_with_no_glider(client):
+    _ensure_full_member_status()
+    pilot = _make_member("foreflight_no_glider_pilot")
+
+    airfield = Airfield.objects.create(name="No Glider Field", identifier="KNGL")
+    logsheet = Logsheet.objects.create(
+        log_date=date(2024, 7, 1),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    # Flight with glider=None (e.g. offline sync scenario)
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        glider=None,
+        launch_method="tow",
+        launch_time=time(10, 0),
+        landing_time=time(10, 15),
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook_export_foreflight"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Flight with no glider should use the placeholder AircraftID
+    assert "UNKNOWN-AIRCRAFT" in content
+    # A corresponding aircraft row should also be present
+    lines = [line for line in content.split("\n") if "UNKNOWN-AIRCRAFT" in line]
+    assert (
+        len(lines) >= 2
+    ), "UNKNOWN-AIRCRAFT should appear in both aircraft and flights sections"

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -759,17 +759,17 @@ def test_foreflight_csv_uses_decimal_hours(client):
 
     # Flights section starts after blank line, includes header and data rows
     flights_section = lines[blank_idx + 1 :]  # Include the header row
+    assert flights_section, "CSV should include a flights section after the separator"
 
     # Parse flights section with csv reader
-    if flights_section and len(flights_section) > 1:
-        flight_rows = list(csv.DictReader(io.StringIO("\n".join(flights_section))))
-        assert (
-            len(flight_rows) >= 1
-        ), f"Should have at least one flight row. Lines: {flights_section}"
-        flight_row = flight_rows[0]
-        # 25 min = 0.42 hours
-        assert float(flight_row["TotalTime"]) == 0.42
-        assert float(flight_row["PIC"]) == 0.42
+    flight_rows = list(csv.DictReader(io.StringIO("\n".join(flights_section))))
+    assert (
+        len(flight_rows) >= 1
+    ), f"Should have at least one flight row. Lines: {flights_section}"
+    flight_row = flight_rows[0]
+    # 25 min = 0.42 hours
+    assert float(flight_row["TotalTime"]) == 0.42
+    assert float(flight_row["PIC"]) == 0.42
 
 
 @pytest.mark.django_db

--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -657,3 +657,160 @@ def test_logbook_signature_without_lesson_codes_has_no_leading_line_break(client
     assert flight_row is not None
     assert "/s/" in flight_row["signature_html"]
     assert not flight_row["signature_html"].startswith("<br>/s/")
+
+
+@pytest.mark.django_db
+def test_member_can_export_own_logbook_foreflight_csv(client):
+    _ensure_full_member_status()
+    student = _make_member("foreflight_export_self")
+
+    client.force_login(student)
+    response = client.get(reverse("instructors:member_logbook_export_foreflight"))
+
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/csv")
+    assert "foreflight" in response["Content-Disposition"]
+
+
+@pytest.mark.django_db
+def test_instructor_can_export_student_logbook_foreflight_csv(client):
+    _ensure_full_member_status()
+    instructor = _make_member("foreflight_export_instructor", instructor=True)
+    student = _make_member("foreflight_export_student")
+
+    client.force_login(instructor)
+    response = client.get(
+        reverse(
+            "instructors:member_logbook_export_foreflight_member", args=[student.pk]
+        )
+    )
+
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/csv")
+
+
+@pytest.mark.django_db
+def test_non_instructor_cannot_export_another_members_logbook_foreflight_csv(client):
+    _ensure_full_member_status()
+    member_a = _make_member("foreflight_export_member_a")
+    member_b = _make_member("foreflight_export_member_b")
+
+    client.force_login(member_a)
+    response = client.get(
+        reverse(
+            "instructors:member_logbook_export_foreflight_member", args=[member_b.pk]
+        )
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_foreflight_csv_uses_decimal_hours(client):
+    _ensure_full_member_status()
+    pilot = _make_member("foreflight_decimal_hours_pilot", glider_rating="rated")
+    pilot.private_glider_checkride_date = date(2020, 1, 1)
+    pilot.save(update_fields=["private_glider_checkride_date"])
+
+    instructor = _make_member(
+        "foreflight_decimal_hours_instructor", instructor=True, glider_rating="rated"
+    )
+    airfield = Airfield.objects.create(name="Decimal Hours Field", identifier="KDEC")
+    glider = Glider.objects.create(
+        n_number="N123DEC",
+        make="Schleicher",
+        model="ASK-21",
+        club_owned=True,
+        is_active=True,
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date(2024, 6, 1),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    # 25-minute flight = 0.42 hours (rounded to 2 decimals)
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        instructor=instructor,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(10, 0),
+        landing_time=time(10, 25),
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook_export_foreflight"))
+
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/csv")
+
+    content = response.content.decode()
+    lines = content.strip().split("\n")
+
+    # Find blank line separating aircraft and flights sections
+    blank_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() == "":
+            blank_idx = i
+            break
+
+    assert blank_idx is not None, "CSV should have a blank line separator"
+
+    # Flights section starts after blank line, includes header and data rows
+    flights_section = lines[blank_idx + 1 :]  # Include the header row
+
+    # Parse flights section with csv reader
+    if flights_section and len(flights_section) > 1:
+        flight_rows = list(csv.DictReader(io.StringIO("\n".join(flights_section))))
+        assert (
+            len(flight_rows) >= 1
+        ), f"Should have at least one flight row. Lines: {flights_section}"
+        flight_row = flight_rows[0]
+        # 25 min = 0.42 hours
+        assert float(flight_row["TotalTime"]) == 0.42
+        assert float(flight_row["PIC"]) == 0.42
+
+
+@pytest.mark.django_db
+def test_foreflight_csv_has_aircraft_and_flights_sections(client):
+    _ensure_full_member_status()
+    pilot = _make_member("foreflight_sections_pilot")
+
+    airfield = Airfield.objects.create(name="Section Test Field", identifier="KSEC")
+    glider = Glider.objects.create(
+        n_number="N456SEC",
+        make="Sailplane",
+        model="2-33",
+        club_owned=True,
+        is_active=True,
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date(2024, 6, 1),
+        airfield=airfield,
+        created_by=pilot,
+    )
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        glider=glider,
+        launch_method="tow",
+        launch_time=time(10, 0),
+        landing_time=time(10, 15),
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook_export_foreflight"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Check for aircraft section header
+    assert "AircraftID,EquipmentType,TypeCode,Year,Make,Model,Category,Class" in content
+    # Check for flights section header
+    assert "Date,AircraftID,From,To,Route,TimeOut,TimeOff,TimeOn,TimeIn" in content
+    # Check for aircraft data
+    assert "N456SEC" in content
+    assert "Sailplane" in content
+    assert "2-33" in content
+    assert "Glider" in content

--- a/instructors/urls.py
+++ b/instructors/urls.py
@@ -62,6 +62,16 @@ urlpatterns = [
         name="member_logbook_export_csv_member",
     ),
     path(
+        "logbook/export/foreflight/",
+        views.export_member_logbook_foreflight_csv,
+        name="member_logbook_export_foreflight",
+    ),
+    path(
+        "logbook/<int:member_id>/export/foreflight/",
+        views.export_member_logbook_foreflight_csv,
+        name="member_logbook_export_foreflight_member",
+    ),
+    path(
         "students/<int:member_id>/needed-for-solo/",
         views.needed_for_solo,
         name="needed_for_solo",

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -3004,13 +3004,18 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
                 if codes:
                     instructor_comments = _sanitize_csv_cell(", ".join(codes))
 
-            aircraft_id = f.glider.n_number if f.glider else _UNKNOWN_AIRCRAFT_ID
+            aircraft_id = _sanitize_csv_cell(
+                f.glider.n_number if f.glider else _UNKNOWN_AIRCRAFT_ID
+            )
+            airfield_identifier = _sanitize_csv_cell(
+                f.airfield.identifier if f.airfield else ""
+            )
             flight_writer.writerow(
                 {
                     "Date": date_val.strftime("%Y-%m-%d"),
                     "AircraftID": aircraft_id,
-                    "From": f.airfield.identifier if f.airfield else "",
-                    "To": f.airfield.identifier if f.airfield else "",
+                    "From": airfield_identifier,
+                    "To": airfield_identifier,
                     "Route": "",
                     "TimeOut": time_out_str,
                     "TimeOff": time_off_str,

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -68,7 +68,7 @@ from knowledgetest.models import (
     WrittenTestTemplateQuestion,
 )
 from knowledgetest.views import get_presets
-from logsheet.models import Flight, Glider
+from logsheet.models import Flight
 from members.decorators import active_member_required
 from members.models import Member
 from members.utils.membership import get_active_membership_statuses
@@ -2580,22 +2580,18 @@ class WrittenTestReviewView(DjangoView):
         )
 
 
-@active_member_required
-def export_member_logbook_csv(request, member_id=None):
-    """Export the member's logbook as CSV for Excel/Google Sheets with explicit instructor, pilot, passenger columns and constructed comments."""
-    member = request.user
-    if member_id is not None:
-        member = get_object_or_404(Member, pk=member_id)
-        if request.user != member and not request.user.instructor:
-            raise PermissionDenied
+def _build_logbook_events(member):
+    """Build a sorted timeline of logbook events (flights + ground instruction) for *member*.
 
-    def format_hhmm(duration):
-        if not duration:
-            return ""
-        total_minutes = int(duration.total_seconds() // 60)
-        h, m = divmod(total_minutes, 60)
-        return f"{h}:{m:02d}"
+    Returns a tuple ``(events, report_lookup, rating_date)`` where:
 
+    * **events** – list of dicts sorted by ``(date, time)``; each has keys
+      ``type`` ("flight" or "ground"), ``obj``, ``date``, and ``time``.
+    * **report_lookup** – ``{(instructor_id, date): [lesson_codes]}`` for the
+      member's instruction reports.
+    * **rating_date** – the member's ``private_glider_checkride_date`` (or
+      ``None`` if not set), used for logbook classification.
+    """
     flights = (
         Flight.objects.filter(
             Q(pilot=member) | Q(instructor=member) | Q(passenger=member)
@@ -2636,6 +2632,27 @@ def export_member_logbook_csv(request, member_id=None):
     for g in grounds:
         events.append({"type": "ground", "obj": g, "date": g.date, "time": time(0, 0)})
     events.sort(key=lambda e: (e["date"], e["time"]))
+
+    return events, report_lookup, rating_date
+
+
+@active_member_required
+def export_member_logbook_csv(request, member_id=None):
+    """Export the member's logbook as CSV for Excel/Google Sheets with explicit instructor, pilot, passenger columns and constructed comments."""
+    member = request.user
+    if member_id is not None:
+        member = get_object_or_404(Member, pk=member_id)
+        if request.user != member and not request.user.instructor:
+            raise PermissionDenied
+
+    def format_hhmm(duration):
+        if not duration:
+            return ""
+        total_minutes = int(duration.total_seconds() // 60)
+        h, m = divmod(total_minutes, 60)
+        return f"{h}:{m:02d}"
+
+    events, report_lookup, rating_date = _build_logbook_events(member)
 
     rows = []
     flight_no = 0
@@ -2769,6 +2786,7 @@ def export_member_logbook_csv(request, member_id=None):
     return response
 
 
+@active_member_required
 def export_member_logbook_foreflight_csv(request, member_id=None):
     """Export the member's logbook as CSV in ForeFlight import template format.
 
@@ -2776,7 +2794,7 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
     1. Aircraft table: unique aircraft with make, model, category, class, etc.
     2. Flights table: flights with decimal hours, ForeFlight column names
     """
-    from io import StringIO
+    _UNKNOWN_AIRCRAFT_ID = "UNKNOWN-AIRCRAFT"
 
     member = request.user
     if member_id is not None:
@@ -2791,56 +2809,21 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
         total_minutes = int(duration.total_seconds() // 60)
         return round(total_minutes / 60, 2)
 
-    # Query flights and ground instruction
-    flights = (
-        Flight.objects.filter(
-            Q(pilot=member) | Q(instructor=member) | Q(passenger=member)
-        )
-        .select_related(
-            "glider", "instructor", "pilot", "passenger", "airfield", "logsheet"
-        )
-        .order_by("logsheet__log_date")
-    )
-    grounds = (
-        GroundInstruction.objects.filter(student=member)
-        .prefetch_related("lesson_scores__lesson")
-        .order_by("date")
-    )
+    events, report_lookup, rating_date = _build_logbook_events(member)
 
-    rating_date = getattr(member, "private_glider_checkride_date", None)
-    instruction_reports = (
-        InstructionReport.objects.filter(student=member)
-        .select_related("instructor")
-        .prefetch_related("lesson_scores__lesson")
-    )
-    report_lookup = {}
-    for rpt in instruction_reports:
-        report_lookup[(rpt.instructor_id, rpt.report_date)] = [
-            ls.lesson.code for ls in rpt.lesson_scores.all()
-        ]
-
-    # Build unique aircraft list
+    # Build unique aircraft set from flight events (preserving insertion order)
     aircraft_map = {}  # {glider_id: glider_obj}
-    for f in flights:
-        if f.glider and f.glider.id not in aircraft_map:
-            aircraft_map[f.glider.id] = f.glider
+    has_unknown_aircraft = False
+    for ev in events:
+        if ev["type"] == "flight":
+            f = ev["obj"]
+            if f.glider:
+                if f.glider.id not in aircraft_map:
+                    aircraft_map[f.glider.id] = f.glider
+            else:
+                has_unknown_aircraft = True
 
-    # Build events timeline
-    events = []
-    for f in flights:
-        events.append(
-            {
-                "type": "flight",
-                "obj": f,
-                "date": f.logsheet.log_date,
-                "time": f.launch_time or time(0, 0),
-            }
-        )
-    for g in grounds:
-        events.append({"type": "ground", "obj": g, "date": g.date, "time": time(0, 0)})
-    events.sort(key=lambda e: (e["date"], e["time"]))
-
-    # Build flight rows
+    # Build flight/ground rows
     flight_rows = []
     for ev in events:
         if ev["type"] == "flight":
@@ -2860,7 +2843,6 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
             pic_m = classification["pic_m"]
             inst_m = classification["inst_m"]
 
-            # Determine time columns
             time_out_str = ""
             time_off_str = ""
             time_on_str = ""
@@ -2874,7 +2856,6 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
                 time_on_str = f"{hours:02d}:{mins:02d}"
                 time_in_str = f"{hours:02d}:{mins:02d}"
 
-            # Determine pilot names and times
             pic_hours = decimal_hours(timedelta(minutes=pic_m)) if pic_m else 0.0
             sic_hours = (
                 decimal_hours(timedelta(minutes=dual_m))
@@ -2890,7 +2871,6 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
             total_hours = decimal_hours(timedelta(minutes=dur_m)) if dur_m else 0.0
             solo_hours = decimal_hours(timedelta(minutes=solo_m)) if solo_m else 0.0
 
-            # Get instructor comments from instruction report
             instructor_name = f.instructor.full_display_name if f.instructor else ""
             instructor_comments = ""
             if is_pilot and has_logbook_instructor_context(f):
@@ -2900,9 +2880,10 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
                 if codes:
                     instructor_comments = ", ".join(codes)
 
+            aircraft_id = f.glider.n_number if f.glider else _UNKNOWN_AIRCRAFT_ID
             row = {
                 "Date": date_val.strftime("%Y-%m-%d"),
-                "AircraftID": f.glider.n_number if f.glider else "",
+                "AircraftID": aircraft_id,
                 "From": f.airfield.identifier if f.airfield else "",
                 "To": f.airfield.identifier if f.airfield else "",
                 "Route": "",
@@ -3006,10 +2987,14 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
             }
             flight_rows.append(row)
 
-    # Build CSV content in memory
-    csv_buffer = StringIO()
+    # Build response — write both sections directly to HttpResponse to avoid
+    # buffering the entire CSV in memory.
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = (
+        f'attachment; filename="logbook_{member.username}_foreflight.csv"'
+    )
 
-    # Write aircraft section header
+    # Section 1 — Aircraft table
     aircraft_fieldnames = [
         "AircraftID",
         "EquipmentType",
@@ -3026,33 +3011,53 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
         "Pressurized",
         "TAA",
     ]
-    aircraft_writer = csv.DictWriter(csv_buffer, fieldnames=aircraft_fieldnames)
+    aircraft_writer = csv.DictWriter(response, fieldnames=aircraft_fieldnames)
     aircraft_writer.writeheader()
 
-    # Write aircraft rows
     for glider in aircraft_map.values():
-        aircraft_row = {
-            "AircraftID": glider.n_number,
-            "EquipmentType": "",
-            "TypeCode": "",
-            "Year": "",
-            "Make": glider.make,
-            "Model": glider.model,
-            "Category": "Glider",
-            "Class": "Glider",
-            "GearType": "Fixed Gear",
-            "EngType": "None",
-            "Complex": "False",
-            "HighPerf": "False",
-            "Pressurized": "False",
-            "TAA": "False",
-        }
-        aircraft_writer.writerow(aircraft_row)
+        aircraft_writer.writerow(
+            {
+                "AircraftID": glider.n_number,
+                "EquipmentType": "",
+                "TypeCode": "",
+                "Year": "",
+                "Make": glider.make,
+                "Model": glider.model,
+                "Category": "Glider",
+                "Class": "Glider",
+                "GearType": "Fixed Gear",
+                "EngType": "None",
+                "Complex": "False",
+                "HighPerf": "False",
+                "Pressurized": "False",
+                "TAA": "False",
+            }
+        )
 
-    # Write blank line separator
-    csv_buffer.write("\n")
+    if has_unknown_aircraft:
+        aircraft_writer.writerow(
+            {
+                "AircraftID": _UNKNOWN_AIRCRAFT_ID,
+                "EquipmentType": "",
+                "TypeCode": "",
+                "Year": "",
+                "Make": "",
+                "Model": "",
+                "Category": "Glider",
+                "Class": "Glider",
+                "GearType": "",
+                "EngType": "None",
+                "Complex": "False",
+                "HighPerf": "False",
+                "Pressurized": "False",
+                "TAA": "False",
+            }
+        )
 
-    # Write flights section header
+    # Blank line separates the two sections (ForeFlight convention)
+    response.write("\n")
+
+    # Section 2 — Flights table
     flight_fieldnames = [
         "Date",
         "AircraftID",
@@ -3098,19 +3103,11 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
         "NVGProficiency",
         "PilotComments",
     ]
-    flight_writer = csv.DictWriter(csv_buffer, fieldnames=flight_fieldnames)
+    flight_writer = csv.DictWriter(response, fieldnames=flight_fieldnames)
     flight_writer.writeheader()
 
-    # Write flight rows
     for row in flight_rows:
         flight_writer.writerow(row)
-
-    # Create response
-    response = HttpResponse(content_type="text/csv")
-    response["Content-Disposition"] = (
-        f'attachment; filename="logbook_{member.username}_foreflight.csv"'
-    )
-    response.write(csv_buffer.getvalue())
 
     return response
 

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -68,7 +68,7 @@ from knowledgetest.models import (
     WrittenTestTemplateQuestion,
 )
 from knowledgetest.views import get_presets
-from logsheet.models import Flight
+from logsheet.models import Flight, Glider
 from members.decorators import active_member_required
 from members.models import Member
 from members.utils.membership import get_active_membership_statuses
@@ -2766,6 +2766,352 @@ def export_member_logbook_csv(request, member_id=None):
     writer.writeheader()
     for row in rows:
         writer.writerow(row)
+    return response
+
+
+def export_member_logbook_foreflight_csv(request, member_id=None):
+    """Export the member's logbook as CSV in ForeFlight import template format.
+
+    ForeFlight format is a two-section CSV:
+    1. Aircraft table: unique aircraft with make, model, category, class, etc.
+    2. Flights table: flights with decimal hours, ForeFlight column names
+    """
+    from io import StringIO
+
+    member = request.user
+    if member_id is not None:
+        member = get_object_or_404(Member, pk=member_id)
+        if request.user != member and not request.user.instructor:
+            raise PermissionDenied
+
+    def decimal_hours(duration):
+        """Convert timedelta to decimal hours (e.g., 90 min = 1.5)"""
+        if not duration:
+            return 0.0
+        total_minutes = int(duration.total_seconds() // 60)
+        return round(total_minutes / 60, 2)
+
+    # Query flights and ground instruction
+    flights = (
+        Flight.objects.filter(
+            Q(pilot=member) | Q(instructor=member) | Q(passenger=member)
+        )
+        .select_related(
+            "glider", "instructor", "pilot", "passenger", "airfield", "logsheet"
+        )
+        .order_by("logsheet__log_date")
+    )
+    grounds = (
+        GroundInstruction.objects.filter(student=member)
+        .prefetch_related("lesson_scores__lesson")
+        .order_by("date")
+    )
+
+    rating_date = getattr(member, "private_glider_checkride_date", None)
+    instruction_reports = (
+        InstructionReport.objects.filter(student=member)
+        .select_related("instructor")
+        .prefetch_related("lesson_scores__lesson")
+    )
+    report_lookup = {}
+    for rpt in instruction_reports:
+        report_lookup[(rpt.instructor_id, rpt.report_date)] = [
+            ls.lesson.code for ls in rpt.lesson_scores.all()
+        ]
+
+    # Build unique aircraft list
+    aircraft_map = {}  # {glider_id: glider_obj}
+    for f in flights:
+        if f.glider and f.glider.id not in aircraft_map:
+            aircraft_map[f.glider.id] = f.glider
+
+    # Build events timeline
+    events = []
+    for f in flights:
+        events.append(
+            {
+                "type": "flight",
+                "obj": f,
+                "date": f.logsheet.log_date,
+                "time": f.launch_time or time(0, 0),
+            }
+        )
+    for g in grounds:
+        events.append({"type": "ground", "obj": g, "date": g.date, "time": time(0, 0)})
+    events.sort(key=lambda e: (e["date"], e["time"]))
+
+    # Build flight rows
+    flight_rows = []
+    for ev in events:
+        if ev["type"] == "flight":
+            f = ev["obj"]
+            date_val = ev["date"]
+            classification = classify_logbook_flight_minutes(
+                f,
+                member.id,
+                rating_date,
+            )
+            is_pilot = classification["is_pilot"]
+            is_instructor = classification["is_instructor"]
+            is_passenger = classification["is_passenger"]
+            dur_m = classification["duration_m"]
+            dual_m = classification["dual_m"]
+            solo_m = classification["solo_m"]
+            pic_m = classification["pic_m"]
+            inst_m = classification["inst_m"]
+
+            # Determine time columns
+            time_out_str = ""
+            time_off_str = ""
+            time_on_str = ""
+            time_in_str = ""
+            if f.launch_time:
+                hours, mins = f.launch_time.hour, f.launch_time.minute
+                time_out_str = f"{hours:02d}:{mins:02d}"
+                time_off_str = f"{hours:02d}:{mins:02d}"
+            if f.landing_time:
+                hours, mins = f.landing_time.hour, f.landing_time.minute
+                time_on_str = f"{hours:02d}:{mins:02d}"
+                time_in_str = f"{hours:02d}:{mins:02d}"
+
+            # Determine pilot names and times
+            pic_hours = decimal_hours(timedelta(minutes=pic_m)) if pic_m else 0.0
+            sic_hours = (
+                decimal_hours(timedelta(minutes=dual_m))
+                if (dual_m and is_pilot)
+                else 0.0
+            )
+            dual_received = (
+                decimal_hours(timedelta(minutes=dual_m)) if is_pilot else 0.0
+            )
+            dual_given = (
+                decimal_hours(timedelta(minutes=inst_m)) if is_instructor else 0.0
+            )
+            total_hours = decimal_hours(timedelta(minutes=dur_m)) if dur_m else 0.0
+            solo_hours = decimal_hours(timedelta(minutes=solo_m)) if solo_m else 0.0
+
+            # Get instructor comments from instruction report
+            instructor_name = f.instructor.full_display_name if f.instructor else ""
+            instructor_comments = ""
+            if is_pilot and has_logbook_instructor_context(f):
+                codes = []
+                if f.instructor_id:
+                    codes = report_lookup.get((f.instructor_id, date_val), [])
+                if codes:
+                    instructor_comments = ", ".join(codes)
+
+            row = {
+                "Date": date_val.strftime("%Y-%m-%d"),
+                "AircraftID": f.glider.n_number if f.glider else "",
+                "From": f.airfield.identifier if f.airfield else "",
+                "To": f.airfield.identifier if f.airfield else "",
+                "Route": "",
+                "TimeOut": time_out_str,
+                "TimeOff": time_off_str,
+                "TimeOn": time_on_str,
+                "TimeIn": time_in_str,
+                "OnDuty": "",
+                "OffDuty": "",
+                "TotalTime": str(total_hours),
+                "PIC": str(pic_hours),
+                "SIC": str(sic_hours),
+                "Night": "0",
+                "Solo": str(solo_hours),
+                "CrossCountry": "0",
+                "NVG": "0",
+                "NVGOps": "0",
+                "Distance": "",
+                "DayTakeoffs": "1" if (is_pilot or is_instructor) else "0",
+                "DayLandingsFullStop": "1" if (is_pilot or is_instructor) else "0",
+                "NightTakeoffs": "0",
+                "NightLandingsFullStop": "0",
+                "AllLandings": "1" if (is_pilot or is_instructor) else "0",
+                "ActualInstrument": "0",
+                "SimulatedInstrument": "0",
+                "HobbsStart": "",
+                "HobbsEnd": "",
+                "TachStart": "",
+                "TachEnd": "",
+                "Holds": "0",
+                "DualGiven": str(dual_given),
+                "DualReceived": str(dual_received),
+                "SimulatedFlight": "0",
+                "GroundTraining": "0",
+                "InstructorName": instructor_name,
+                "InstructorComments": instructor_comments,
+                "FlightReview": "",
+                "Checkride": "",
+                "IPC": "",
+                "NVGProficiency": "",
+                "PilotComments": f.notes if f.notes else "",
+            }
+            flight_rows.append(row)
+        else:
+            # Ground instruction row
+            g = ev["obj"]
+            gm = int(g.duration.total_seconds() // 60) if g.duration else 0
+            ground_hours = decimal_hours(timedelta(minutes=gm))
+            codes = [ls.lesson.code for ls in g.lesson_scores.all()]
+            instructor_comments = ", ".join(codes) if codes else ""
+            instructor_name = (
+                g.instructor.full_display_name
+                if g.instructor and hasattr(g.instructor, "full_display_name")
+                else ""
+            )
+
+            row = {
+                "Date": g.date.strftime("%Y-%m-%d"),
+                "AircraftID": "",
+                "From": "",
+                "To": "",
+                "Route": "",
+                "TimeOut": "",
+                "TimeOff": "",
+                "TimeOn": "",
+                "TimeIn": "",
+                "OnDuty": "",
+                "OffDuty": "",
+                "TotalTime": "0",
+                "PIC": "0",
+                "SIC": "0",
+                "Night": "0",
+                "Solo": "0",
+                "CrossCountry": "0",
+                "NVG": "0",
+                "NVGOps": "0",
+                "Distance": "",
+                "DayTakeoffs": "0",
+                "DayLandingsFullStop": "0",
+                "NightTakeoffs": "0",
+                "NightLandingsFullStop": "0",
+                "AllLandings": "0",
+                "ActualInstrument": "0",
+                "SimulatedInstrument": "0",
+                "HobbsStart": "",
+                "HobbsEnd": "",
+                "TachStart": "",
+                "TachEnd": "",
+                "Holds": "0",
+                "DualGiven": "0",
+                "DualReceived": "0",
+                "SimulatedFlight": "0",
+                "GroundTraining": str(ground_hours),
+                "InstructorName": instructor_name,
+                "InstructorComments": instructor_comments,
+                "FlightReview": "",
+                "Checkride": "",
+                "IPC": "",
+                "NVGProficiency": "",
+                "PilotComments": "",
+            }
+            flight_rows.append(row)
+
+    # Build CSV content in memory
+    csv_buffer = StringIO()
+
+    # Write aircraft section header
+    aircraft_fieldnames = [
+        "AircraftID",
+        "EquipmentType",
+        "TypeCode",
+        "Year",
+        "Make",
+        "Model",
+        "Category",
+        "Class",
+        "GearType",
+        "EngType",
+        "Complex",
+        "HighPerf",
+        "Pressurized",
+        "TAA",
+    ]
+    aircraft_writer = csv.DictWriter(csv_buffer, fieldnames=aircraft_fieldnames)
+    aircraft_writer.writeheader()
+
+    # Write aircraft rows
+    for glider in aircraft_map.values():
+        aircraft_row = {
+            "AircraftID": glider.n_number,
+            "EquipmentType": "",
+            "TypeCode": "",
+            "Year": "",
+            "Make": glider.make,
+            "Model": glider.model,
+            "Category": "Glider",
+            "Class": "Glider",
+            "GearType": "Fixed Gear",
+            "EngType": "None",
+            "Complex": "False",
+            "HighPerf": "False",
+            "Pressurized": "False",
+            "TAA": "False",
+        }
+        aircraft_writer.writerow(aircraft_row)
+
+    # Write blank line separator
+    csv_buffer.write("\n")
+
+    # Write flights section header
+    flight_fieldnames = [
+        "Date",
+        "AircraftID",
+        "From",
+        "To",
+        "Route",
+        "TimeOut",
+        "TimeOff",
+        "TimeOn",
+        "TimeIn",
+        "OnDuty",
+        "OffDuty",
+        "TotalTime",
+        "PIC",
+        "SIC",
+        "Night",
+        "Solo",
+        "CrossCountry",
+        "NVG",
+        "NVGOps",
+        "Distance",
+        "DayTakeoffs",
+        "DayLandingsFullStop",
+        "NightTakeoffs",
+        "NightLandingsFullStop",
+        "AllLandings",
+        "ActualInstrument",
+        "SimulatedInstrument",
+        "HobbsStart",
+        "HobbsEnd",
+        "TachStart",
+        "TachEnd",
+        "Holds",
+        "DualGiven",
+        "DualReceived",
+        "SimulatedFlight",
+        "GroundTraining",
+        "InstructorName",
+        "InstructorComments",
+        "FlightReview",
+        "Checkride",
+        "IPC",
+        "NVGProficiency",
+        "PilotComments",
+    ]
+    flight_writer = csv.DictWriter(csv_buffer, fieldnames=flight_fieldnames)
+    flight_writer.writeheader()
+
+    # Write flight rows
+    for row in flight_rows:
+        flight_writer.writerow(row)
+
+    # Create response
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = (
+        f'attachment; filename="logbook_{member.username}_foreflight.csv"'
+    )
+    response.write(csv_buffer.getvalue())
+
     return response
 
 

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -2823,172 +2823,8 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
             else:
                 has_unknown_aircraft = True
 
-    # Build flight/ground rows
-    flight_rows = []
-    for ev in events:
-        if ev["type"] == "flight":
-            f = ev["obj"]
-            date_val = ev["date"]
-            classification = classify_logbook_flight_minutes(
-                f,
-                member.id,
-                rating_date,
-            )
-            is_pilot = classification["is_pilot"]
-            is_instructor = classification["is_instructor"]
-            is_passenger = classification["is_passenger"]
-            dur_m = classification["duration_m"]
-            dual_m = classification["dual_m"]
-            solo_m = classification["solo_m"]
-            pic_m = classification["pic_m"]
-            inst_m = classification["inst_m"]
-
-            time_out_str = ""
-            time_off_str = ""
-            time_on_str = ""
-            time_in_str = ""
-            if f.launch_time:
-                hours, mins = f.launch_time.hour, f.launch_time.minute
-                time_out_str = f"{hours:02d}:{mins:02d}"
-                time_off_str = f"{hours:02d}:{mins:02d}"
-            if f.landing_time:
-                hours, mins = f.landing_time.hour, f.landing_time.minute
-                time_on_str = f"{hours:02d}:{mins:02d}"
-                time_in_str = f"{hours:02d}:{mins:02d}"
-
-            pic_hours = decimal_hours(timedelta(minutes=pic_m)) if pic_m else 0.0
-            sic_hours = (
-                decimal_hours(timedelta(minutes=dual_m))
-                if (dual_m and is_pilot)
-                else 0.0
-            )
-            dual_received = (
-                decimal_hours(timedelta(minutes=dual_m)) if is_pilot else 0.0
-            )
-            dual_given = (
-                decimal_hours(timedelta(minutes=inst_m)) if is_instructor else 0.0
-            )
-            total_hours = decimal_hours(timedelta(minutes=dur_m)) if dur_m else 0.0
-            solo_hours = decimal_hours(timedelta(minutes=solo_m)) if solo_m else 0.0
-
-            instructor_name = f.instructor.full_display_name if f.instructor else ""
-            instructor_comments = ""
-            if is_pilot and has_logbook_instructor_context(f):
-                codes = []
-                if f.instructor_id:
-                    codes = report_lookup.get((f.instructor_id, date_val), [])
-                if codes:
-                    instructor_comments = ", ".join(codes)
-
-            aircraft_id = f.glider.n_number if f.glider else _UNKNOWN_AIRCRAFT_ID
-            row = {
-                "Date": date_val.strftime("%Y-%m-%d"),
-                "AircraftID": aircraft_id,
-                "From": f.airfield.identifier if f.airfield else "",
-                "To": f.airfield.identifier if f.airfield else "",
-                "Route": "",
-                "TimeOut": time_out_str,
-                "TimeOff": time_off_str,
-                "TimeOn": time_on_str,
-                "TimeIn": time_in_str,
-                "OnDuty": "",
-                "OffDuty": "",
-                "TotalTime": str(total_hours),
-                "PIC": str(pic_hours),
-                "SIC": str(sic_hours),
-                "Night": "0",
-                "Solo": str(solo_hours),
-                "CrossCountry": "0",
-                "NVG": "0",
-                "NVGOps": "0",
-                "Distance": "",
-                "DayTakeoffs": "1" if (is_pilot or is_instructor) else "0",
-                "DayLandingsFullStop": "1" if (is_pilot or is_instructor) else "0",
-                "NightTakeoffs": "0",
-                "NightLandingsFullStop": "0",
-                "AllLandings": "1" if (is_pilot or is_instructor) else "0",
-                "ActualInstrument": "0",
-                "SimulatedInstrument": "0",
-                "HobbsStart": "",
-                "HobbsEnd": "",
-                "TachStart": "",
-                "TachEnd": "",
-                "Holds": "0",
-                "DualGiven": str(dual_given),
-                "DualReceived": str(dual_received),
-                "SimulatedFlight": "0",
-                "GroundTraining": "0",
-                "InstructorName": instructor_name,
-                "InstructorComments": instructor_comments,
-                "FlightReview": "",
-                "Checkride": "",
-                "IPC": "",
-                "NVGProficiency": "",
-                "PilotComments": f.notes if f.notes else "",
-            }
-            flight_rows.append(row)
-        else:
-            # Ground instruction row
-            g = ev["obj"]
-            gm = int(g.duration.total_seconds() // 60) if g.duration else 0
-            ground_hours = decimal_hours(timedelta(minutes=gm))
-            codes = [ls.lesson.code for ls in g.lesson_scores.all()]
-            instructor_comments = ", ".join(codes) if codes else ""
-            instructor_name = (
-                g.instructor.full_display_name
-                if g.instructor and hasattr(g.instructor, "full_display_name")
-                else ""
-            )
-
-            row = {
-                "Date": g.date.strftime("%Y-%m-%d"),
-                "AircraftID": "",
-                "From": "",
-                "To": "",
-                "Route": "",
-                "TimeOut": "",
-                "TimeOff": "",
-                "TimeOn": "",
-                "TimeIn": "",
-                "OnDuty": "",
-                "OffDuty": "",
-                "TotalTime": "0",
-                "PIC": "0",
-                "SIC": "0",
-                "Night": "0",
-                "Solo": "0",
-                "CrossCountry": "0",
-                "NVG": "0",
-                "NVGOps": "0",
-                "Distance": "",
-                "DayTakeoffs": "0",
-                "DayLandingsFullStop": "0",
-                "NightTakeoffs": "0",
-                "NightLandingsFullStop": "0",
-                "AllLandings": "0",
-                "ActualInstrument": "0",
-                "SimulatedInstrument": "0",
-                "HobbsStart": "",
-                "HobbsEnd": "",
-                "TachStart": "",
-                "TachEnd": "",
-                "Holds": "0",
-                "DualGiven": "0",
-                "DualReceived": "0",
-                "SimulatedFlight": "0",
-                "GroundTraining": str(ground_hours),
-                "InstructorName": instructor_name,
-                "InstructorComments": instructor_comments,
-                "FlightReview": "",
-                "Checkride": "",
-                "IPC": "",
-                "NVGProficiency": "",
-                "PilotComments": "",
-            }
-            flight_rows.append(row)
-
-    # Build response — write both sections directly to HttpResponse to avoid
-    # buffering the entire CSV in memory.
+    # Build response — write aircraft section first, then stream flight rows
+    # directly to the response writer to avoid holding all rows in memory.
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = (
         f'attachment; filename="logbook_{member.username}_foreflight.csv"'
@@ -3054,10 +2890,11 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
             }
         )
 
-    # Blank line separates the two sections (ForeFlight convention)
-    response.write("\n")
+    # Blank line separates the two sections (ForeFlight convention).
+    # Use the dialect's line terminator to keep the whole file consistent.
+    response.write(aircraft_writer.writer.dialect.lineterminator)
 
-    # Section 2 — Flights table
+    # Section 2 — Flights table (rows are streamed directly to the writer)
     flight_fieldnames = [
         "Date",
         "AircraftID",
@@ -3106,8 +2943,167 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
     flight_writer = csv.DictWriter(response, fieldnames=flight_fieldnames)
     flight_writer.writeheader()
 
-    for row in flight_rows:
-        flight_writer.writerow(row)
+    for ev in events:
+        if ev["type"] == "flight":
+            f = ev["obj"]
+            date_val = ev["date"]
+            classification = classify_logbook_flight_minutes(
+                f,
+                member.id,
+                rating_date,
+            )
+            is_pilot = classification["is_pilot"]
+            is_instructor = classification["is_instructor"]
+            is_passenger = classification["is_passenger"]
+            dur_m = classification["duration_m"]
+            dual_m = classification["dual_m"]
+            solo_m = classification["solo_m"]
+            pic_m = classification["pic_m"]
+            inst_m = classification["inst_m"]
+
+            time_out_str = ""
+            time_off_str = ""
+            time_on_str = ""
+            time_in_str = ""
+            if f.launch_time:
+                hours, mins = f.launch_time.hour, f.launch_time.minute
+                time_out_str = f"{hours:02d}:{mins:02d}"
+                time_off_str = f"{hours:02d}:{mins:02d}"
+            if f.landing_time:
+                hours, mins = f.landing_time.hour, f.landing_time.minute
+                time_on_str = f"{hours:02d}:{mins:02d}"
+                time_in_str = f"{hours:02d}:{mins:02d}"
+
+            pic_hours = decimal_hours(timedelta(minutes=pic_m)) if pic_m else 0.0
+            # ForeFlight SIC time is distinct from dual instruction received.
+            # Glider exports do not have a separate SIC concept; keep instruction
+            # time solely in DualReceived/DualGiven to avoid inflating totals.
+            sic_hours = 0.0
+            dual_received = (
+                decimal_hours(timedelta(minutes=dual_m)) if is_pilot else 0.0
+            )
+            dual_given = (
+                decimal_hours(timedelta(minutes=inst_m)) if is_instructor else 0.0
+            )
+            total_hours = decimal_hours(timedelta(minutes=dur_m)) if dur_m else 0.0
+            solo_hours = decimal_hours(timedelta(minutes=solo_m)) if solo_m else 0.0
+
+            instructor_name = f.instructor.full_display_name if f.instructor else ""
+            instructor_comments = ""
+            if is_pilot and has_logbook_instructor_context(f):
+                codes = []
+                if f.instructor_id:
+                    codes = report_lookup.get((f.instructor_id, date_val), [])
+                if codes:
+                    instructor_comments = ", ".join(codes)
+
+            aircraft_id = f.glider.n_number if f.glider else _UNKNOWN_AIRCRAFT_ID
+            flight_writer.writerow(
+                {
+                    "Date": date_val.strftime("%Y-%m-%d"),
+                    "AircraftID": aircraft_id,
+                    "From": f.airfield.identifier if f.airfield else "",
+                    "To": f.airfield.identifier if f.airfield else "",
+                    "Route": "",
+                    "TimeOut": time_out_str,
+                    "TimeOff": time_off_str,
+                    "TimeOn": time_on_str,
+                    "TimeIn": time_in_str,
+                    "OnDuty": "",
+                    "OffDuty": "",
+                    "TotalTime": str(total_hours),
+                    "PIC": str(pic_hours),
+                    "SIC": str(sic_hours),
+                    "Night": "0",
+                    "Solo": str(solo_hours),
+                    "CrossCountry": "0",
+                    "NVG": "0",
+                    "NVGOps": "0",
+                    "Distance": "",
+                    "DayTakeoffs": "1" if (is_pilot or is_instructor) else "0",
+                    "DayLandingsFullStop": "1" if (is_pilot or is_instructor) else "0",
+                    "NightTakeoffs": "0",
+                    "NightLandingsFullStop": "0",
+                    "AllLandings": "1" if (is_pilot or is_instructor) else "0",
+                    "ActualInstrument": "0",
+                    "SimulatedInstrument": "0",
+                    "HobbsStart": "",
+                    "HobbsEnd": "",
+                    "TachStart": "",
+                    "TachEnd": "",
+                    "Holds": "0",
+                    "DualGiven": str(dual_given),
+                    "DualReceived": str(dual_received),
+                    "SimulatedFlight": "0",
+                    "GroundTraining": "0",
+                    "InstructorName": instructor_name,
+                    "InstructorComments": instructor_comments,
+                    "FlightReview": "",
+                    "Checkride": "",
+                    "IPC": "",
+                    "NVGProficiency": "",
+                    "PilotComments": f.notes if f.notes else "",
+                }
+            )
+        else:
+            # Ground instruction row
+            g = ev["obj"]
+            gm = int(g.duration.total_seconds() // 60) if g.duration else 0
+            ground_hours = decimal_hours(timedelta(minutes=gm))
+            codes = [ls.lesson.code for ls in g.lesson_scores.all()]
+            instructor_comments = ", ".join(codes) if codes else ""
+            instructor_name = (
+                g.instructor.full_display_name
+                if g.instructor and hasattr(g.instructor, "full_display_name")
+                else ""
+            )
+            flight_writer.writerow(
+                {
+                    "Date": g.date.strftime("%Y-%m-%d"),
+                    "AircraftID": "",
+                    "From": "",
+                    "To": "",
+                    "Route": "",
+                    "TimeOut": "",
+                    "TimeOff": "",
+                    "TimeOn": "",
+                    "TimeIn": "",
+                    "OnDuty": "",
+                    "OffDuty": "",
+                    "TotalTime": "0",
+                    "PIC": "0",
+                    "SIC": "0",
+                    "Night": "0",
+                    "Solo": "0",
+                    "CrossCountry": "0",
+                    "NVG": "0",
+                    "NVGOps": "0",
+                    "Distance": "",
+                    "DayTakeoffs": "0",
+                    "DayLandingsFullStop": "0",
+                    "NightTakeoffs": "0",
+                    "NightLandingsFullStop": "0",
+                    "AllLandings": "0",
+                    "ActualInstrument": "0",
+                    "SimulatedInstrument": "0",
+                    "HobbsStart": "",
+                    "HobbsEnd": "",
+                    "TachStart": "",
+                    "TachEnd": "",
+                    "Holds": "0",
+                    "DualGiven": "0",
+                    "DualReceived": "0",
+                    "SimulatedFlight": "0",
+                    "GroundTraining": str(ground_hours),
+                    "InstructorName": instructor_name,
+                    "InstructorComments": instructor_comments,
+                    "FlightReview": "",
+                    "Checkride": "",
+                    "IPC": "",
+                    "NVGProficiency": "",
+                    "PilotComments": "",
+                }
+            )
 
     return response
 

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -69,6 +69,7 @@ from knowledgetest.models import (
 )
 from knowledgetest.views import get_presets
 from logsheet.models import Flight
+from logsheet.views import _sanitize_csv_cell
 from members.decorators import active_member_required
 from members.models import Member
 from members.utils.membership import get_active_membership_statuses
@@ -2987,14 +2988,16 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
             total_hours = decimal_hours(timedelta(minutes=dur_m)) if dur_m else 0.0
             solo_hours = decimal_hours(timedelta(minutes=solo_m)) if solo_m else 0.0
 
-            instructor_name = f.instructor.full_display_name if f.instructor else ""
+            instructor_name = _sanitize_csv_cell(
+                f.instructor.full_display_name if f.instructor else ""
+            )
             instructor_comments = ""
             if is_pilot and has_logbook_instructor_context(f):
                 codes = []
                 if f.instructor_id:
                     codes = report_lookup.get((f.instructor_id, date_val), [])
                 if codes:
-                    instructor_comments = ", ".join(codes)
+                    instructor_comments = _sanitize_csv_cell(", ".join(codes))
 
             aircraft_id = f.glider.n_number if f.glider else _UNKNOWN_AIRCRAFT_ID
             flight_writer.writerow(
@@ -3041,7 +3044,7 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
                     "Checkride": "",
                     "IPC": "",
                     "NVGProficiency": "",
-                    "PilotComments": f.notes if f.notes else "",
+                    "PilotComments": _sanitize_csv_cell(f.notes) if f.notes else "",
                 }
             )
         else:
@@ -3050,8 +3053,8 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
             gm = int(g.duration.total_seconds() // 60) if g.duration else 0
             ground_hours = decimal_hours(timedelta(minutes=gm))
             codes = [ls.lesson.code for ls in g.lesson_scores.all()]
-            instructor_comments = ", ".join(codes) if codes else ""
-            instructor_name = (
+            instructor_comments = _sanitize_csv_cell(", ".join(codes)) if codes else ""
+            instructor_name = _sanitize_csv_cell(
                 g.instructor.full_display_name
                 if g.instructor and hasattr(g.instructor, "full_display_name")
                 else ""

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -69,10 +69,10 @@ from knowledgetest.models import (
 )
 from knowledgetest.views import get_presets
 from logsheet.models import Flight
-from logsheet.views import _sanitize_csv_cell
 from members.decorators import active_member_required
 from members.models import Member
 from members.utils.membership import get_active_membership_statuses
+from utils.csv import sanitize_csv_cell as _sanitize_csv_cell
 from utils.url_helpers import build_absolute_url
 
 try:
@@ -2988,9 +2988,14 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
             total_hours = decimal_hours(timedelta(minutes=dur_m)) if dur_m else 0.0
             solo_hours = decimal_hours(timedelta(minutes=solo_m)) if solo_m else 0.0
 
-            instructor_name = _sanitize_csv_cell(
-                f.instructor.full_display_name if f.instructor else ""
-            )
+            raw_instructor_name = ""
+            if f.instructor:
+                raw_instructor_name = f.instructor.full_display_name
+            elif f.guest_instructor_name and f.guest_instructor_name.strip():
+                raw_instructor_name = f.guest_instructor_name.strip()
+            elif f.legacy_instructor_name and f.legacy_instructor_name.strip():
+                raw_instructor_name = f.legacy_instructor_name.strip()
+            instructor_name = _sanitize_csv_cell(raw_instructor_name)
             instructor_comments = ""
             if is_pilot and has_logbook_instructor_context(f):
                 codes = []

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -2954,7 +2954,6 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
             )
             is_pilot = classification["is_pilot"]
             is_instructor = classification["is_instructor"]
-            is_passenger = classification["is_passenger"]
             dur_m = classification["duration_m"]
             dual_m = classification["dual_m"]
             solo_m = classification["solo_m"]

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -28,6 +28,7 @@ from duty_roster.models import GliderReservation
 from members.decorators import active_member_required
 from members.models import Member
 from siteconfig.models import SiteConfiguration
+from utils.csv import sanitize_csv_cell as _sanitize_csv_cell
 
 from .forms import (
     CommercialTicketEditForm,
@@ -219,7 +220,6 @@ def edit_commercial_ticket(request, pk):
 
 
 # Re-exported for backward compatibility; canonical definition lives in utils.csv
-from utils.csv import sanitize_csv_cell as _sanitize_csv_cell
 
 
 def _format_charge_csv_number(value):

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -218,15 +218,8 @@ def edit_commercial_ticket(request, pk):
     )
 
 
-def _sanitize_csv_cell(value):
-    """Neutralize spreadsheet-formula strings in CSV cells."""
-    if not isinstance(value, str):
-        return value
-
-    stripped = value.lstrip()
-    if stripped.startswith(("=", "+", "-", "@")):
-        return f"'{value}"
-    return value
+# Re-exported for backward compatibility; canonical definition lives in utils.csv
+from utils.csv import sanitize_csv_cell as _sanitize_csv_cell
 
 
 def _format_charge_csv_number(value):

--- a/members/templatetags/member_extras.py
+++ b/members/templatetags/member_extras.py
@@ -182,7 +182,7 @@ def duty_badge_legend():
         else "Assistant Duty Officer"
     )
     # Dynamic content is properly escaped above - safe to use mark_safe
-    return mark_safe(  # nosec
+    return mark_safe(
         f"""
         <div class='accordion mb-4' id='badgeLegendAccordion'>
             <div class='accordion-item'>
@@ -240,7 +240,7 @@ def duty_badge_legend():
             </div>
         </div>
         """
-    )
+    )  # nosec
 
 
 # Keep the old function name for backward compatibility

--- a/members/templatetags/member_extras.py
+++ b/members/templatetags/member_extras.py
@@ -240,7 +240,7 @@ def duty_badge_legend():
             </div>
         </div>
         """
-    )  # nosec B308, B703
+    )
 
 
 # Keep the old function name for backward compatibility

--- a/members/templatetags/member_extras.py
+++ b/members/templatetags/member_extras.py
@@ -240,7 +240,7 @@ def duty_badge_legend():
             </div>
         </div>
         """
-    )  # nosec
+    )  # nosec B308, B703
 
 
 # Keep the old function name for backward compatibility

--- a/utils/csv.py
+++ b/utils/csv.py
@@ -1,0 +1,17 @@
+"""Shared CSV utilities used across multiple apps."""
+
+
+def sanitize_csv_cell(value):
+    """Neutralize spreadsheet-formula strings in CSV cells.
+
+    Values starting with ``=``, ``+``, ``-``, or ``@`` are prefixed with a
+    single quote so they are treated as plain text when opened in Excel or
+    Google Sheets (CSV injection / formula injection prevention).
+    """
+    if not isinstance(value, str):
+        return value
+
+    stripped = value.lstrip()
+    if stripped.startswith(("=", "+", "-", "@")):
+        return f"'{value}"
+    return value


### PR DESCRIPTION
## Summary
- add a new ForeFlight-specific logbook export endpoint in `instructors/views.py`
- generate ForeFlight-compatible two-section CSV output (Aircraft + Flights)
- add new routes for self and instructor export access in `instructors/urls.py`
- add an `Export to ForeFlight` button and duplicate-import warning on the logbook page
- add permission and format tests for ForeFlight export in `instructors/tests/test_member_logbook_permissions.py`

## Details
- Uses the same permission model as existing logbook export:
  - members can export their own logbook
  - instructors can export student logbooks
  - non-instructors are blocked from exporting another member's logbook
- Flight durations are exported in decimal hours for ForeFlight compatibility.
- CSV includes a duplicate import caution in the UI flow per issue requirements.

## Testing
- `pytest instructors/tests/test_member_logbook_permissions.py -v`
- `pytest instructors/tests/ -q --tb=short`

Closes #562