### PR TITLE
feat: actionable error messages for flight form setup failures

### DIFF
--- a/e2e_tests/e2e/test_flight_form_setup_error_modal.py
+++ b/e2e_tests/e2e/test_flight_form_setup_error_modal.py
@@ -1,0 +1,137 @@
+"""
+E2E tests for flight form setup error display in the AJAX modal (PR #900).
+
+Verifies that when the server returns a 500 JSON error (e.g., missing
+SiteConfiguration), the Add Flight / Edit Flight modal displays the
+server-provided ``payload.error`` message rather than the generic fallback.
+
+This guards against regressions in the JS fetch handler in logsheet_manage.html
+that parses structured JSON error payloads and injects them into the modal body.
+"""
+
+from datetime import date
+
+from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+from logsheet.models import Airfield, Flight, Glider, Logsheet
+from siteconfig.models import SiteConfiguration
+
+
+class TestFlightFormSetupErrorModal(DjangoPlaywrightTestCase):
+    """Modal correctly surfaces server-provided JSON error messages."""
+
+    def setUp(self):
+        super().setUp()
+        self.member = self.create_test_member(username="pilottest", is_superuser=True)
+        self.login(username="pilottest")
+
+        self.airfield = Airfield.objects.create(
+            identifier="KFRR", name="Front Royal Airport", is_active=True
+        )
+        self.glider = Glider.objects.create(
+            make="Schleicher",
+            model="ASK-21",
+            n_number="N900PR",
+            competition_number="P1",
+            seats=2,
+            is_active=True,
+        )
+        self.logsheet = Logsheet.objects.create(
+            log_date=date(2026, 1, 20),
+            airfield=self.airfield,
+            created_by=self.member,
+            duty_officer=self.member,
+        )
+
+    # ------------------------------------------------------------------
+    # Add Flight: missing SiteConfiguration → modal shows server message
+    # ------------------------------------------------------------------
+
+    def test_add_flight_modal_shows_server_error_when_site_config_missing(self):
+        """
+        When SiteConfiguration is absent, clicking Add Flight should open the
+        modal and display the server-provided error text (not the generic JS
+        fallback) so admins know exactly what to fix.
+        """
+        # Ensure no SiteConfiguration exists (PR #900 regression scenario)
+        SiteConfiguration.objects.all().delete()
+
+        self.page.goto(f"{self.live_server_url}/logsheet/manage/{self.logsheet.pk}/")
+
+        # Click the Add Flight button to trigger the AJAX modal fetch
+        add_btn = self.page.locator(
+            f"a[data-url*='add-flight'][data-bs-target='#flightModal']"
+        ).first
+        add_btn.click()
+
+        # Wait for the modal to be visible
+        modal = self.page.locator("#flightModal")
+        modal.wait_for(state="visible", timeout=5000)
+
+        # Wait for the fetch to complete (loading spinner → error content)
+        self.page.wait_for_function(
+            "() => !document.querySelector('#flightModalContent .spinner-border')",
+            timeout=8000,
+        )
+
+        modal_body = self.page.locator("#flightModalContent").inner_text()
+
+        # The server returns: "Flight form setup is incomplete: Site Configuration
+        # is missing. An admin should create it in Admin > Siteconfig > Site
+        # Configuration." — verify the key phrase is visible in the modal.
+        assert (
+            "Site Configuration is missing" in modal_body
+        ), f"Expected server-provided error message in modal, got: {modal_body!r}"
+
+        # Confirm the generic JS fallback message is NOT shown
+        assert (
+            "The server could not load the flight form" not in modal_body
+        ), "Generic JS fallback message shown instead of server-provided error"
+
+    # ------------------------------------------------------------------
+    # Edit Flight: missing SiteConfiguration → modal shows server message
+    # ------------------------------------------------------------------
+
+    def test_edit_flight_modal_shows_server_error_when_site_config_missing(self):
+        """
+        Same scenario for an existing flight's Edit button.
+        """
+        # Need a SiteConfiguration to create the flight row, then delete it
+        SiteConfiguration.objects.create(
+            club_name="Test Club",
+            domain_name="test.example.com",
+            club_abbreviation="TC",
+        )
+        flight = Flight.objects.create(
+            logsheet=self.logsheet,
+            pilot=self.member,
+            glider=self.glider,
+            airfield=self.airfield,
+            flight_type="solo",
+        )
+        # Now remove the SiteConfiguration to trigger the error
+        SiteConfiguration.objects.all().delete()
+
+        self.page.goto(f"{self.live_server_url}/logsheet/manage/{self.logsheet.pk}/")
+
+        # Locate the Edit button for this specific flight
+        edit_btn = self.page.locator(
+            f"a[data-url*='edit-flight/{flight.pk}'][data-bs-target='#flightModal']"
+        ).first
+        edit_btn.click()
+
+        modal = self.page.locator("#flightModal")
+        modal.wait_for(state="visible", timeout=5000)
+
+        self.page.wait_for_function(
+            "() => !document.querySelector('#flightModalContent .spinner-border')",
+            timeout=8000,
+        )
+
+        modal_body = self.page.locator("#flightModalContent").inner_text()
+
+        assert (
+            "Site Configuration is missing" in modal_body
+        ), f"Expected server-provided error message in modal, got: {modal_body!r}"
+        assert (
+            "The server could not load the flight form" not in modal_body
+        ), "Generic JS fallback message shown instead of server-provided error"

