### PR TITLE
Fix flight.airfield persistence and ForeFlight airport code fallback

### DIFF
--- a/instructors/tests/test_member_logbook_permissions.py
+++ b/instructors/tests/test_member_logbook_permissions.py
@@ -849,3 +849,48 @@ def test_foreflight_csv_handles_flight_with_no_glider(client):
     assert (
         len(lines) >= 2
     ), "UNKNOWN-AIRCRAFT should appear in both aircraft and flights sections"
+
+
+@pytest.mark.django_db
+def test_foreflight_csv_uses_logsheet_airfield_when_flight_airfield_missing(client):
+    _ensure_full_member_status()
+    pilot = _make_member("foreflight_airfield_fallback_pilot")
+
+    logsheet_airfield = Airfield.objects.create(
+        name="Fallback Field",
+        identifier="KFBK",
+    )
+    glider = Glider.objects.create(
+        n_number="N999FBK",
+        make="Schempp-Hirth",
+        model="Discus",
+        club_owned=True,
+        is_active=True,
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date(2026, 4, 25),
+        airfield=logsheet_airfield,
+        created_by=pilot,
+    )
+    Flight.objects.create(
+        logsheet=logsheet,
+        pilot=pilot,
+        glider=glider,
+        airfield=None,
+        launch_method="tow",
+        launch_time=time(10, 0),
+        landing_time=time(10, 15),
+    )
+
+    client.force_login(pilot)
+    response = client.get(reverse("instructors:member_logbook_export_foreflight"))
+
+    assert response.status_code == 200
+    lines = response.content.decode().splitlines()
+    blank_idx = lines.index("")
+    flights_section = lines[blank_idx + 1 :]
+    rows = list(csv.DictReader(io.StringIO("\n".join(flights_section))))
+
+    assert rows
+    assert rows[0]["From"] == "KFBK"
+    assert rows[0]["To"] == "KFBK"

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -3007,8 +3007,11 @@ def export_member_logbook_foreflight_csv(request, member_id=None):
             aircraft_id = _sanitize_csv_cell(
                 f.glider.n_number if f.glider else _UNKNOWN_AIRCRAFT_ID
             )
+            flight_airfield = f.airfield or (
+                f.logsheet.airfield if f.logsheet else None
+            )
             airfield_identifier = _sanitize_csv_cell(
-                f.airfield.identifier if f.airfield else ""
+                flight_airfield.identifier if flight_airfield else ""
             )
             flight_writer.writerow(
                 {

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -2598,7 +2598,13 @@ def _build_logbook_events(member):
             Q(pilot=member) | Q(instructor=member) | Q(passenger=member)
         )
         .select_related(
-            "glider", "instructor", "pilot", "passenger", "airfield", "logsheet"
+            "glider",
+            "instructor",
+            "pilot",
+            "passenger",
+            "airfield",
+            "logsheet",
+            "logsheet__airfield",
         )
         .order_by("logsheet__log_date")
     )

