### PR TITLE
Show pending report columns in the training grid

### DIFF
--- a/instructors/tests/test_training_grid_multiple_instructors.py
+++ b/instructors/tests/test_training_grid_multiple_instructors.py
@@ -120,13 +120,14 @@ class TestTrainingGridMultipleInstructors(TestCase):
         """Set up for each test."""
         self.client = Client()
 
-    def test_training_grid_shows_correct_instructor_flight_counts(self):
+    def test_training_grid_shows_report_and_pending_columns_for_same_day(self):
         """
-        Verify that the training grid shows correct flight counts per instructor
-        when multiple instructors fly on the same day.
+        Verify that the training grid keeps the saved report column and adds
+        a blank pending column for the same-day instructor who has no report.
 
-        Expected: Instructor 1 (Manny) should show 2 flights, Instructor 2 (Rufus)
-        should show 1 flight, NOT 3 flights each.
+        Expected: Instructor 1 (Manny) shows the saved report column with
+        2 flights, and Instructor 2 (Rufus) gets a second pending column
+        with 1 flight.
         """
         # Login as student
         self.client.force_login(self.student)
@@ -143,18 +144,23 @@ class TestTrainingGridMultipleInstructors(TestCase):
 
         # Find the column for our date
         date_columns = [m for m in column_metadata if m["date"] == self.log_date]
-        assert len(date_columns) == 1, "Should have exactly one column for our date"
+        assert len(date_columns) == 2, "Should have a saved and pending column"
 
-        column = date_columns[0]
+        saved_column = date_columns[0]
+        pending_column = date_columns[1]
 
-        # The column should show the first instructor's flight count (2, not 3)
-        # This is the key fix: it should only count flights for that specific instructor
         assert (
-            column["num_flights"] == 2
-        ), f"First instructor column should show 2 flights, got {column['num_flights']}"
+            saved_column["num_flights"] == 2
+        ), f"Saved instructor column should show 2 flights, got {saved_column['num_flights']}"
         assert (
-            column["instructor_name"] == "Manny Serrano"
-        ), f"Column should show Manny Serrano, got {column['instructor_name']}"
+            saved_column["instructor_name"] == "Manny Serrano"
+        ), f"Saved column should show Manny Serrano, got {saved_column['instructor_name']}"
+        assert saved_column["is_pending"] is False
+
+        assert pending_column["instructor_name"] == "Rufus Decker"
+        assert pending_column["num_flights"] == 1
+        assert pending_column["is_pending"] is True
+        assert "Pending report" in pending_column["flights_tooltip"]
 
     def test_training_grid_instructor_initials_correct(self):
         """Verify that instructor initials are correctly displayed."""
@@ -270,3 +276,50 @@ class TestTrainingGridMultipleInstructors(TestCase):
         )
         assert lesson_row is not None
         assert [c["score"] for c in lesson_row["scores"]] == ["2", "4"]
+
+    def test_training_grid_shows_pending_only_date_without_saved_report(self):
+        """A date with flights but no saved report should still produce a blank column."""
+        pending_date = self.log_date - timedelta(days=2)
+        pending_logsheet = Logsheet.objects.create(
+            log_date=pending_date,
+            airfield=self.airfield,
+            created_by=self.student,
+            finalized=False,
+        )
+
+        for _ in range(2):
+            Flight.objects.create(
+                logsheet=pending_logsheet,
+                pilot=self.student,
+                glider=self.glider,
+                towplane=self.towplane,
+                instructor=self.instructor2,
+            )
+
+        self.client.force_login(self.student)
+        url = reverse("instructors:member_training_grid", args=[self.student.id])
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+
+        pending_columns = [
+            m for m in response.context["column_metadata"] if m["date"] == pending_date
+        ]
+        assert len(pending_columns) == 1
+
+        pending_column = pending_columns[0]
+        assert pending_column["instructor_name"] == "Rufus Decker"
+        assert pending_column["is_pending"] is True
+        assert pending_column["num_flights"] == 2
+
+        lesson_data = response.context["lesson_data"]
+        lesson_row = next(
+            (row for row in lesson_data if row["lesson_id"] == self.lesson.id), None
+        )
+        assert lesson_row is not None
+
+        pending_index = response.context["column_metadata"].index(pending_column)
+        pending_cell = lesson_row["scores"][pending_index]
+        assert pending_cell["score"] == ""
+        assert pending_cell["is_pending"] is True
+        assert "Pending report" in pending_cell["tooltip"]

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -589,47 +589,67 @@ def member_training_grid(request, member_id):
         for sc in rep.lesson_scores.all()
     }
 
