### PR TITLE
feat(infra): IaC hardening for private-node migration (issue #913)

### DIFF
--- a/infrastructure/ansible/inventory/gcp_app.yml.example
+++ b/infrastructure/ansible/inventory/gcp_app.yml.example
@@ -99,6 +99,18 @@ all:
     # Enable to expose the application via domain names
     gke_enable_ingress: false
 
+    # Reserved static IPv4 drift guard behavior:
+    # - false (default): warn only when reserved IPv4 is unbound
+    # - true: fail deployment when reserved IPv4 is unbound
+    # Recommended: true in strict production workflows
+    gke_fail_on_unbound_static_ipv4: false
+
+    # Optional cleanup for unbound reserved static IPv4 (Issue #913)
+    # SAFETY: deletion requires BOTH flags to be true
+    gke_cleanup_unbound_static_ipv4: false
+    gke_cleanup_unbound_static_ipv4_execute: false
+    gke_cleanup_unbound_static_ipv4_grace_seconds: 60
+
     # TLS is enabled by default using Google-managed SSL certificates
     # These are free, automatic, and don't require cert-manager or Let's Encrypt
     # gke_enable_tls: true  # Default

--- a/infrastructure/ansible/inventory/gcp_cluster.yml.example
+++ b/infrastructure/ansible/inventory/gcp_cluster.yml.example
@@ -107,6 +107,32 @@ all:
     gke_use_spot_vms: false
 
     # ============================================================
+    # PRIVATE-NODE ROLLOUT HARDENING (Issue #913)
+    # ============================================================
+
+    # Run node-pool rollout command during migration when legacy worker nodes
+    # still have public IPv4 addresses.
+    gke_enable_private_node_pool_rollout: true
+
+    # Wait/poll settings for rollout completion gate
+    gke_wait_for_node_pool_rollout: true
+    gke_node_pool_rollout_wait_retries: 60
+    gke_node_pool_rollout_wait_delay: 20
+
+    # Fail if any worker public IPv4 remains after migration and rollout.
+    gke_assert_zero_public_worker_ipv4: true
+
+    # Optional outbound NAT smoke test (disabled by default).
+    # This test requires explicit target inputs and is intended for maintenance
+    # verification runs, not every routine apply.
+    gke_run_nat_egress_smoke_test: false
+    gke_nat_smoke_test_namespace: ""
+    gke_nat_smoke_test_pod_selector: ""
+    gke_nat_smoke_test_pod_name: ""
+    gke_nat_smoke_test_url: "https://api.ipify.org"
+    gke_nat_smoke_test_timeout_seconds: 10
+
+    # ============================================================
     # SECURITY & ACCESS
     # ============================================================
 

--- a/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
+++ b/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
@@ -596,6 +596,7 @@
         cmd: >
           gcloud compute instances list
           --project={{ gcp_project }}
+          --zones={{ gcp_zone }}
           --filter="name~^gke-{{ gke_cluster_name }}-"
           --format="value(networkInterfaces[0].accessConfigs[0].natIP)"
       register: post_rollout_node_nat_ips

--- a/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
+++ b/infrastructure/ansible/playbooks/gcp-cluster-provision.yml
@@ -540,6 +540,109 @@
       tags: [cluster, autoscaling]
 
     # ============================================================
+    # PRIVATE-NODE ROLLOUT HARDENING (Issue #913)
+    # ============================================================
+    - name: Trigger node pool rollout to replace legacy public-IP nodes
+      ansible.builtin.command:
+        cmd: >
+          gcloud container node-pools update {{ gke_node_pool_name }}
+          --cluster={{ gke_cluster_name }}
+          --project={{ gcp_project }}
+          --zone={{ gcp_zone }}
+          --enable-private-nodes
+      register: nodepool_private_nodes_update
+      changed_when: nodepool_private_nodes_update.rc == 0
+      failed_when: >
+        nodepool_private_nodes_update.rc != 0 and
+        'already has private nodes enabled' not in (nodepool_private_nodes_update.stderr | default('') | lower) and
+        'already configured' not in (nodepool_private_nodes_update.stderr | default('') | lower)
+      when:
+        - gke_cluster_type == 'standard'
+        - gke_private_nodes | default(false) | bool
+        - existing_standard_cluster.rc == 0
+        - gke_nodes_have_public_ips | default(false)
+        - gke_enable_private_node_pool_rollout | default(true) | bool
+        - not ansible_check_mode
+      tags: [cluster, nodepool]
+
+    - name: Wait for node pool rollout operations to complete
+      ansible.builtin.command:
+        cmd: >
+          gcloud container operations list
+          --project={{ gcp_project }}
+          --location={{ gcp_zone }}
+          --filter="targetLink~clusters/{{ gke_cluster_name }} AND status!=DONE AND (operationType=UPDATE_CLUSTER OR operationType=UPGRADE_NODES)"
+          --format="value(name)"
+      register: nodepool_rollout_pending_ops
+      changed_when: false
+      retries: "{{ gke_node_pool_rollout_wait_retries | default(60) }}"
+      delay: "{{ gke_node_pool_rollout_wait_delay | default(20) }}"
+      until: >-
+        (nodepool_rollout_pending_ops.stdout_lines | default([])
+        | map('trim') | reject('equalto', '') | list | length) == 0
+      when:
+        - gke_cluster_type == 'standard'
+        - gke_private_nodes | default(false) | bool
+        - existing_standard_cluster is defined
+        - existing_standard_cluster.rc == 0
+        - gke_nodes_have_public_ips | default(false)
+        - gke_enable_private_node_pool_rollout | default(true) | bool
+        - gke_wait_for_node_pool_rollout | default(true) | bool
+        - not ansible_check_mode
+      tags: [cluster, nodepool, verify]
+
+    - name: Re-check worker node public IPs after private-node rollout
+      ansible.builtin.command:
+        cmd: >
+          gcloud compute instances list
+          --project={{ gcp_project }}
+          --filter="name~^gke-{{ gke_cluster_name }}-"
+          --format="value(networkInterfaces[0].accessConfigs[0].natIP)"
+      register: post_rollout_node_nat_ips
+      changed_when: false
+      when:
+        - gke_cluster_type == 'standard'
+        - gke_private_nodes | default(false) | bool
+        - existing_standard_cluster is defined
+        - existing_standard_cluster.rc == 0
+        - gke_enable_private_node_pool_rollout | default(true) | bool
+        - not ansible_check_mode
+      tags: [cluster, verify]
+
+    - name: Build remaining worker public IPv4 list
+      ansible.builtin.set_fact:
+        gke_remaining_worker_public_ipv4s: >-
+          {{
+            post_rollout_node_nat_ips.stdout_lines | default([])
+            | map('trim') | reject('equalto', '') | list
+          }}
+      when:
+        - gke_cluster_type == 'standard'
+        - gke_private_nodes | default(false) | bool
+        - existing_standard_cluster is defined
+        - existing_standard_cluster.rc == 0
+        - gke_enable_private_node_pool_rollout | default(true) | bool
+        - not ansible_check_mode
+      tags: [cluster, verify]
+
+    - name: Assert zero worker public IPv4 after private-node rollout
+      ansible.builtin.assert:
+        that:
+          - (gke_remaining_worker_public_ipv4s | default([]) | length) == 0
+        fail_msg: |
+          Worker nodes still expose public IPv4 after private-node rollout.
+          Remaining public IPv4 addresses: {{ gke_remaining_worker_public_ipv4s | default([]) | join(', ') }}
+          Investigate node pool rollout status and rerun playbook once rollout completes.
+      when:
+        - gke_cluster_type == 'standard'
+        - gke_private_nodes | default(false) | bool
+        - existing_standard_cluster is defined
+        - existing_standard_cluster.rc == 0
+        - gke_assert_zero_public_worker_ipv4 | default(true) | bool
+        - not ansible_check_mode
+      tags: [cluster, verify]
+
+    # ============================================================
     # GET CREDENTIALS
     # ============================================================
     - name: Get cluster credentials
@@ -571,6 +674,92 @@
       register: nodes_result
       changed_when: false
       tags: [verify]
+
+    - name: Validate NAT smoke test inputs
+      ansible.builtin.assert:
+        that:
+          - gke_nat_smoke_test_namespace | default('') | length > 0
+          - >-
+            (gke_nat_smoke_test_pod_name | default('') | length > 0) or
+            (gke_nat_smoke_test_pod_selector | default('') | length > 0)
+        fail_msg: |
+          NAT smoke test requires explicit target inputs.
+          Set gke_nat_smoke_test_namespace and either:
+          - gke_nat_smoke_test_pod_name, or
+          - gke_nat_smoke_test_pod_selector
+      when:
+        - gke_run_nat_egress_smoke_test | default(false) | bool
+      tags: [verify, nat]
+
+    - name: Discover NAT smoke test pod by selector
+      ansible.builtin.command:
+        cmd: >
+          kubectl get pods
+          -n {{ gke_nat_smoke_test_namespace }}
+          -l {{ gke_nat_smoke_test_pod_selector }}
+          --field-selector=status.phase=Running
+          --no-headers
+          -o custom-columns=:metadata.name
+      register: nat_smoke_test_pods
+      changed_when: false
+      when:
+        - gke_run_nat_egress_smoke_test | default(false) | bool
+        - gke_nat_smoke_test_pod_name | default('') | length == 0
+      tags: [verify, nat]
+
+    - name: Set selected NAT smoke test pod
+      ansible.builtin.set_fact:
+        gke_nat_smoke_selected_pod: >-
+          {{
+            gke_nat_smoke_test_pod_name | default('')
+            if (gke_nat_smoke_test_pod_name | default('') | length > 0)
+            else (nat_smoke_test_pods.stdout_lines | default([]) | first | default(''))
+          }}
+      when:
+        - gke_run_nat_egress_smoke_test | default(false) | bool
+      tags: [verify, nat]
+
+    - name: Assert NAT smoke test pod is available
+      ansible.builtin.assert:
+        that:
+          - gke_nat_smoke_selected_pod | default('') | length > 0
+        fail_msg: |
+          NAT smoke test could not find a running pod.
+          Namespace: {{ gke_nat_smoke_test_namespace | default('unset') }}
+          Selector: {{ gke_nat_smoke_test_pod_selector | default('unset') }}
+          Pod name override: {{ gke_nat_smoke_test_pod_name | default('unset') }}
+      when:
+        - gke_run_nat_egress_smoke_test | default(false) | bool
+      tags: [verify, nat]
+
+    - name: Run optional NAT egress smoke test
+      ansible.builtin.command:
+        cmd: >
+          kubectl exec
+          -n {{ gke_nat_smoke_test_namespace }}
+          {{ gke_nat_smoke_selected_pod }}
+          -- python -c "import urllib.request; print(urllib.request.urlopen('{{ gke_nat_smoke_test_url | default('https://api.ipify.org') }}', timeout={{ gke_nat_smoke_test_timeout_seconds | default(10) }}).read().decode())"
+      register: nat_smoke_test_result
+      changed_when: false
+      failed_when: >
+        nat_smoke_test_result.rc != 0 or
+        (nat_smoke_test_result.stdout | default('') | trim | length) == 0
+      when:
+        - gke_run_nat_egress_smoke_test | default(false) | bool
+        - not ansible_check_mode
+      tags: [verify, nat]
+
+    - name: Display NAT smoke test result
+      ansible.builtin.debug:
+        msg: |
+          NAT egress smoke test passed.
+          Namespace: {{ gke_nat_smoke_test_namespace }}
+          Pod: {{ gke_nat_smoke_selected_pod }}
+          Observed outbound IP: {{ nat_smoke_test_result.stdout | trim }}
+      when:
+        - gke_run_nat_egress_smoke_test | default(false) | bool
+        - nat_smoke_test_result is defined
+      tags: [verify, nat]
 
     - name: Display cluster status
       ansible.builtin.debug:

--- a/infrastructure/ansible/roles/gke-deploy/defaults/main.yml
+++ b/infrastructure/ansible/roles/gke-deploy/defaults/main.yml
@@ -271,7 +271,16 @@ gke_static_ip_name: "{{ gke_cluster_name }}-ingress-ip"
 # When true, fail deployment if the reserved IPv4 static address is not actually
 # attached to any forwarding rule after Gateway reconcile.
 # Default is false to keep deploys non-blocking while still surfacing warnings.
+# Set to true in inventory for strict enforcement in production.
 gke_fail_on_unbound_static_ipv4: false
+
+# Opt-in cleanup for unbound reserved static IPv4 addresses.
+# SAFETY: Deletion requires BOTH flags to be true.
+gke_cleanup_unbound_static_ipv4: false
+gke_cleanup_unbound_static_ipv4_execute: false
+
+# Grace period before re-check + delete to avoid racing Gateway reconciliation.
+gke_cleanup_unbound_static_ipv4_grace_seconds: 60
 
 # Enable IPv6 for Gateway/Ingress
 # When true, reserves both IPv4 and IPv6 global static IPs

--- a/infrastructure/ansible/roles/gke-deploy/tasks/ingress.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/ingress.yml
@@ -659,6 +659,116 @@
     - not (gke_static_ipv4_bound | default(false))
   tags: [ingress, verify, ip]
 
+- name: Preview cleanup for unbound reserved static IPv4
+  ansible.builtin.debug:
+    msg: |
+      Unbound reserved static IPv4 cleanup is enabled in preview mode.
+      Address: {{ gke_static_ip_name }}
+      IP: {{ gke_ingress_ip | default('unknown') }}
+      No deletion performed because gke_cleanup_unbound_static_ipv4_execute is false.
+      To execute deletion, set BOTH:
+        gke_cleanup_unbound_static_ipv4: true
+        gke_cleanup_unbound_static_ipv4_execute: true
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - gke_cleanup_unbound_static_ipv4 | default(false) | bool
+    - not (gke_cleanup_unbound_static_ipv4_execute | default(false) | bool)
+    - static_ip_users is defined
+    - static_ip_users.rc == 0
+    - not (gke_static_ipv4_bound | default(false))
+  tags: [ingress, verify, ip, cleanup]
+
+- name: Wait before unbound static IPv4 cleanup re-check
+  ansible.builtin.pause:
+    seconds: "{{ gke_cleanup_unbound_static_ipv4_grace_seconds | default(60) }}"
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - gke_cleanup_unbound_static_ipv4 | default(false) | bool
+    - gke_cleanup_unbound_static_ipv4_execute | default(false) | bool
+    - static_ip_users is defined
+    - static_ip_users.rc == 0
+    - not (gke_static_ipv4_bound | default(false))
+  tags: [ingress, verify, ip, cleanup]
+
+- name: Re-check static IPv4 users before cleanup delete
+  ansible.builtin.command:
+    cmd: >
+      gcloud compute addresses describe {{ gke_static_ip_name }}
+      --global
+      --project={{ gcp_project }}
+      --format="value(users)"
+  register: static_ip_users_recheck
+  changed_when: false
+  failed_when: false
+  delegate_to: localhost
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - gke_cleanup_unbound_static_ipv4 | default(false) | bool
+    - gke_cleanup_unbound_static_ipv4_execute | default(false) | bool
+    - static_ip_users is defined
+    - static_ip_users.rc == 0
+    - not (gke_static_ipv4_bound | default(false))
+  tags: [ingress, verify, ip, cleanup]
+
+- name: Determine whether reserved static IPv4 is still unbound before delete
+  ansible.builtin.set_fact:
+    gke_static_ipv4_still_unbound: "{{ (static_ip_users_recheck.stdout | default('') | trim) | length == 0 }}"
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - static_ip_users_recheck is defined
+  tags: [ingress, verify, ip, cleanup]
+
+- name: Skip cleanup delete because static IPv4 was re-bound
+  ansible.builtin.debug:
+    msg: |
+      Skipping static IPv4 deletion because it became bound during re-check.
+      Address: {{ gke_static_ip_name }}
+      Current users: {{ static_ip_users_recheck.stdout | trim }}
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - gke_cleanup_unbound_static_ipv4 | default(false) | bool
+    - gke_cleanup_unbound_static_ipv4_execute | default(false) | bool
+    - static_ip_users_recheck is defined
+    - not (gke_static_ipv4_still_unbound | default(false))
+  tags: [ingress, verify, ip, cleanup]
+
+- name: Delete unbound reserved static IPv4 (opt-in)
+  ansible.builtin.command:
+    cmd: >
+      gcloud compute addresses delete {{ gke_static_ip_name }}
+      --global
+      --project={{ gcp_project }}
+      --quiet
+  register: static_ip_cleanup_delete
+  changed_when: static_ip_cleanup_delete.rc == 0
+  failed_when: static_ip_cleanup_delete.rc != 0
+  delegate_to: localhost
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - gke_cleanup_unbound_static_ipv4 | default(false) | bool
+    - gke_cleanup_unbound_static_ipv4_execute | default(false) | bool
+    - static_ip_users_recheck is defined
+    - gke_static_ipv4_still_unbound | default(false)
+  tags: [ingress, verify, ip, cleanup]
+
+- name: Report unbound static IPv4 cleanup result
+  ansible.builtin.debug:
+    msg: |
+      Deleted unbound reserved static IPv4.
+      Address: {{ gke_static_ip_name }}
+      IP: {{ gke_ingress_ip | default('unknown') }}
+  run_once: true
+  when:
+    - not ansible_check_mode
+    - (static_ip_cleanup_delete.rc | default(1)) == 0
+  tags: [ingress, verify, ip, cleanup]
+
 - name: Get Gateway status
   ansible.builtin.command:
     cmd: kubectl get gateway {{ gke_app_name }}-gateway -n default -o wide

--- a/infrastructure/ansible/roles/gke-deploy/tasks/ingress.yml
+++ b/infrastructure/ansible/roles/gke-deploy/tasks/ingress.yml
@@ -715,7 +715,11 @@
 
 - name: Determine whether reserved static IPv4 is still unbound before delete
   ansible.builtin.set_fact:
-    gke_static_ipv4_still_unbound: "{{ (static_ip_users_recheck.stdout | default('') | trim) | length == 0 }}"
+    gke_static_ipv4_still_unbound: >-
+      {{
+        static_ip_users_recheck.rc == 0 and
+        (static_ip_users_recheck.stdout | default('') | trim) | length == 0
+      }}
   run_once: true
   when:
     - not ansible_check_mode


### PR DESCRIPTION
## Summary

Implements all 5 deferred IaC hardening tasks from issue #913, making the private-node migration fully reproducible and verifiable through Ansible.

## Changes

### `playbooks/gcp-cluster-provision.yml`
- **Task 1** — `Trigger node pool rollout to replace legacy public-IP nodes`: runs `gcloud container node-pools update --enable-private-nodes`, guarded by `gke_nodes_have_public_ips` fact and `gke_enable_private_node_pool_rollout` flag (default `true`).
- **Task 2** — `Wait for node pool rollout operations to complete`: polls `gcloud container operations list` until no pending ops, with configurable retries (`gke_node_pool_rollout_wait_retries`, default 60) and delay (`gke_node_pool_rollout_wait_delay`, default 20s).
- **Task 3** — Post-rollout assertion that zero public worker IPv4s remain, guarded by `gke_assert_zero_public_worker_ipv4` (default `true`).
- **Task 4** — Optional NAT egress smoke test: discovers a Running pod by label selector or explicit name, `kubectl exec`s `urllib.request.urlopen('https://api.ipify.org')`, and displays observed outbound IP. Guarded by `gke_run_nat_egress_smoke_test` (default `false`).

### `roles/gke-deploy/tasks/ingress.yml`
- **Task 5** — Two-gate static IPv4 cleanup path: preview mode prints what would be deleted; execution requires both `gke_cleanup_unbound_static_ipv4: true` AND `gke_cleanup_unbound_static_ipv4_execute: true`, with a configurable grace-period re-check before actual deletion.

### `roles/gke-deploy/defaults/main.yml`
- Adds defaults for all new cleanup variables with safe-off values.

### `inventory/gcp_cluster.yml.example` / `inventory/gcp_app.yml.example`
- Documents all new operator override variables with comments and safe defaults.

## Verification

- ✅ Both playbooks pass `ansible-playbook --syntax-check`
- ✅ NAT egress smoke test verified against `tenant-demo`: pod `django-app-demo-5b9957b7dc-mvq4c` observed egress IP `34.139.205.92` (Cloud NAT)
- ✅ Cleanup preview path verified: correct no-op with `gke_cleanup_unbound_static_ipv4_execute=false`, correct tasks skipped

Closes #913