--- a/logsheet/tests/test_commercial_flight_views.py
+++ b/logsheet/tests/test_commercial_flight_views.py
@@ -316,6 +316,96 @@ def test_launch_now_redeems_soft_locked_ticket(client, active_member, glider, ai
 
 
 @pytest.mark.django_db
+def test_add_flight_copies_logsheet_airfield_when_missing(
+    client, active_member, glider
+):
+    SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="example.org",
+        club_abbreviation="TC",
+        commercial_rides_enabled=True,
+    )
+
+    from logsheet.models import Airfield, Logsheet
+
+    logsheet_airfield = Airfield.objects.create(
+        name="Skyline",
+        identifier="KSKY",
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date.today(),
+        airfield=logsheet_airfield,
+        created_by=active_member,
+    )
+
+    client.force_login(active_member)
+    url = reverse("logsheet:add_flight", args=[logsheet.pk])
+    response = client.post(
+        url,
+        data={
+            "pilot": active_member.pk,
+            "glider": glider.pk,
+            "launch_time": "09:00",
+            "landing_time": "09:25",
+            "release_altitude": "3000",
+        },
+    )
+
+    assert response.status_code == 302
+    flight = Flight.objects.get(logsheet=logsheet)
+    assert flight.airfield == logsheet_airfield
+
+
+@pytest.mark.django_db
+def test_edit_flight_copies_logsheet_airfield_when_missing(
+    client, active_member, glider
+):
+    SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="example.org",
+        club_abbreviation="TC",
+        commercial_rides_enabled=True,
+    )
+
+    from logsheet.models import Airfield, Logsheet
+
+    logsheet_airfield = Airfield.objects.create(
+        name="Front Royal",
+        identifier="KFRR",
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date.today(),
+        airfield=logsheet_airfield,
+        created_by=active_member,
+    )
+    flight = Flight.objects.create(
+        logsheet=logsheet,
+        pilot=active_member,
+        glider=glider,
+        airfield=None,
+        launch_time=time(8, 30),
+        landing_time=time(8, 55),
+    )
+
+    client.force_login(active_member)
+    url = reverse("logsheet:edit_flight", args=[logsheet.pk, flight.pk])
+    response = client.post(
+        url,
+        data={
+            "pilot": active_member.pk,
+            "glider": glider.pk,
+            "launch_time": "09:00",
+            "landing_time": "09:25",
+            "release_altitude": "3000",
+        },
+    )
+
+    assert response.status_code == 302
+    flight.refresh_from_db()
+    assert flight.airfield == logsheet_airfield
+
+
+@pytest.mark.django_db
 def test_launch_now_rolls_back_launch_time_when_ticket_link_fails(
     client, active_member, glider, airfield, monkeypatch
 ):

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -1695,7 +1695,7 @@ def edit_flight(request, logsheet_pk, flight_pk):
                 flight = form.save(commit=False)
                 flight.commercial_ride = form.cleaned_data.get("commercial_ride", False)
                 if not flight.airfield_id:
-                    flight.airfield = logsheet.airfield
+                    flight.airfield_id = logsheet.airfield_id
                 if flight.commercial_ride:
                     flight.passenger = None
                     flight.passenger_name = ""
@@ -1860,7 +1860,7 @@ def add_flight(request, logsheet_pk):
                 flight.logsheet = logsheet
                 flight.commercial_ride = form.cleaned_data.get("commercial_ride", False)
                 if not flight.airfield_id:
-                    flight.airfield = logsheet.airfield
+                    flight.airfield_id = logsheet.airfield_id
                 if flight.commercial_ride:
                     flight.passenger = None
                     flight.passenger_name = ""

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -1694,6 +1694,8 @@ def edit_flight(request, logsheet_pk, flight_pk):
 
                 flight = form.save(commit=False)
                 flight.commercial_ride = form.cleaned_data.get("commercial_ride", False)
+                if not flight.airfield_id:
+                    flight.airfield = logsheet.airfield
                 if flight.commercial_ride:
                     flight.passenger = None
                     flight.passenger_name = ""
@@ -1857,6 +1859,8 @@ def add_flight(request, logsheet_pk):
                 flight = form.save(commit=False)
                 flight.logsheet = logsheet
                 flight.commercial_ride = form.cleaned_data.get("commercial_ride", False)
+                if not flight.airfield_id:
+                    flight.airfield = logsheet.airfield
                 if flight.commercial_ride:
                     flight.passenger = None
                     flight.passenger_name = ""


### PR DESCRIPTION
Closes #898

## Problem

Flights added through the normal logsheet flow were not persisting `flight.airfield`, defaulting to null. The airfield already exists on the parent `Logsheet`, but it was never copied down to each `Flight`. This became a data quality regression around early 2026:

| Year | Total flights | flight.airfield set | logsheet.airfield set |
|------|--------------|--------------------|-----------------------|
| 2025 | 199 | 199 | 199 |
| 2026 | 12 | 1 | 12 |

Symptom: ForeFlight CSV export had blank `From`/`To` columns for all recent flights.

## Changes

### Write-path fix (`logsheet/views.py`)
- In both `add_flight` and `edit_flight` views: when `flight.airfield` is not already set, default it to `logsheet.airfield` before saving.

### ForeFlight export resilience (`instructors/views.py`)
- Fallback to `flight.logsheet.airfield` when `flight.airfield` is null, so historical records with null `flight.airfield` also export the airport code correctly.

### Tests
- `test_add_flight_copies_logsheet_airfield_when_missing` — new flight via add view persists airfield
- `test_edit_flight_copies_logsheet_airfield_when_missing` — edited flight via edit view persists airfield
- `test_foreflight_csv_uses_logsheet_airfield_when_flight_airfield_missing` — export correctly falls back for legacy records

## Not in this PR

A data backfill command for existing null `flight.airfield` records will be tracked as a follow-up to issue #898.
