### PR TITLE
Track CMS document update timestamps

### DIFF
--- a/cms/migrations/0020_document_updated_at.py
+++ b/cms/migrations/0020_document_updated_at.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+from django.db.models import F
+
+
+def backfill_document_updated_at(apps, schema_editor):
+    Document = apps.get_model("cms", "Document")
+    Document.objects.filter(updated_at__isnull=True).update(updated_at=F("uploaded_at"))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cms", "0019_document_file_size_bytes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="document",
+            name="updated_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.RunPython(backfill_document_updated_at, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="document",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True),
+        ),
+    ]

--- a/cms/migrations/0020_document_updated_at.py
+++ b/cms/migrations/0020_document_updated_at.py
@@ -4,7 +4,10 @@ from django.db.models import F
 
 def backfill_document_updated_at(apps, schema_editor):
     Document = apps.get_model("cms", "Document")
-    Document.objects.filter(updated_at__isnull=True).update(updated_at=F("uploaded_at"))
+    db_alias = schema_editor.connection.alias
+    Document.objects.using(db_alias).filter(updated_at__isnull=True).update(
+        updated_at=F("uploaded_at")
+    )
 
 
 class Migration(migrations.Migration):

--- a/cms/models.py
+++ b/cms/models.py
@@ -646,6 +646,7 @@ class Document(models.Model):
         settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.SET_NULL
     )
     uploaded_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
     file_size_bytes = models.BigIntegerField(
         null=True,
         blank=True,
@@ -682,6 +683,12 @@ class Document(models.Model):
                 update_fields_set = set(update_fields)
                 # Recompute only when the file itself is being updated.
                 refresh_size = "file" in update_fields_set
+
+        if update_fields is not None:
+            update_fields_set = set(update_fields)
+            update_fields_set.add("updated_at")
+            kwargs["update_fields"] = tuple(update_fields_set)
+            update_fields = kwargs["update_fields"]
 
         if refresh_size:
             try:

--- a/cms/templates/cms/page.html
+++ b/cms/templates/cms/page.html
@@ -158,7 +158,7 @@
                 <span><strong>{{ doc.title|default:"Untitled PDF" }}</strong></span>
                 <span style="font-size:0.95em;color:#555;">
                   {% if doc.uploaded_by %}Uploaded by {{ doc.uploaded_by.get_full_name|default:doc.uploaded_by.username }}{% endif %}
-                  {% if doc.uploaded_at %} on {{ doc.uploaded_at|date:"Y-m-d H:i" }}{% endif %}
+                  {% if doc.updated_at %}{% if doc.uploaded_by %} &bull; {% endif %}Last updated {{ doc.updated_at|date:"Y-m-d H:i" }}{% endif %}
                   {% if doc.file_size_bytes is not None %} &bull; {{ doc.file_size_bytes|filesizeformat }}{% endif %}
                 </span>
               </div>

--- a/cms/tests/test_document_performance.py
+++ b/cms/tests/test_document_performance.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -5,6 +6,7 @@ import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.urls import reverse
+from django.utils import timezone
 
 from cms.models import Document, Page
 
@@ -56,6 +58,30 @@ def test_document_save_refreshes_file_size_when_file_replaced(settings, tmp_path
     doc.refresh_from_db()
 
     assert doc.file_size_bytes == len(replacement)
+
+
+@pytest.mark.django_db
+def test_document_save_updates_updated_at_when_file_replaced(settings, tmp_path):
+    _use_filesystem_storage(settings)
+    settings.MEDIA_ROOT = str(tmp_path)
+
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "original.pdf").write_bytes(b"%PDF-1.4 original")
+    (docs_dir / "replacement.pdf").write_bytes(b"%PDF-1.4 replacement")
+
+    page = Page.objects.create(title="Docs", slug="docs-updated-at", is_public=True)
+    doc = Document.objects.create(page=page, title="Doc", file="docs/original.pdf")
+
+    original_updated_at = timezone.make_aware(datetime(2026, 1, 1, 12, 0, 0))
+    Document.objects.filter(pk=doc.pk).update(updated_at=original_updated_at)
+
+    doc.refresh_from_db()
+    doc.file = "docs/replacement.pdf"
+    doc.save()
+    doc.refresh_from_db()
+
+    assert doc.updated_at > original_updated_at
 
 
 @pytest.mark.django_db
@@ -122,6 +148,43 @@ def test_cms_page_hides_documents_section_when_no_pdfs(client, settings, tmp_pat
 
     assert response.status_code == 200
     assert b"<h2>Documents</h2>" not in response.content
+
+
+@pytest.mark.django_db
+def test_cms_page_uses_document_updated_at_for_last_updated(client, settings, tmp_path):
+    _use_filesystem_storage(settings)
+    settings.MEDIA_ROOT = str(tmp_path)
+
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "handbook.pdf").write_bytes(b"%PDF-1.4 handbook")
+
+    parent = Page.objects.create(title="Docs Home", slug="docs-home", is_public=True)
+    child = Page.objects.create(
+        title="SSC Documents", slug="ssc-documents", parent=parent, is_public=True
+    )
+    doc = Document.objects.create(
+        page=child, title="Handbook", file="docs/handbook.pdf"
+    )
+
+    child_updated_at = timezone.make_aware(datetime(2026, 1, 1, 10, 0, 0))
+    document_updated_at = timezone.make_aware(datetime(2026, 2, 3, 15, 20, 0))
+    Page.objects.filter(pk=child.pk).update(updated_at=child_updated_at)
+    Document.objects.filter(pk=doc.pk).update(updated_at=document_updated_at)
+
+    response = client.get(reverse("cms:cms_page", kwargs={"path": parent.slug}))
+
+    assert response.status_code == 200
+    subpages = response.context["subpages"]
+    child_entry = next(item for item in subpages if item["page"].pk == child.pk)
+    assert child_entry["last_updated"] == document_updated_at
+
+    response = client.get(
+        reverse("cms:cms_page", kwargs={"path": f"{parent.slug}/{child.slug}"})
+    )
+
+    assert response.status_code == 200
+    assert b"Last updated 2026-02-03 15:20" in response.content
 
 
 @pytest.mark.django_db

--- a/cms/tests/test_document_performance.py
+++ b/cms/tests/test_document_performance.py
@@ -85,6 +85,33 @@ def test_document_save_updates_updated_at_when_file_replaced(settings, tmp_path)
 
 
 @pytest.mark.django_db
+def test_document_save_with_update_fields_advances_updated_at(settings, tmp_path):
+    _use_filesystem_storage(settings)
+    settings.MEDIA_ROOT = str(tmp_path)
+
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "update-fields.pdf").write_bytes(b"%PDF-1.4 update fields")
+
+    page = Page.objects.create(title="Docs", slug="docs-update-fields", is_public=True)
+    doc = Document.objects.create(
+        page=page,
+        title="Original Title",
+        file="docs/update-fields.pdf",
+    )
+
+    original_updated_at = timezone.make_aware(datetime(2026, 1, 1, 12, 0, 0))
+    Document.objects.filter(pk=doc.pk).update(updated_at=original_updated_at)
+
+    doc.refresh_from_db()
+    doc.title = "Updated Title"
+    doc.save(update_fields=["title"])
+    doc.refresh_from_db()
+
+    assert doc.updated_at > original_updated_at
+
+
+@pytest.mark.django_db
 def test_cms_page_does_not_call_storage_size_when_file_size_cached(
     client, settings, tmp_path
 ):

