### PR TITLE
IaC: private GKE nodes + Cloud NAT for app cluster

### DIFF
--- a/infrastructure/ansible/docs/gke-cluster-provisioning-guide.md
+++ b/infrastructure/ansible/docs/gke-cluster-provisioning-guide.md
@@ -203,6 +203,28 @@ gke_pods_cidr: "10.4.0.0/14"
 gke_services_cidr: "10.8.0.0/20"
 ```
 
+### Private Nodes + Cloud NAT (Recommended)
+
+Avoid per-node public IPv4 charges by running worker nodes without external IPs and using Cloud NAT for outbound internet access.
+
+```yaml
+gke_create_vpc: true
+
+# Private worker nodes (no external/public IPv4 on nodes)
+gke_private_nodes: true
+gke_private_endpoint: false
+gke_master_ipv4_cidr_block: "172.16.0.0/28"
+
+# Outbound internet egress for private nodes
+gke_enable_cloud_nat: true
+gke_cloud_router_name: "manage2soar-router"
+gke_cloud_nat_name: "manage2soar-nat"
+```
+
+Notes:
+- Keep `gke_private_endpoint: false` unless you have private control-plane connectivity configured.
+- With this setup, clients can still access your load balancer over IPv4 and/or IPv6, while nodes remain private.
+
 ## Configuration Reference
 
 ### Required Variables
@@ -244,6 +266,22 @@ gke_services_cidr: "10.8.0.0/20"
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `gke_enable_workload_identity` | `true` | Enable Workload Identity |
+
+### Private Nodes (Standard only)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `gke_private_nodes` | `false` | Enable private GKE nodes (no external IPs) |
+| `gke_private_endpoint` | `false` | Use private control-plane endpoint |
+| `gke_master_ipv4_cidr_block` | unset | Control-plane IPv4 CIDR (required for private nodes) |
+
+### Cloud NAT (for private nodes)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `gke_enable_cloud_nat` | `false` | Create/manage Cloud NAT for node egress |
+| `gke_cloud_router_name` | unset | Cloud Router name used by NAT |
+| `gke_cloud_nat_name` | unset | Cloud NAT name |
 
 ## Playbook Tags
 

--- a/infrastructure/ansible/group_vars/gcp_cluster.vars.yml.example
+++ b/infrastructure/ansible/group_vars/gcp_cluster.vars.yml.example
@@ -42,7 +42,12 @@
 # gke_machine_type: "e2-standard-4"
 # gke_min_nodes: 2
 # gke_max_nodes: 10
-# gke_private_cluster: true
+# gke_private_nodes: true
+# gke_private_endpoint: false
+# gke_master_ipv4_cidr_block: "172.16.0.0/28"
+# gke_enable_cloud_nat: true
+# gke_cloud_router_name: "manage2soar-router"
+# gke_cloud_nat_name: "manage2soar-nat"
 
 # ============================================================
 # LABELS AND TAGS
@@ -59,6 +64,5 @@ gke_cluster_labels:
 # The following features are planned but not yet implemented:
 # - Maintenance windows
 # - Resource quotas
-# - Private clusters
 # - VPA (Vertical Pod Autoscaling)
 # See https://github.com/pietbarber/Manage2Soar/issues for status

--- a/infrastructure/ansible/inventory/gcp_cluster.yml.example
+++ b/infrastructure/ansible/inventory/gcp_cluster.yml.example
@@ -52,7 +52,8 @@ all:
     # Create new VPC or use existing
     # Set to true to create a dedicated VPC for the cluster
     # Set to false to use the default VPC
-    gke_create_vpc: false
+    # NOTE: private nodes and Cloud NAT require gke_create_vpc: true
+    gke_create_vpc: true
 
     # VPC configuration (only used if gke_create_vpc: true)
     gke_vpc_name: "manage2soar-vpc"

--- a/infrastructure/ansible/inventory/gcp_cluster.yml.example
+++ b/infrastructure/ansible/inventory/gcp_cluster.yml.example
@@ -61,6 +61,18 @@ all:
     gke_pods_cidr: "10.4.0.0/14"
     gke_services_cidr: "10.8.0.0/20"
 
+    # Private nodes (recommended to avoid per-node public IPv4 charges)
+    # - Nodes get no external/public IPv4 addresses
+    # - Keep private endpoint disabled unless private control-plane access is configured
+    gke_private_nodes: true
+    gke_private_endpoint: false
+    gke_master_ipv4_cidr_block: "172.16.0.0/28"
+
+    # Cloud NAT for outbound internet from private nodes
+    gke_enable_cloud_nat: true
+    gke_cloud_router_name: "manage2soar-router"
+    gke_cloud_nat_name: "manage2soar-nat"
+
     # ============================================================
     # NODE POOL CONFIGURATION (Standard clusters only)
     # ============================================================

--- a/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
+++ b/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
@@ -376,10 +376,10 @@
           --cluster-secondary-range-name=pods
           --services-secondary-range-name=services
           {%- endif %}
-          {%- if gke_private_nodes | default(false) %}
+          {%- if gke_private_nodes | default(false) | bool %}
           --enable-private-nodes
           --master-ipv4-cidr={{ gke_master_ipv4_cidr_block }}
-          {%- if gke_private_endpoint | default(false) %}
+          {%- if gke_private_endpoint | default(false) | bool %}
           --enable-private-endpoint
           {%- endif %}
           {%- endif %}
@@ -400,6 +400,7 @@
       when:
         - gke_cluster_type == 'standard'
         - existing_standard_cluster.rc != 0
+        - not ansible_check_mode
       tags: [cluster]
 
     - name: Get actual node pool name from Standard cluster

--- a/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
+++ b/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
@@ -403,6 +403,52 @@
         - not ansible_check_mode
       tags: [cluster]
 
+    - name: Check for public IPs on existing cluster worker nodes
+      ansible.builtin.command:
+        cmd: >
+          gcloud compute instances list
+          --project={{ gcp_project }}
+          --filter="name~^gke-{{ gke_cluster_name }}-"
+          --format="value(networkInterfaces[0].accessConfigs[0].natIP)"
+      register: cluster_node_nat_ips
+      changed_when: false
+      when:
+        - gke_cluster_type == 'standard'
+        - existing_standard_cluster.rc == 0
+      tags: [cluster]
+
+    - name: Determine if existing worker nodes still have public IPs
+      ansible.builtin.set_fact:
+        gke_nodes_have_public_ips: >-
+          {{
+            (cluster_node_nat_ips.stdout_lines | default([])
+            | map('trim') | reject('equalto', '') | list | length) > 0
+          }}
+      when:
+        - gke_cluster_type == 'standard'
+        - existing_standard_cluster.rc == 0
+      tags: [cluster]
+
+    - name: Migrate existing Standard cluster to private nodes
+      ansible.builtin.command:
+        cmd: >
+          gcloud container clusters update {{ gke_cluster_name }}
+          --project={{ gcp_project }}
+          --zone={{ gcp_zone }}
+          --enable-private-nodes
+          {%- if gke_private_endpoint | default(false) | bool %}
+          --enable-private-endpoint
+          {%- endif %}
+      register: private_nodes_update
+      changed_when: private_nodes_update.rc == 0
+      when:
+        - gke_cluster_type == 'standard'
+        - gke_private_nodes | default(false) | bool
+        - existing_standard_cluster.rc == 0
+        - gke_nodes_have_public_ips | default(false)
+        - not ansible_check_mode
+      tags: [cluster]
+
     - name: Get actual node pool name from Standard cluster
       ansible.builtin.command:
         cmd: >

--- a/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
+++ b/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
@@ -289,7 +289,7 @@
           gcloud compute routers nats describe {{ gke_cloud_nat_name }}
           --project={{ gcp_project }}
           --router={{ gke_cloud_router_name }}
-          --region={{ gcp_region }}
+          --router-region={{ gcp_region }}
       register: cloud_nat_check
       changed_when: false
       failed_when: false

--- a/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
+++ b/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
@@ -130,6 +130,26 @@
           Cloud NAT provisioning in this playbook requires a custom VPC.
           Please set gke_create_vpc: true when gke_enable_cloud_nat: true
 
+    - name: Validate private endpoint requires private nodes
+      ansible.builtin.assert:
+        that:
+          - not (gke_private_endpoint | default(false) | bool) or (gke_private_nodes | default(false) | bool)
+        fail_msg: |
+          gke_private_endpoint: true requires gke_private_nodes: true.
+          Please set gke_private_nodes: true when gke_private_endpoint: true
+
+    - name: Validate Cloud NAT router and NAT names are set
+      ansible.builtin.assert:
+        that:
+          - gke_cloud_router_name is defined and gke_cloud_router_name | length > 0
+          - gke_cloud_nat_name is defined and gke_cloud_nat_name | length > 0
+        fail_msg: |
+          Cloud NAT requires both gke_cloud_router_name and gke_cloud_nat_name to be set.
+          Example:
+            gke_cloud_router_name: "manage2soar-router"
+            gke_cloud_nat_name: "manage2soar-nat"
+      when: gke_enable_cloud_nat | default(false) | bool
+
     - name: Verify GCP project exists and user has access
       ansible.builtin.command:
         cmd: "gcloud projects describe {{ gcp_project }}"
@@ -260,6 +280,7 @@
       when:
         - gke_enable_cloud_nat | default(false) | bool
         - gke_create_vpc | bool
+        - not ansible_check_mode
       tags: [network, nat]
 
     - name: Check if Cloud NAT exists
@@ -291,7 +312,8 @@
       when:
         - gke_enable_cloud_nat | default(false) | bool
         - gke_create_vpc | bool
-        - cloud_nat_check.rc != 0
+        - not ansible_check_mode
+        - cloud_nat_check is defined and cloud_nat_check.rc != 0
       tags: [network, nat]
 
     - name: Update Cloud NAT gateway settings
@@ -304,11 +326,12 @@
           --nat-all-subnet-ip-ranges
           --auto-allocate-nat-external-ips
       register: cloud_nat_update
-      changed_when: cloud_nat_update.rc == 0
+      changed_when: false
       when:
         - gke_enable_cloud_nat | default(false) | bool
         - gke_create_vpc | bool
-        - cloud_nat_check.rc == 0
+        - not ansible_check_mode
+        - cloud_nat_check is defined and cloud_nat_check.rc == 0
       tags: [network, nat]
 
     # ============================================================

--- a/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
+++ b/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
@@ -98,6 +98,38 @@
           Autopilot clusters may support IPv6, but the flags are not yet configured.
           Please use gke_cluster_type: standard when gke_enable_ipv6: true
 
+    - name: Validate private nodes only for Standard clusters
+      ansible.builtin.assert:
+        that:
+          - not (gke_private_nodes | default(false) | bool) or (gke_cluster_type | default('standard')) == 'standard'
+        fail_msg: |
+          Private nodes are only supported for Standard clusters in this playbook.
+          Please use gke_cluster_type: standard when gke_private_nodes: true
+
+    - name: Validate private nodes require custom VPC
+      ansible.builtin.assert:
+        that:
+          - not (gke_private_nodes | default(false) | bool) or (gke_create_vpc | default(false) | bool)
+        fail_msg: |
+          Private nodes require a custom VPC/subnet in this playbook.
+          Please set gke_create_vpc: true when gke_private_nodes: true
+
+    - name: Validate private nodes require control plane CIDR
+      ansible.builtin.assert:
+        that:
+          - not (gke_private_nodes | default(false) | bool) or (gke_master_ipv4_cidr_block is defined and gke_master_ipv4_cidr_block | length > 0)
+        fail_msg: |
+          Private nodes require gke_master_ipv4_cidr_block.
+          Example: gke_master_ipv4_cidr_block: "172.16.0.0/28"
+
+    - name: Validate Cloud NAT requires custom VPC
+      ansible.builtin.assert:
+        that:
+          - not (gke_enable_cloud_nat | default(false) | bool) or (gke_create_vpc | default(false) | bool)
+        fail_msg: |
+          Cloud NAT provisioning in this playbook requires a custom VPC.
+          Please set gke_create_vpc: true when gke_enable_cloud_nat: true
+
     - name: Verify GCP project exists and user has access
       ansible.builtin.command:
         cmd: "gcloud projects describe {{ gcp_project }}"
@@ -121,8 +153,14 @@
           Initial Nodes: {{ gke_initial_node_count }}
           Autoscaling: {{ gke_enable_autoscaling }} ({{ gke_min_nodes }}-{{ gke_max_nodes }})
           Spot VMs: {{ gke_use_spot_vms }}
+          Private Nodes: {{ gke_private_nodes | default(false) }}
+          Private Endpoint: {{ gke_private_endpoint | default(false) }}
+          Master CIDR: {{ gke_master_ipv4_cidr_block | default('N/A') }}
           {% endif %}
           Create VPC: {{ gke_create_vpc }}
+          Cloud NAT: {{ gke_enable_cloud_nat | default(false) }}
+          Cloud Router: {{ gke_cloud_router_name | default('N/A') }}
+          Cloud NAT Name: {{ gke_cloud_nat_name | default('N/A') }}
           Workload Identity: {{ gke_enable_workload_identity }}
           ========================================
 
@@ -207,6 +245,72 @@
         - not (gke_enable_ipv6 | default(false) | bool)
       tags: [network]
 
+    - name: Create Cloud Router for NAT
+      ansible.builtin.command:
+        cmd: >
+          gcloud compute routers create {{ gke_cloud_router_name }}
+          --project={{ gcp_project }}
+          --region={{ gcp_region }}
+          --network={{ gke_vpc_name }}
+      register: cloud_router_create
+      changed_when: cloud_router_create.rc == 0
+      failed_when: >
+        cloud_router_create.rc != 0 and
+        'already exists' not in (cloud_router_create.stderr | default('') | lower)
+      when:
+        - gke_enable_cloud_nat | default(false) | bool
+        - gke_create_vpc | bool
+      tags: [network, nat]
+
+    - name: Check if Cloud NAT exists
+      ansible.builtin.command:
+        cmd: >
+          gcloud compute routers nats describe {{ gke_cloud_nat_name }}
+          --project={{ gcp_project }}
+          --router={{ gke_cloud_router_name }}
+          --region={{ gcp_region }}
+      register: cloud_nat_check
+      changed_when: false
+      failed_when: false
+      when:
+        - gke_enable_cloud_nat | default(false) | bool
+        - gke_create_vpc | bool
+      tags: [network, nat]
+
+    - name: Create Cloud NAT gateway
+      ansible.builtin.command:
+        cmd: >
+          gcloud compute routers nats create {{ gke_cloud_nat_name }}
+          --project={{ gcp_project }}
+          --router={{ gke_cloud_router_name }}
+          --router-region={{ gcp_region }}
+          --nat-all-subnet-ip-ranges
+          --auto-allocate-nat-external-ips
+      register: cloud_nat_create
+      changed_when: cloud_nat_create.rc == 0
+      when:
+        - gke_enable_cloud_nat | default(false) | bool
+        - gke_create_vpc | bool
+        - cloud_nat_check.rc != 0
+      tags: [network, nat]
+
+    - name: Update Cloud NAT gateway settings
+      ansible.builtin.command:
+        cmd: >
+          gcloud compute routers nats update {{ gke_cloud_nat_name }}
+          --project={{ gcp_project }}
+          --router={{ gke_cloud_router_name }}
+          --router-region={{ gcp_region }}
+          --nat-all-subnet-ip-ranges
+          --auto-allocate-nat-external-ips
+      register: cloud_nat_update
+      changed_when: cloud_nat_update.rc == 0
+      when:
+        - gke_enable_cloud_nat | default(false) | bool
+        - gke_create_vpc | bool
+        - cloud_nat_check.rc == 0
+      tags: [network, nat]
+
     # ============================================================
     # GKE CLUSTER CREATION
     # ============================================================
@@ -248,6 +352,13 @@
           --subnetwork={{ gke_subnet_name }}
           --cluster-secondary-range-name=pods
           --services-secondary-range-name=services
+          {%- endif %}
+          {%- if gke_private_nodes | default(false) %}
+          --enable-private-nodes
+          --master-ipv4-cidr={{ gke_master_ipv4_cidr_block }}
+          {%- if gke_private_endpoint | default(false) %}
+          --enable-private-endpoint
+          {%- endif %}
           {%- endif %}
           --enable-ip-alias
           {%- if gke_enable_ipv6 | default(false) %}

--- a/infrastructure/ansible/roles/gke-deploy/defaults/main.yml
+++ b/infrastructure/ansible/roles/gke-deploy/defaults/main.yml
@@ -268,6 +268,10 @@ gke_enable_ingress: false
 # Static IP name for Gateway (will be created if doesn't exist)
 gke_static_ip_name: "{{ gke_cluster_name }}-ingress-ip"
 
+# When true, fail deployment if the reserved IPv4 static address is not actually
+# attached to any forwarding rule after Gateway reconcile.
+gke_fail_on_unbound_static_ipv4: true
+
 # Enable IPv6 for Gateway/Ingress
 # When true, reserves both IPv4 and IPv6 global static IPs
 # Requires GKE cluster with IPv6 enabled (--stack-type=IPV4_IPV6)

--- a/infrastructure/ansible/roles/gke-deploy/tasks/ingress.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/ingress.yml
@@ -603,6 +603,62 @@
     - gateway_ip.stdout | trim | length > 0
   tags: [ingress, verify]
 
+- name: Get static IPv4 users (forwarding rules) for reserved address
+  ansible.builtin.command:
+    cmd: >
+      gcloud compute addresses describe {{ gke_static_ip_name }}
+      --global
+      --project={{ gcp_project }}
+      --format="value(users)"
+  register: static_ip_users
+  changed_when: false
+  failed_when: false
+  delegate_to: localhost
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - gke_static_ip_name is defined
+    - gke_static_ip_name | trim | length > 0
+  tags: [ingress, verify, ip]
+
+- name: Determine whether reserved static IPv4 is currently bound
+  ansible.builtin.set_fact:
+    gke_static_ipv4_bound: "{{ (static_ip_users.stdout | default('') | trim) | length > 0 }}"
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - static_ip_users is defined
+  tags: [ingress, verify, ip]
+
+- name: Warn when reserved static IPv4 is unbound
+  ansible.builtin.debug:
+    msg: |
+      WARNING: Reserved static IPv4 '{{ gke_static_ip_name }}' appears unbound (no forwarding rule users).
+      Reserved IP: {{ gke_ingress_ip | default('unknown') }}
+      Gateway status IPv4: {{ gateway_ip.stdout | default('unknown') | trim }}
+      This can cause unnecessary monthly IPv4 charges.
+      Consider deleting the unused address or re-attaching the Gateway to it.
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - static_ip_users is defined
+    - not (gke_static_ipv4_bound | default(false))
+  tags: [ingress, verify, ip]
+
+- name: Enforce static IPv4 binding when configured
+  ansible.builtin.fail:
+    msg: |
+      Reserved static IPv4 '{{ gke_static_ip_name }}' is unbound after Gateway deployment.
+      This indicates address drift and may incur unnecessary IPv4 charges.
+      To bypass this guard (not recommended), set gke_fail_on_unbound_static_ipv4: false.
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - gke_fail_on_unbound_static_ipv4 | default(true) | bool
+    - static_ip_users is defined
+    - not (gke_static_ipv4_bound | default(false))
+  tags: [ingress, verify, ip]
+
 - name: Get Gateway status
   ansible.builtin.command:
     cmd: kubectl get gateway {{ gke_app_name }}-gateway -n default -o wide


### PR DESCRIPTION
## What This PR Does
This PR adds Infrastructure-as-Code support for running the app cluster on private GKE nodes while preserving required outbound connectivity via Cloud NAT.

## Why
- Reduce cost and exposure from per-node public IPv4 addresses
- Keep worker nodes private by default
- Preserve required outbound access for app dependencies (for example GCS and Google OAuth2)
- Keep database and mail traffic on internal VPC paths

## Scope
### 1) GKE cluster provisioning updates
- Adds validation for supported combinations:
  - private nodes only on Standard clusters
  - private nodes require custom VPC
  - private nodes require control-plane CIDR
  - Cloud NAT requires custom VPC
- Extends cluster creation flags:
  - `--enable-private-nodes`
  - `--master-ipv4-cidr`
  - optional `--enable-private-endpoint`

### 2) Cloud NAT provisioning
- Adds Cloud Router create step (idempotent)
- Adds Cloud NAT create/update flow (idempotent)
- Wires NAT flow into cluster provisioning playbook

### 3) Config + docs updates
- Adds private-node/NAT variables to cluster inventory example
- Adds override examples in group vars example
- Adds a dedicated "Private Nodes + Cloud NAT" section in provisioning docs

## Files Changed
- `infrastructure/ansible/playbooks/gcp-cluster-provision.yml`
- `infrastructure/ansible/inventory/gcp_cluster.yml.example`
- `infrastructure/ansible/group_vars/gcp_cluster.vars.yml.example`
- `infrastructure/ansible/docs/gke-cluster-provisioning-guide.md`

## Validation Performed
- `ansible-playbook --syntax-check -i infrastructure/ansible/inventory/gcp_cluster.yml infrastructure/ansible/playbooks/gcp-cluster-provision.yml`

## Operational Notes
- This PR introduces provisioning support; production migration should follow the runbook in Issue #901.
- For current rollout plan, SMTP remains on internal mail path (Option A).
- Cloud NAT stays enabled in Phase 1 to avoid breaking required outbound paths.

## Related
- Closes #901