--- a/logsheet/templates/logsheet/logsheet_manage.html
+++ b/logsheet/templates/logsheet/logsheet_manage.html
@@ -731,6 +731,14 @@ window.getCsrfToken = window.getCsrfToken || function() {
   return domToken ? domToken.value : '';
 };
 
+// Shared helper — defined at global scope so both script blocks can use it.
+function escapeHtml(text) {
+  if (!text) return '';
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
 // Shared function to attach NOW and 2K/3K button handlers to flight modal form
 // This must be called after any modal content is loaded (normal open, clone, etc.)
 // Uses clone-and-replace pattern to prevent duplicate event listeners
@@ -1114,14 +1122,6 @@ document.addEventListener("click", async function(e) {
         const landingTimeInput = form.querySelector('input[name="landing_time"]');
         if (landingTimeInput) landingTimeInput.value = '';
       }
-    }
-
-    // Helper function to escape HTML special characters
-    function escapeHtml(text) {
-      if (!text) return '';
-      const div = document.createElement('div');
-      div.textContent = text;
-      return div.innerHTML;
     }
 
     // Helper to add clone notice to modal
@@ -2374,12 +2374,6 @@ document.addEventListener("click", async function(e) {
       }
     })
     .catch(async error => {
-      const escapeHtml = (unsafe) => {
-        const div = document.createElement('div');
-        div.textContent = unsafe || '';
-        return div.innerHTML;
-      };
-
       // Handle offline/network errors gracefully
       const isOffline = error.message === 'offline' || !navigator.onLine;
       const isAddFlight = url && url.includes('/add-flight/');

--- a/logsheet/templates/logsheet/logsheet_manage.html
+++ b/logsheet/templates/logsheet/logsheet_manage.html
@@ -2047,13 +2047,27 @@ document.addEventListener("click", async function(e) {
         "X-Requested-With": "XMLHttpRequest"
       }
     })
-    .then(response => {
+    .then(async response => {
       if (!response.ok) {
         // Handle offline/error responses
         if (!navigator.onLine || response.status === 503) {
           throw new Error('offline');
         }
-        throw new Error('server_error');
+
+        const contentType = response.headers.get("content-type") || "";
+        let serverMessage = "";
+        if (contentType.includes("application/json")) {
+          try {
+            const payload = await response.json();
+            serverMessage = payload.error || payload.message || "";
+          } catch (e) {
+            console.warn("Unable to parse JSON error payload", e);
+          }
+        }
+
+        const error = new Error(serverMessage || 'server_error');
+        error.httpStatus = response.status;
+        throw error;
       }
       return response.text();
     })
@@ -2343,11 +2357,20 @@ document.addEventListener("click", async function(e) {
       }
     })
     .catch(async error => {
+      const escapeHtml = (unsafe) => {
+        const div = document.createElement('div');
+        div.textContent = unsafe || '';
+        return div.innerHTML;
+      };
+
       // Handle offline/network errors gracefully
       const isOffline = error.message === 'offline' || !navigator.onLine;
       const isAddFlight = url && url.includes('/add-flight/');
       const isEditFlight = url && url.includes('/edit-flight/');
       const modalContent = document.getElementById("flightModalContent");
+      const serverMessage = !isOffline && error.message && error.message !== 'server_error'
+        ? error.message
+        : "The server could not load the flight form. Check Site Configuration and towplane charge tiers in Admin, then retry.";
 
       // If offline and adding/editing a flight, try to use offline form
       if (isOffline && (isAddFlight || isEditFlight) && window.M2SOffline) {
@@ -2390,7 +2413,7 @@ document.addEventListener("click", async function(e) {
                 ? "No cached data available for offline entry. Please connect to the internet at least once to cache flight data."
                 : isOffline
                   ? "This action requires an internet connection."
-                  : "There was a problem connecting to the server. Please try again."}
+                  : escapeHtml(serverMessage)}
             </p>
           </div>
           <div id="offline-modal-status" class="text-muted small">

--- a/logsheet/templates/logsheet/logsheet_manage.html
+++ b/logsheet/templates/logsheet/logsheet_manage.html
@@ -2112,7 +2112,19 @@ document.addEventListener("click", async function(e) {
                 document.body.innerHTML = html;
               }
             } else {
-              throw new Error('server_error');
+              // Non-OK, non-HTML response — try to extract a structured JSON error message.
+              let serverMessage = "";
+              if (contentType.includes("application/json")) {
+                try {
+                  const payload = await response.json();
+                  serverMessage = payload.error || payload.message || "";
+                } catch (e) {
+                  console.warn("Unable to parse JSON error payload from submit response", e);
+                }
+              }
+              const submitError = new Error(serverMessage || "server_error");
+              submitError.httpStatus = response.status;
+              throw submitError;
             }
           })
           .catch(async error => {
@@ -2175,7 +2187,15 @@ document.addEventListener("click", async function(e) {
                 alert("Could not save the flight offline. Please try again when online.");
               }
             } else {
-              alert("Could not save the flight. Please check your connection and try again.");
+              const escapeHtml = (unsafe) => {
+                const div = document.createElement('div');
+                div.textContent = unsafe || '';
+                return div.innerHTML;
+              };
+              const serverMessage = error.message && error.message !== 'server_error'
+                ? error.message
+                : "Could not save the flight. Please check your connection and try again.";
+              alert(escapeHtml(serverMessage));
             }
           });
         });

--- a/logsheet/templates/logsheet/logsheet_manage.html
+++ b/logsheet/templates/logsheet/logsheet_manage.html
@@ -2187,15 +2187,12 @@ document.addEventListener("click", async function(e) {
                 alert("Could not save the flight offline. Please try again when online.");
               }
             } else {
-              const escapeHtml = (unsafe) => {
-                const div = document.createElement('div');
-                div.textContent = unsafe || '';
-                return div.innerHTML;
-              };
+              // alert() displays plain text — do NOT pass HTML-escaped content or
+              // characters like '>' will show as '&gt;'. escapeHtml is only for innerHTML.
               const serverMessage = error.message && error.message !== 'server_error'
                 ? error.message
                 : "Could not save the flight. Please check your connection and try again.";
-              alert(escapeHtml(serverMessage));
+              alert(serverMessage);
             }
           });
         });

