### PR TITLE
Security: Upgrade Django to 5.2.14 and urllib3 to 2.7.0 (Dependabot alerts #50–#54)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ cyclonedx-python-lib==9.1.0
 defusedxml==0.7.1
 diff-match-patch==20241021
 distlib==0.4.0
-Django==5.2.13
+Django==5.2.14
 django-crispy-forms==2.4
 django-extensions==4.1
 django-htmx==1.23.2
@@ -136,6 +136,6 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.2
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 virtualenv==20.36.1
 wheel>=0.46.3


### PR DESCRIPTION
## Summary

Resolves 5 open Dependabot security alerts by upgrading two pip dependencies.

## Changes

- `Django`: `5.2.13` → `5.2.14`
- `urllib3`: `2.6.3` → `2.7.0`

## Alerts Resolved

| Alert | Severity | Package | Description |
|-------|----------|---------|-------------|
| #50 | Low | Django | Uses Persistent Cookies Containing Sensitive Information |
| #51 | Medium | Django | Improper Handling of Length Parameter Inconsistency |
| #52 | Low | Django | Uses Cache Containing Sensitive Information |
| #53 | High | urllib3 | Decompression-bomb safeguards bypassed in parts of the streaming API |
| #54 | High | urllib3 | Sensitive headers forwarded across origins in proxied low-level redirects |

## Validation

- `python manage.py check` — no issues
- Pre-commit hooks (bandit, django-upgrade, isort, black) — all passed