--- a/cms/views.py
+++ b/cms/views.py
@@ -161,7 +161,7 @@ def cms_page(request, **kwargs):
     subpages = []
     children = (
         page.children.annotate(
-            doc_count=Count("documents"), doc_max=Max("documents__uploaded_at")
+            doc_count=Count("documents"), doc_max=Max("documents__updated_at")
         )
         .prefetch_related("role_permissions")
         .order_by("title")
@@ -171,7 +171,7 @@ def cms_page(request, **kwargs):
         if not child.can_user_access(request.user, request):
             continue
 
-        # last updated is the later of the page's updated_at and latest document upload
+        # last updated is the later of the page's updated_at and latest document update
         last_updated = child.updated_at
         if getattr(child, "doc_max", None) and child.doc_max > last_updated:
             last_updated = child.doc_max

--- a/templates/cms/edit_page.html
+++ b/templates/cms/edit_page.html
@@ -155,7 +155,7 @@
                                                     {{ form.instance.title|default:form.instance.file.name }}
                                                 </h6>
                                                 <small class="text-muted">
-                                                    Uploaded {{ form.instance.uploaded_at|date:"M d, Y H:i" }}
+                                                    Last updated {{ form.instance.updated_at|date:"M d, Y H:i" }}
                                                     {% if form.instance.uploaded_by %}
                                                         by {{ form.instance.uploaded_by.get_full_name|default:form.instance.uploaded_by.username }}
                                                     {% endif %}

--- a/templates/cms/edit_page.html
+++ b/templates/cms/edit_page.html
@@ -155,10 +155,11 @@
                                                     {{ form.instance.title|default:form.instance.file.name }}
                                                 </h6>
                                                 <small class="text-muted">
-                                                    Last updated {{ form.instance.updated_at|date:"M d, Y H:i" }}
                                                     {% if form.instance.uploaded_by %}
-                                                        by {{ form.instance.uploaded_by.get_full_name|default:form.instance.uploaded_by.username }}
+                                                        Uploaded by {{ form.instance.uploaded_by.get_full_name|default:form.instance.uploaded_by.username }}
+                                                        •
                                                     {% endif %}
+                                                    Last updated {{ form.instance.updated_at|date:"M d, Y H:i" }}
                                                 </small>
                                             </div>
                                             <div>


### PR DESCRIPTION
## Summary
Fix the stale "Last updated" timestamp in the public CMS document repository by tracking document modification time separately from original upload time.

Fixes #910

## What Changed
- add `cms.Document.updated_at` with a backfill migration seeded from existing `uploaded_at` values
- ensure `Document.save()` preserves `updated_at` even when `update_fields` is used
- update CMS page aggregation to use the latest document update time when computing subpage `last_updated`
- show `Last updated` instead of original upload time in the public document accordion and CMS edit page UI
- add focused regression coverage for document replacement and public page timestamp rendering

## Validation
- `pytest cms/tests/test_document_performance.py cms/tests/test_page_breadcrumbs.py -q`
- editor diagnostics on touched files returned no errors

## Notes
- This PR includes a schema migration: `cms/migrations/0020_document_updated_at.py`
- Existing documents are backfilled so their initial `updated_at` matches `uploaded_at`