--- a/logsheet/tests/test_commercial_flight_views.py
+++ b/logsheet/tests/test_commercial_flight_views.py
@@ -407,7 +407,7 @@ def test_edit_flight_copies_logsheet_airfield_when_missing(
 
 @pytest.mark.django_db
 def test_add_flight_ajax_returns_setup_error_when_site_configuration_missing(
-    client, active_member, glider, airfield
+    client, active_member, airfield
 ):
     from logsheet.models import Logsheet
 
@@ -518,7 +518,7 @@ def test_launch_now_rolls_back_launch_time_when_ticket_link_fails(
 
 @pytest.mark.django_db
 def test_add_flight_ajax_returns_unexpected_error_code_on_generic_exception(
-    client, active_member, glider, airfield, monkeypatch
+    client, active_member, airfield, monkeypatch
 ):
     """Unexpected exceptions during FlightForm init return error_code='flight_form_unexpected_error'."""
     from logsheet.models import Logsheet

--- a/logsheet/tests/test_commercial_flight_views.py
+++ b/logsheet/tests/test_commercial_flight_views.py
@@ -514,3 +514,78 @@ def test_launch_now_rolls_back_launch_time_when_ticket_link_fails(
     ticket.refresh_from_db(from_queryset=None)
     assert flight.launch_time is None
     assert ticket.status == CommercialTicket.Status.AVAILABLE
+
+
+@pytest.mark.django_db
+def test_add_flight_ajax_returns_unexpected_error_code_on_generic_exception(
+    client, active_member, glider, airfield, monkeypatch
+):
+    """Unexpected exceptions during FlightForm init return error_code='flight_form_unexpected_error'."""
+    from logsheet.models import Logsheet
+
+    SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="example.org",
+        club_abbreviation="TC",
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date.today(),
+        airfield=airfield,
+        created_by=active_member,
+    )
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated unexpected form init failure")
+
+    monkeypatch.setattr("logsheet.views.FlightForm", _boom)
+
+    client.force_login(active_member)
+    response = client.get(
+        reverse("logsheet:add_flight", args=[logsheet.pk]),
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["error_code"] == "flight_form_unexpected_error"
+    assert "unexpected server error" in payload["error"]
+
+
+@pytest.mark.django_db
+def test_edit_flight_ajax_returns_unexpected_error_code_on_generic_exception(
+    client, active_member, glider, airfield, monkeypatch
+):
+    """Unexpected exceptions during FlightForm init return error_code='flight_form_unexpected_error'."""
+    from logsheet.models import Flight, Logsheet
+
+    SiteConfiguration.objects.create(
+        club_name="Test Club",
+        domain_name="example.org",
+        club_abbreviation="TC",
+    )
+    logsheet = Logsheet.objects.create(
+        log_date=date.today(),
+        airfield=airfield,
+        created_by=active_member,
+    )
+    flight = Flight.objects.create(
+        logsheet=logsheet,
+        pilot=active_member,
+        glider=glider,
+    )
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated unexpected form init failure")
+
+    monkeypatch.setattr("logsheet.views.FlightForm", _boom)
+
+    client.force_login(active_member)
+    response = client.get(
+        reverse("logsheet:edit_flight", args=[logsheet.pk, flight.pk]),
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["error_code"] == "flight_form_unexpected_error"
+    assert "unexpected server error" in payload["error"]

--- a/logsheet/tests/test_commercial_flight_views.py
+++ b/logsheet/tests/test_commercial_flight_views.py
@@ -51,7 +51,7 @@ def test_add_commercial_flight_redeems_ticket_and_creates_ride(
     assert response.status_code == 302
 
     flight = Flight.objects.get(logsheet=logsheet)
-    ticket.refresh_from_db()
+    ticket.refresh_from_db(from_queryset=None)
 
     assert flight.commercial_ride is True
     assert flight.passenger is None
@@ -210,7 +210,7 @@ def test_edit_commercial_flight_rolls_back_when_ticket_link_fails(
 
     assert response.status_code == 200
     assert "ticket_number" in response.context["form"].errors
-    flight.refresh_from_db()
+    flight.refresh_from_db(from_queryset=None)
     assert flight.commercial_ride is False
     assert flight.passenger_name == "Keep Me"
 
@@ -256,7 +256,7 @@ def test_add_pending_commercial_flight_soft_locks_ticket_without_redeeming(
     assert response.status_code == 302
 
     flight = Flight.objects.get(logsheet=logsheet)
-    ticket.refresh_from_db()
+    ticket.refresh_from_db(from_queryset=None)
 
     assert flight.launch_time is None
     assert ticket.status == CommercialTicket.Status.AVAILABLE
@@ -298,7 +298,7 @@ def test_launch_now_redeems_soft_locked_ticket(client, active_member, glider, ai
         revenue_amount=ticket.amount_paid,
     )
 
-    ticket.refresh_from_db()
+    ticket.refresh_from_db(from_queryset=None)
     assert ticket.status == CommercialTicket.Status.AVAILABLE
 
     client.force_login(active_member)
@@ -310,7 +310,7 @@ def test_launch_now_redeems_soft_locked_ticket(client, active_member, glider, ai
     )
 
     assert response.status_code == 200
-    ticket.refresh_from_db()
+    ticket.refresh_from_db(from_queryset=None)
     assert ticket.status == CommercialTicket.Status.REDEEMED
     assert ticket.flight == flight
 
@@ -401,8 +401,61 @@ def test_edit_flight_copies_logsheet_airfield_when_missing(
     )
 
     assert response.status_code == 302
-    flight.refresh_from_db()
+    flight.refresh_from_db(from_queryset=None)
     assert flight.airfield == logsheet_airfield
+
+
+@pytest.mark.django_db
+def test_add_flight_ajax_returns_setup_error_when_site_configuration_missing(
+    client, active_member, glider, airfield
+):
+    from logsheet.models import Logsheet
+
+    logsheet = Logsheet.objects.create(
+        log_date=date.today(),
+        airfield=airfield,
+        created_by=active_member,
+    )
+
+    client.force_login(active_member)
+    response = client.get(
+        reverse("logsheet:add_flight", args=[logsheet.pk]),
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["error_code"] == "flight_form_setup_incomplete"
+    assert "Site Configuration is missing" in payload["error"]
+
+
+@pytest.mark.django_db
+def test_edit_flight_ajax_returns_setup_error_when_site_configuration_missing(
+    client, active_member, glider, airfield
+):
+    from logsheet.models import Flight, Logsheet
+
+    logsheet = Logsheet.objects.create(
+        log_date=date.today(),
+        airfield=airfield,
+        created_by=active_member,
+    )
+    flight = Flight.objects.create(
+        logsheet=logsheet,
+        pilot=active_member,
+        glider=glider,
+    )
+
+    client.force_login(active_member)
+    response = client.get(
+        reverse("logsheet:edit_flight", args=[logsheet.pk, flight.pk]),
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["error_code"] == "flight_form_setup_incomplete"
+    assert "Site Configuration is missing" in payload["error"]
 
 
 @pytest.mark.django_db
@@ -457,7 +510,7 @@ def test_launch_now_rolls_back_launch_time_when_ticket_link_fails(
     )
 
     assert response.status_code == 400
-    flight.refresh_from_db()
-    ticket.refresh_from_db()
+    flight.refresh_from_db(from_queryset=None)
+    ticket.refresh_from_db(from_queryset=None)
     assert flight.launch_time is None
     assert ticket.status == CommercialTicket.Status.AVAILABLE

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -74,28 +74,37 @@ def _can_issue_commercial_ticket(user):
 
 
 def _missing_towplane_pricing_setup(limit=3):
-    """Return a short list of active towplanes missing active charge tier setup."""
+    """Return a short list of active towplanes with no charge scheme configured.
+
+    Towplanes with a charge scheme but no active tiers are valid (hookup-fee-only
+    pricing is supported); only towplanes with no charge_scheme at all are flagged.
+    """
     missing = list(
-        Towplane.objects.filter(is_active=True)
-        .exclude(
-            charge_scheme__is_active=True,
-            charge_scheme__charge_tiers__is_active=True,
-        )
-        .order_by("name", "n_number")[:limit]
+        Towplane.objects.filter(is_active=True, charge_scheme__isnull=True).order_by(
+            "name", "n_number"
+        )[:limit]
     )
     if not missing:
         return ""
 
     names = ", ".join(f"{tp.name} ({tp.n_number})" for tp in missing)
     suffix = "" if len(missing) < limit else ", ..."
-    return " Active towplanes missing charge tiers: " f"{names}{suffix}."
+    return f" Active towplanes with no charge scheme configured: {names}{suffix}."
 
 
-def _flight_form_setup_error_message(exc, *, unexpected=False):
+def _flight_form_setup_error_message(
+    exc, *, unexpected=False, site_config_missing=False
+):
     """Build a user-facing setup error message for flight form initialization.
 
     Never include exc details in the returned string — those are logged server-side
     to avoid information exposure (CWE-209 / CodeQL python/stack-trace-exposure).
+
+    Args:
+        exc: The caught exception (used only for server-side logging).
+        unexpected: True when the exception is not ImproperlyConfigured.
+        site_config_missing: True when SiteConfiguration.objects.first() is None;
+            detected by the caller via a direct DB check, not by parsing exc.args.
     """
     suffix = _missing_towplane_pricing_setup()
     if unexpected:
@@ -104,13 +113,13 @@ def _flight_form_setup_error_message(exc, *, unexpected=False):
             "An admin should check the server logs, Site Configuration, and towplane charge tiers."
             + suffix
         )
-    if "Site configuration is missing" in str(exc):
+    if site_config_missing:
         return (
             "Flight form setup is incomplete: Site Configuration is missing. "
             "An admin should create it in Admin > Siteconfig > Site Configuration."
             + suffix
         )
-    # ImproperlyConfigured with an unrecognised message — log detail, show generic text.
+    # ImproperlyConfigured with an unrecognised cause — log detail, show generic text.
     logger.error("FlightForm setup error (ImproperlyConfigured): %s", exc)
     return (
         "Flight form setup is incomplete due to a configuration error. "
@@ -1727,17 +1736,24 @@ def edit_flight(request, logsheet_pk, flight_pk):
     commercial_rides_enabled = bool(config and config.commercial_rides_enabled)
 
     def _setup_error_response(exc, *, unexpected=False):
-        message = _flight_form_setup_error_message(exc, unexpected=unexpected)
+        site_config_missing = (
+            not unexpected and SiteConfiguration.objects.first() is None
+        )
+        message = _flight_form_setup_error_message(
+            exc, unexpected=unexpected, site_config_missing=site_config_missing
+        )
         if unexpected:
             logger.exception(
                 "Unexpected error initialising FlightForm in edit_flight: %s", exc
             )
         if request.headers.get("x-requested-with") == "XMLHttpRequest":
+            error_code = (
+                "flight_form_unexpected_error"
+                if unexpected
+                else "flight_form_setup_incomplete"
+            )
             return JsonResponse(
-                {
-                    "error": message,
-                    "error_code": "flight_form_setup_incomplete",
-                },
+                {"error": message, "error_code": error_code},
                 status=500,
             )
         messages.error(request, message)
@@ -1924,17 +1940,24 @@ def add_flight(request, logsheet_pk):
     commercial_rides_enabled = bool(config and config.commercial_rides_enabled)
 
     def _setup_error_response(exc, *, unexpected=False):
-        message = _flight_form_setup_error_message(exc, unexpected=unexpected)
+        site_config_missing = (
+            not unexpected and SiteConfiguration.objects.first() is None
+        )
+        message = _flight_form_setup_error_message(
+            exc, unexpected=unexpected, site_config_missing=site_config_missing
+        )
         if unexpected:
             logger.exception(
                 "Unexpected error initialising FlightForm in add_flight: %s", exc
             )
         if request.headers.get("x-requested-with") == "XMLHttpRequest":
+            error_code = (
+                "flight_form_unexpected_error"
+                if unexpected
+                else "flight_form_setup_incomplete"
+            )
             return JsonResponse(
-                {
-                    "error": message,
-                    "error_code": "flight_form_setup_incomplete",
-                },
+                {"error": message, "error_code": error_code},
                 status=500,
             )
         messages.error(request, message)

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -99,6 +99,7 @@ def _flight_form_setup_error_message(
 
     Never include exc details in the returned string — those are logged server-side
     to avoid information exposure (CWE-209 / CodeQL python/stack-trace-exposure).
+    The caller is responsible for logging unexpected exceptions via logger.exception.
 
     Args:
         exc: The caught exception (used only for server-side logging).
@@ -114,6 +115,9 @@ def _flight_form_setup_error_message(
             + suffix
         )
     if site_config_missing:
+        logger.warning(
+            "FlightForm init failed: SiteConfiguration row is missing for this tenant."
+        )
         return (
             "Flight form setup is incomplete: Site Configuration is missing. "
             "An admin should create it in Admin > Siteconfig > Site Configuration."
@@ -1736,9 +1740,9 @@ def edit_flight(request, logsheet_pk, flight_pk):
     commercial_rides_enabled = bool(config and config.commercial_rides_enabled)
 
     def _setup_error_response(exc, *, unexpected=False):
-        site_config_missing = (
-            not unexpected and SiteConfiguration.objects.first() is None
-        )
+        # Use the already-fetched config to avoid an extra DB query and potential
+        # inconsistency if a row is created between the two calls.
+        site_config_missing = not unexpected and config is None
         message = _flight_form_setup_error_message(
             exc, unexpected=unexpected, site_config_missing=site_config_missing
         )
@@ -1940,9 +1944,9 @@ def add_flight(request, logsheet_pk):
     commercial_rides_enabled = bool(config and config.commercial_rides_enabled)
 
     def _setup_error_response(exc, *, unexpected=False):
-        site_config_missing = (
-            not unexpected and SiteConfiguration.objects.first() is None
-        )
+        # Use the already-fetched config to avoid an extra DB query and potential
+        # inconsistency if a row is created between the two calls.
+        site_config_missing = not unexpected and config is None
         message = _flight_form_setup_error_message(
             exc, unexpected=unexpected, site_config_missing=site_config_missing
         )

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -111,7 +111,14 @@ def _flight_form_setup_error_message(
         site_config_missing: True when SiteConfiguration.objects.first() is None;
             detected by the caller via a direct DB check, not by parsing exc.args.
     """
-    suffix = _missing_towplane_pricing_setup()
+    try:
+        suffix = _missing_towplane_pricing_setup()
+    except Exception:
+        # If the hint query itself fails (e.g., DB connection issue that triggered
+        # the original FlightForm error), swallow it gracefully so the caller's
+        # JSON/flash-message error handling is not bypassed.
+        logger.warning("Could not retrieve towplane pricing hint for error message.")
+        suffix = ""
     if unexpected:
         return (
             "Flight form could not be loaded due to an unexpected server error. "

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -92,8 +92,11 @@ def _missing_towplane_pricing_setup(limit=3):
 
 
 def _flight_form_setup_error_message(exc, *, unexpected=False):
-    """Build a user-facing setup error message for flight form initialization."""
-    base = str(exc)
+    """Build a user-facing setup error message for flight form initialization.
+
+    Never include exc details in the returned string — those are logged server-side
+    to avoid information exposure (CWE-209 / CodeQL python/stack-trace-exposure).
+    """
     suffix = _missing_towplane_pricing_setup()
     if unexpected:
         return (
@@ -101,13 +104,18 @@ def _flight_form_setup_error_message(exc, *, unexpected=False):
             "An admin should check the server logs, Site Configuration, and towplane charge tiers."
             + suffix
         )
-    if "Site configuration is missing" in base:
+    if "Site configuration is missing" in str(exc):
         return (
             "Flight form setup is incomplete: Site Configuration is missing. "
             "An admin should create it in Admin > Siteconfig > Site Configuration."
             + suffix
         )
-    return f"Flight form setup is incomplete. {base}{suffix}"
+    # ImproperlyConfigured with an unrecognised message — log detail, show generic text.
+    logger.error("FlightForm setup error (ImproperlyConfigured): %s", exc)
+    return (
+        "Flight form setup is incomplete due to a configuration error. "
+        "An admin should check the server logs and Site Configuration." + suffix
+    )
 
 
 @active_member_required

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -117,7 +117,10 @@ def _flight_form_setup_error_message(
         # If the hint query itself fails (e.g., DB connection issue that triggered
         # the original FlightForm error), swallow it gracefully so the caller's
         # JSON/flash-message error handling is not bypassed.
-        logger.warning("Could not retrieve towplane pricing hint for error message.")
+        logger.warning(
+            "Could not retrieve towplane pricing hint for error message.",
+            exc_info=True,
+        )
         suffix = ""
     if unexpected:
         return (
@@ -135,7 +138,7 @@ def _flight_form_setup_error_message(
             + suffix
         )
     # ImproperlyConfigured with an unrecognised cause — log detail, show generic text.
-    logger.error("FlightForm setup error (ImproperlyConfigured): %s", exc)
+    logger.exception("FlightForm setup error (ImproperlyConfigured): %s", exc)
     return (
         "Flight form setup is incomplete due to a configuration error. "
         "An admin should check the server logs and Site Configuration." + suffix

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -5,7 +5,7 @@ from datetime import date, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 
 from django.contrib import messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.paginator import Paginator
 from django.db import transaction
 from django.db.models import Count, F, Q, Sum, Value
@@ -71,6 +71,43 @@ def _can_issue_commercial_ticket(user):
     return bool(
         getattr(user, "duty_officer", False) or getattr(user, "treasurer", False)
     )
+
+
+def _missing_towplane_pricing_setup(limit=3):
+    """Return a short list of active towplanes missing active charge tier setup."""
+    missing = list(
+        Towplane.objects.filter(is_active=True)
+        .exclude(
+            charge_scheme__is_active=True,
+            charge_scheme__charge_tiers__is_active=True,
+        )
+        .order_by("name", "n_number")[:limit]
+    )
+    if not missing:
+        return ""
+
+    names = ", ".join(f"{tp.name} ({tp.n_number})" for tp in missing)
+    suffix = "" if len(missing) < limit else ", ..."
+    return " Active towplanes missing charge tiers: " f"{names}{suffix}."
+
+
+def _flight_form_setup_error_message(exc, *, unexpected=False):
+    """Build a user-facing setup error message for flight form initialization."""
+    base = str(exc)
+    suffix = _missing_towplane_pricing_setup()
+    if unexpected:
+        return (
+            "Flight form could not be loaded due to an unexpected server error. "
+            "An admin should check the server logs, Site Configuration, and towplane charge tiers."
+            + suffix
+        )
+    if "Site configuration is missing" in base:
+        return (
+            "Flight form setup is incomplete: Site Configuration is missing. "
+            "An admin should create it in Admin > Siteconfig > Site Configuration."
+            + suffix
+        )
+    return f"Flight form setup is incomplete. {base}{suffix}"
 
 
 @active_member_required
@@ -1681,8 +1718,30 @@ def edit_flight(request, logsheet_pk, flight_pk):
     config = SiteConfiguration.objects.first()
     commercial_rides_enabled = bool(config and config.commercial_rides_enabled)
 
+    def _setup_error_response(exc, *, unexpected=False):
+        message = _flight_form_setup_error_message(exc, unexpected=unexpected)
+        if unexpected:
+            logger.exception(
+                "Unexpected error initialising FlightForm in edit_flight: %s", exc
+            )
+        if request.headers.get("x-requested-with") == "XMLHttpRequest":
+            return JsonResponse(
+                {
+                    "error": message,
+                    "error_code": "flight_form_setup_incomplete",
+                },
+                status=500,
+            )
+        messages.error(request, message)
+        return redirect("logsheet:manage", pk=logsheet.pk)
+
     if request.method == "POST":
-        form = FlightForm(request.POST, instance=flight, logsheet=logsheet)
+        try:
+            form = FlightForm(request.POST, instance=flight, logsheet=logsheet)
+        except ImproperlyConfigured as exc:
+            return _setup_error_response(exc)
+        except Exception as exc:
+            return _setup_error_response(exc, unexpected=True)
         if form.is_valid():
             ticket_link_error = None
             with transaction.atomic():
@@ -1783,7 +1842,12 @@ def edit_flight(request, logsheet_pk, flight_pk):
                 status=400,
             )
     else:
-        form = FlightForm(instance=flight, logsheet=logsheet)
+        try:
+            form = FlightForm(instance=flight, logsheet=logsheet)
+        except ImproperlyConfigured as exc:
+            return _setup_error_response(exc)
+        except Exception as exc:
+            return _setup_error_response(exc, unexpected=True)
 
     return render(
         request,
@@ -1851,8 +1915,30 @@ def add_flight(request, logsheet_pk):
     config = SiteConfiguration.objects.first()
     commercial_rides_enabled = bool(config and config.commercial_rides_enabled)
 
+    def _setup_error_response(exc, *, unexpected=False):
+        message = _flight_form_setup_error_message(exc, unexpected=unexpected)
+        if unexpected:
+            logger.exception(
+                "Unexpected error initialising FlightForm in add_flight: %s", exc
+            )
+        if request.headers.get("x-requested-with") == "XMLHttpRequest":
+            return JsonResponse(
+                {
+                    "error": message,
+                    "error_code": "flight_form_setup_incomplete",
+                },
+                status=500,
+            )
+        messages.error(request, message)
+        return redirect("logsheet:manage", pk=logsheet.pk)
+
     if request.method == "POST":
-        form = FlightForm(request.POST, logsheet=logsheet)
+        try:
+            form = FlightForm(request.POST, logsheet=logsheet)
+        except ImproperlyConfigured as exc:
+            return _setup_error_response(exc)
+        except Exception as exc:
+            return _setup_error_response(exc, unexpected=True)
         if form.is_valid():
             ticket_link_error = None
             with transaction.atomic():
@@ -1932,7 +2018,12 @@ def add_flight(request, logsheet_pk):
             initial["tow_pilot"] = logsheet.tow_pilot_id
         if logsheet.default_towplane_id:
             initial["towplane"] = logsheet.default_towplane_id
-        form = FlightForm(initial=initial, logsheet=logsheet)
+        try:
+            form = FlightForm(initial=initial, logsheet=logsheet)
+        except ImproperlyConfigured as exc:
+            return _setup_error_response(exc)
+        except Exception as exc:
+            return _setup_error_response(exc, unexpected=True)
 
     return render(
         request,

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -79,16 +79,20 @@ def _missing_towplane_pricing_setup(limit=3):
     Towplanes with a charge scheme but no active tiers are valid (hookup-fee-only
     pricing is supported); only towplanes with no charge_scheme at all are flagged.
     """
-    missing = list(
+    # Fetch limit+1 so we can reliably detect whether more results exist beyond
+    # the display limit (len == limit after slicing does NOT imply overflow).
+    rows = list(
         Towplane.objects.filter(is_active=True, charge_scheme__isnull=True).order_by(
             "name", "n_number"
-        )[:limit]
+        )[: limit + 1]
     )
-    if not missing:
+    if not rows:
         return ""
 
-    names = ", ".join(f"{tp.name} ({tp.n_number})" for tp in missing)
-    suffix = "" if len(missing) < limit else ", ..."
+    has_more = len(rows) > limit
+    display = rows[:limit]
+    names = ", ".join(f"{tp.name} ({tp.n_number})" for tp in display)
+    suffix = ", ..." if has_more else ""
     return f" Active towplanes with no charge scheme configured: {names}{suffix}."
 
 


### PR DESCRIPTION
## Problem

New tenants (e.g. tenant-svs / Shenandoah Valley Soaring) who had not yet created a `SiteConfiguration` record saw a generic "could not load the form / There was a problem connecting to the server. Please try again." modal whenever they clicked **Add Flight** or **Edit Flight**. The real root cause was completely hidden.

## Root Cause

`FlightForm.__init__` raises `ImproperlyConfigured` when `SiteConfiguration.objects.first()` returns `None`. The views had no handler for this exception, so Django returned a bare HTML 500 error page. The AJAX fetch handler in the logsheet template treated any non-200/non-503 response as a network failure and discarded the body entirely, showing only the hard-coded fallback string.

## Changes

### `logsheet/views.py`
- Added `_missing_towplane_pricing_setup()` helper — appends a hint listing active towplanes that lack charge tiers.
- Added `_flight_form_setup_error_message(exc, *, unexpected=False)` helper — builds an admin-actionable message from the exception type.
- All four `FlightForm(...)` instantiations (GET + POST paths in both `add_flight` and `edit_flight`) are now wrapped with **two-tier exception handling**:
  - `ImproperlyConfigured` → specific message directing admin to create Site Configuration
  - `Exception` (fallback) → generic "check server logs" message + `logger.exception(...)` for full traceback in server logs
- AJAX callers receive a structured `{"error": "...", "error_code": "flight_form_setup_incomplete"}` JSON body with HTTP 500 instead of an HTML error page.
- Non-AJAX callers are redirected to the logsheet manage page with a `messages.error` flash.

### `logsheet/templates/logsheet/logsheet_manage.html`
- Fetch `.then()` handler now reads the JSON body on non-OK responses and extracts `payload.error`.
- Fetch `.catch()` handler surfaces the server's error text in the modal instead of the hard-coded fallback string.
- `escapeHtml()` helper prevents XSS from server-supplied error text.

### `logsheet/tests/test_commercial_flight_views.py`
- Two new regression tests: `test_add_flight_ajax_returns_setup_error_when_site_configuration_missing` and `test_edit_flight_ajax_returns_setup_error_when_site_configuration_missing` — verify HTTP 500 JSON with correct `error_code` when no `SiteConfiguration` exists.
- Fixed 8 pre-existing Pylance false-positive errors on `refresh_from_db()` calls (`refresh_from_db(from_queryset=None)`).

## Coverage

| Failure scenario | Before | After |
|---|---|---|
| `SiteConfiguration` row missing | Generic JS "connection error" | "Site Configuration is missing. An admin should create it in Admin > Siteconfig…" |
| Any other exception in form init | Generic JS "connection error" | "Unexpected server error. Check server logs, Site Configuration, and towplane charge tiers." + server log with traceback |
| `SiteConfiguration` exists but fields blank | Silently degraded (no change needed) | No change — form guards handle these with conditionals |

## Testing

```
pytest logsheet/tests/test_commercial_flight_views.py
# 11 passed
```