+    today = now().date()
+    pending_cutoff = today - timedelta(days=30)
+
     report_entries_by_date = defaultdict(list)
     existing_report_keys = set()
     for report in report_entries:
         report_entries_by_date[report.report_date].append(report)
         existing_report_keys.add((report.report_date, report.instructor_id))
 
-    # Fetch flights for pending-column detection and per-column flight metadata.
-    flights = (
+    # Build pending columns from distinct instructor/date flight pairs, bounded to
+    # a recent window to avoid scanning/loading a student's full flight history.
+    pending_candidate_pairs = (
         Flight.objects.filter(pilot=member, instructor__isnull=False)
-        .select_related("logsheet", "instructor")
+        .filter(logsheet__log_date__gte=pending_cutoff)
+        .values_list("logsheet__log_date", "instructor_id")
+        .distinct()
         .order_by(
             "logsheet__log_date",
             "instructor__last_name",
             "instructor__first_name",
-            "id",
+            "instructor_id",
         )
     )
-    flights_by_date_instructor = defaultdict(lambda: defaultdict(list))
+
     pending_entries_by_date = defaultdict(list)
-    seen_pending_keys = set()
-    today = now().date()
+    pending_instructor_ids = set()
 
-    for f in flights:
-        d = f.logsheet.log_date
-
-        flights_by_date_instructor[d][f.instructor_id].append(f)
-
-        pending_key = (d, f.instructor_id)
-        if pending_key in existing_report_keys or pending_key in seen_pending_keys:
+    for report_date, instructor_id in pending_candidate_pairs:
+        pending_key = (report_date, instructor_id)
+        if pending_key in existing_report_keys:
             continue
 
-        seen_pending_keys.add(pending_key)
-        pending_entries_by_date[d].append(
+        pending_instructor_ids.add(instructor_id)
+        pending_entries_by_date[report_date].append(
             {
-                "date": d,
-                "instructor": f.instructor,
-                "instructor_id": f.instructor_id,
+                "date": report_date,
+                "instructor_id": instructor_id,
                 "is_pending": True,
                 "report_id": None,
             }
         )
+
+    pending_instructors_by_id = Member.objects.filter(
+        id__in=pending_instructor_ids
+    ).in_bulk()
+    for report_date, pending_entries in pending_entries_by_date.items():
+        resolved_entries = []
+        for entry in pending_entries:
+            instructor = pending_instructors_by_id.get(entry["instructor_id"])
+            if not instructor:
+                continue
+            resolved_entries.append(
+                {
+                    "date": report_date,
+                    "instructor": instructor,
+                    "instructor_id": entry["instructor_id"],
+                    "is_pending": True,
+                    "report_id": None,
+                }
+            )
+        pending_entries_by_date[report_date] = resolved_entries
 
     column_entries = []
     all_column_dates = sorted(
@@ -657,6 +677,22 @@ def member_training_grid(request, member_id):
         column_entries.extend(pending_columns)
 
     report_dates = [entry["date"] for entry in column_entries]
+
+    # Fetch only flights needed for currently rendered columns and tooltip counts.
+    column_dates = {entry["date"] for entry in column_entries}
+    column_instructor_ids = {entry["instructor_id"] for entry in column_entries}
+    flights = (
+        Flight.objects.filter(pilot=member, instructor__isnull=False)
+        .filter(
+            logsheet__log_date__in=column_dates,
+            instructor_id__in=column_instructor_ids,
+        )
+        .select_related("logsheet", "instructor")
+        .order_by("logsheet__log_date", "id")
+    )
+    flights_by_date_instructor = defaultdict(lambda: defaultdict(list))
+    for f in flights:
+        flights_by_date_instructor[f.logsheet.log_date][f.instructor_id].append(f)
 
     # Compose instructor initials/name per report column.
     def get_column_meta(column_entry):

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -602,7 +602,7 @@ def member_training_grid(request, member_id):
     # a recent window to avoid scanning/loading a student's full flight history.
     pending_candidate_pairs = (
         Flight.objects.filter(pilot=member, instructor__isnull=False)
-        .filter(logsheet__log_date__gte=pending_cutoff)
+        .filter(logsheet__log_date__gte=pending_cutoff, logsheet__log_date__lte=today)
         .values_list("logsheet__log_date", "instructor_id")
         .distinct()
         .order_by("logsheet__log_date", "instructor_id")

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -577,9 +577,9 @@ def member_training_grid(request, member_id):
     if request.user != member and not request.user.instructor:
         raise PermissionDenied
 
-    # Keep one grid column per report (date + instructor), ordered deterministically.
+    # Keep one grid column per saved report and add a pending column for
+    # any flight instructor/date pair that does not yet have a report.
     report_entries = list(reports)
-    report_dates = [r.report_date for r in report_entries]
     lessons = TrainingLesson.objects.all().order_by("sort_key")
 
     # Build lookup for scores by (lesson_id, report_id)
@@ -589,37 +589,86 @@ def member_training_grid(request, member_id):
         for sc in rep.lesson_scores.all()
     }
 
-    # Fetch flights for per-column flight counts and tooltip details.
+    report_entries_by_date = defaultdict(list)
+    existing_report_keys = set()
+    for report in report_entries:
+        report_entries_by_date[report.report_date].append(report)
+        existing_report_keys.add((report.report_date, report.instructor_id))
+
+    # Fetch flights for pending-column detection and per-column flight metadata.
     flights = (
-        Flight.objects.filter(pilot=member, logsheet__log_date__in=report_dates)
+        Flight.objects.filter(pilot=member, instructor__isnull=False)
         .select_related("logsheet", "instructor")
-        .order_by("logsheet__log_date", "id")
+        .order_by(
+            "logsheet__log_date",
+            "instructor__last_name",
+            "instructor__first_name",
+            "id",
+        )
     )
     flights_by_date_instructor = defaultdict(lambda: defaultdict(list))
+    pending_entries_by_date = defaultdict(list)
+    seen_pending_keys = set()
     today = now().date()
 
     for f in flights:
         d = f.logsheet.log_date
 
-        if not f.instructor:
-            continue
-
         flights_by_date_instructor[d][f.instructor_id].append(f)
 
-    # Compose instructor initials/name per report column.
-    def get_instructor_meta(report):
-        d = report.report_date
+        pending_key = (d, f.instructor_id)
+        if pending_key in existing_report_keys or pending_key in seen_pending_keys:
+            continue
 
-        # InstructionReport.instructor is required; map each column directly.
-        initials = get_instructor_initials(report.instructor)
-        full_name = str(report.instructor.full_display_name or "")
-        instructor_id = report.instructor_id
+        seen_pending_keys.add(pending_key)
+        pending_entries_by_date[d].append(
+            {
+                "date": d,
+                "instructor": f.instructor,
+                "instructor_id": f.instructor_id,
+                "is_pending": True,
+                "report_id": None,
+            }
+        )
+
+    column_entries = []
+    all_column_dates = sorted(
+        set(report_entries_by_date) | set(pending_entries_by_date)
+    )
+    for report_date in all_column_dates:
+        for report in report_entries_by_date.get(report_date, []):
+            column_entries.append(
+                {
+                    "date": report.report_date,
+                    "instructor": report.instructor,
+                    "instructor_id": report.instructor_id,
+                    "is_pending": False,
+                    "report_id": report.id,
+                }
+            )
+
+        pending_columns = sorted(
+            pending_entries_by_date.get(report_date, []),
+            key=lambda entry: (
+                str(entry["instructor"].full_display_name or ""),
+                entry["instructor_id"],
+            ),
+        )
+        column_entries.extend(pending_columns)
+
+    report_dates = [entry["date"] for entry in column_entries]
+
+    # Compose instructor initials/name per report column.
+    def get_column_meta(column_entry):
+        d = column_entry["date"]
+        instructor = column_entry["instructor"]
 
         return {
-            "initials": initials,
-            "full_name": full_name,
+            "initials": get_instructor_initials(instructor),
+            "full_name": str(instructor.full_display_name or ""),
             "days_ago": (today - d).days,
-            "instructor_id": instructor_id,
+            "instructor_id": column_entry["instructor_id"],
+            "is_pending": column_entry["is_pending"],
         }
 
     # Compose grid rows per lesson
@@ -634,24 +683,34 @@ def member_training_grid(request, member_id):
             "code": lesson.code,
         }
         max_scores = []
-        for rep in report_entries:
-            score = scores_lookup.get((lesson.id, rep.id), "")
+        for column_entry in column_entries:
+            score = ""
+            if column_entry["report_id"] is not None:
+                score = scores_lookup.get((lesson.id, column_entry["report_id"]), "")
             if score.isdigit():
                 max_scores.append(int(score))
-            info = get_instructor_meta(rep)
+            info = get_column_meta(column_entry)
             tooltip = f"{info['full_name']} – {info['days_ago']} days ago"
-            row["scores"].append({"score": score, "tooltip": tooltip})
+            if info["is_pending"]:
+                tooltip = f"Pending report: {tooltip}"
+            row["scores"].append(
+                {
+                    "score": score,
+                    "tooltip": tooltip,
+                    "is_pending": info["is_pending"],
+                }
+            )
         row["max_score"] = str(max(max_scores)) if max_scores else ""
         lesson_data.append(row)
 
-    # Build column metadata for template headers using per-report instructor metadata.
+    # Build column metadata for template headers using unified column metadata.
     column_metadata = []
-    for rep in report_entries:
-        d = rep.report_date
-        meta = get_instructor_meta(rep)
+    for column_entry in column_entries:
+        d = column_entry["date"]
+        meta = get_column_meta(column_entry)
 
         # Count/display flights for the instructor represented in this column.
-        instructor_id = meta.get("instructor_id")
+        instructor_id = meta["instructor_id"]
         flights_for_instructor = flights_by_date_instructor.get(d, {}).get(
             instructor_id, []
         )
@@ -660,6 +719,8 @@ def member_training_grid(request, member_id):
 
         # Build tooltip string with flights for this specific instructor
         tooltip_lines = [f"{num_flights} flight{'s' if num_flights != 1 else ''}"]
+        if meta["is_pending"]:
+            tooltip_lines.append("Pending report")
         for f in flights_for_instructor:
             tow = (
                 f.release_altitude
@@ -682,11 +743,12 @@ def member_training_grid(request, member_id):
         column_metadata.append(
             {
                 "date": d,
-                "initials": meta.get("initials", ""),
-                "days_ago": meta.get("days_ago", ""),
-                "instructor_name": meta.get("full_name", ""),
+                "initials": meta["initials"],
+                "days_ago": meta["days_ago"],
+                "instructor_name": meta["full_name"],
                 "num_flights": num_flights,
                 "flights_tooltip": flights_tooltip,
+                "is_pending": meta["is_pending"],
             }
         )
 

--- a/instructors/views.py
+++ b/instructors/views.py
@@ -605,12 +605,7 @@ def member_training_grid(request, member_id):
         .filter(logsheet__log_date__gte=pending_cutoff)
         .values_list("logsheet__log_date", "instructor_id")
         .distinct()
-        .order_by(
-            "logsheet__log_date",
-            "instructor__last_name",
-            "instructor__first_name",
-            "instructor_id",
-        )
+        .order_by("logsheet__log_date", "instructor_id")
     )
 
     pending_entries_by_date = defaultdict(list)

--- a/templates/shared/training_grid.html
+++ b/templates/shared/training_grid.html
@@ -71,7 +71,7 @@
     <tr>
   <th rowspan="3" class="sticky-col training-grid-lesson-col">Lesson</th>
       {% for meta in column_metadata %}
-        <th class="training-grid-date-col{% if forloop.revcounter > 10 %} print-hide-old-col{% endif %}">
+        <th class="training-grid-date-col{% if forloop.revcounter > 10 %} print-hide-old-col{% endif %}{% if meta.is_pending %} table-warning{% endif %}">
           {{ meta.date|date:"M d" }}<br>
           <span class="text-muted small">{{ meta.date|date:"Y" }}</span>
         </th>
@@ -80,22 +80,25 @@
     </tr>
     <tr>
         {% for meta in column_metadata %}
-          <th class="small text-muted training-grid-date-col{% if forloop.revcounter > 10 %} print-hide-old-col{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top"{% if meta.instructor_name %} title="{{ meta.instructor_name }}{% if meta.days_ago %} — {{ meta.days_ago }} days ago{% endif %}"{% endif %}>
+          <th class="small text-muted training-grid-date-col{% if forloop.revcounter > 10 %} print-hide-old-col{% endif %}{% if meta.is_pending %} table-warning{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top"{% if meta.instructor_name %} title="{{ meta.instructor_name }}{% if meta.days_ago %} — {{ meta.days_ago }} days ago{% endif %}{% if meta.is_pending %} — pending report{% endif %}"{% endif %}>
             {% if meta.initials %}
               {{ meta.initials }}<br>
             {% else %}
               &mdash;<br>
             {% endif %}
             {{ meta.days_ago }}<br>
+            {% if meta.is_pending %}
+              <span class="small fw-semibold text-dark">Pending</span>
+            {% endif %}
             {% if meta.altitudes %}{{ meta.altitudes }}{% endif %}
           </th>
         {% endfor %}
     </tr>
     <tr>
         {% for meta in column_metadata %}
-          <th class="training-grid-date-col{% if forloop.revcounter > 10 %} print-hide-old-col{% endif %}">
+          <th class="training-grid-date-col{% if forloop.revcounter > 10 %} print-hide-old-col{% endif %}{% if meta.is_pending %} table-warning{% endif %}">
             {% if meta.num_flights > 0 %}
-              <span class="badge bg-secondary text-light fs-6" style="min-width:2em;"{% if meta.flights_tooltip %} title="{{ meta.flights_tooltip }}"{% endif %}>{{ meta.num_flights }}</span>
+              <span class="badge {% if meta.is_pending %}bg-warning text-dark{% else %}bg-secondary text-light{% endif %} fs-6" style="min-width:2em;"{% if meta.flights_tooltip %} title="{{ meta.flights_tooltip }}"{% endif %}>{{ meta.num_flights }}</span>
             {% endif %}
           </th>
         {% endfor %}
@@ -123,7 +126,7 @@
               {% endif %}
             </td>
             {% for cell in row.scores %}
-            <td class="text-center training-grid-date-col{% if forloop.revcounter > 10 %} print-hide-old-col{% endif %}
+            <td class="text-center training-grid-date-col{% if forloop.revcounter > 10 %} print-hide-old-col{% endif %}{% if cell.is_pending %} table-warning{% endif %}
                 {% if cell.score == '1' %}score-1
                 {% elif cell.score == '2' %}score-2
                 {% elif cell.score == '3' %}score-3

--- a/templates/shared/training_grid.html
+++ b/templates/shared/training_grid.html
@@ -80,7 +80,7 @@
     </tr>
     <tr>
         {% for meta in column_metadata %}
-          <th class="small text-muted training-grid-date-col{% if forloop.revcounter > 10 %} print-hide-old-col{% endif %}{% if meta.is_pending %} table-warning{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top"{% if meta.instructor_name %} title="{{ meta.instructor_name }}{% if meta.days_ago %} — {{ meta.days_ago }} days ago{% endif %}{% if meta.is_pending %} — pending report{% endif %}"{% endif %}>
+          <th class="small text-muted training-grid-date-col{% if forloop.revcounter > 10 %} print-hide-old-col{% endif %}{% if meta.is_pending %} table-warning{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top"{% if meta.instructor_name %} title="{{ meta.instructor_name }}{% if meta.days_ago is not None %} — {{ meta.days_ago }} days ago{% endif %}{% if meta.is_pending %} — pending report{% endif %}"{% endif %}>
             {% if meta.initials %}
               {{ meta.initials }}<br>
             {% else %}


### PR DESCRIPTION
## Summary
Restore the training grid behavior for issue #907 by showing a blank pending column when a student has flown with an instructor but no instruction report has been filed yet.

## What Changed
- build grid columns from both saved instruction reports and pending flight-only instructor/date slots
- keep lesson scores tied only to saved reports so pending columns remain visibly blank
- mark pending columns in the grid header and flight-count badge so missing documentation is obvious
- extend training grid regression coverage for same-day mixed saved/pending columns and pending-only dates

Fixes #907

## Validation
- `pytest instructors/tests/test_training_grid_multiple_instructors.py instructors/tests/test_pending_spr_reminders.py -q`
- editor diagnostics for touched files returned no errors