### PR TITLE
Fix forgot-password delivery for OAuth-only users and bypass dev-mode redirection

### DIFF
--- a/docs/resolved-issues/issue-925-password-reset-dev-mode-exception.md
+++ b/docs/resolved-issues/issue-925-password-reset-dev-mode-exception.md
@@ -33,7 +33,7 @@ During investigation, password-reset email sending was aligned with the dev-mode
 
 ### 1. Include active OAuth-first accounts in password reset eligibility
 
-`DevModePasswordResetForm.get_users()` now returns active users matching the submitted email using case-insensitive Unicode-safe comparison, including those with unusable local passwords.
+`DirectRecipientPasswordResetForm.get_users()` now returns active users matching the submitted email using case-insensitive Unicode-safe comparison, including those with unusable local passwords.
 
 ### 2. Bypass dev-mode redirection for forgot-password emails
 

--- a/docs/resolved-issues/issue-925-password-reset-dev-mode-exception.md
+++ b/docs/resolved-issues/issue-925-password-reset-dev-mode-exception.md
@@ -2,7 +2,7 @@
 
 **Resolution Date**: May 22, 2026
 **Branch**: `bugfix/issue-925-password-reset-dev-mode-exception`
-**PR**: TBD
+**PR**: #926
 **Status**: Complete ✅
 
 ## Problem

--- a/docs/resolved-issues/issue-925-password-reset-dev-mode-exception.md
+++ b/docs/resolved-issues/issue-925-password-reset-dev-mode-exception.md
@@ -1,0 +1,71 @@
+# Issue #925: Fix Forgot-Password Delivery for OAuth-Only Users and Dev-Mode Exception
+
+**Resolution Date**: May 22, 2026
+**Branch**: `bugfix/issue-925-password-reset-dev-mode-exception`
+**PR**: TBD
+**Status**: Complete ✅
+
+## Problem
+
+The forgot-password flow was not delivering reset emails in a real tenant scenario for an active member account.
+
+Two behaviors combined into user-visible failure:
+
+- Django's default password reset user selection excludes users with unusable passwords.
+- In this project, many accounts begin OAuth-first and therefore have unusable local passwords until they explicitly set one.
+
+Additionally, product policy for this project requires a special-case rule:
+
+- Forgot-password emails must always go directly to the member requesting reset.
+- General app emails should continue to honor `EMAIL_DEV_MODE` redirection during tenant construction/testing.
+
+## Root Cause
+
+### 1. Unusable-password accounts filtered out
+
+Default `PasswordResetForm.get_users()` omits users where `has_usable_password()` is false. This blocked reset email generation for OAuth-first members.
+
+### 2. Forgot-password email routing policy mismatch
+
+During investigation, password-reset email sending was aligned with the dev-mode wrapper path. That behavior conflicts with the explicit requirement that password-reset is an exception to dev-mode redirection.
+
+## Solution
+
+### 1. Include active OAuth-first accounts in password reset eligibility
+
+`DevModePasswordResetForm.get_users()` now returns active users matching the submitted email using case-insensitive Unicode-safe comparison, including those with unusable local passwords.
+
+### 2. Bypass dev-mode redirection for forgot-password emails
+
+Password reset email sending now uses `EmailMultiAlternatives` directly for this flow so recipient delivery is to the real member email address.
+
+This keeps the policy boundary clear:
+
+- Forgot-password: direct recipient delivery
+- Other operational emails: continue using existing dev-mode redirection utilities
+
+## Files Changed
+
+- `members/forms.py`
+- `members/views.py`
+- `members/tests/test_password_reset.py`
+
+## Validation
+
+Executed focused tests:
+
+- `pytest members/tests/test_password_reset.py -q`
+
+Result:
+
+- 5 passed
+
+Coverage included:
+
+- Reset email sends for active user with unusable password
+- Forgot-password bypasses dev-mode recipient redirection
+- Existing password reset behavior and canonical URL assertions
+
+## Outcome
+
+Tenant dev mode can remain enabled for construction/testing emails, while forgot-password now behaves as a user-account recovery path and delivers reset links to the actual member address as required.

--- a/members/forms.py
+++ b/members/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth import get_user_model
-from django.contrib.auth.forms import PasswordResetForm, _unicode_ci_compare
+from django.contrib.auth.forms import PasswordResetForm
 from django.core.exceptions import ValidationError
 from django.core.mail import EmailMultiAlternatives
 from django.template import loader
@@ -10,6 +10,12 @@ from utils.email import enforce_noreply_from_email
 
 from .models import Biography, Member, SafetyReport
 from .utils.image_processing import generate_profile_thumbnails
+
+
+def _emails_match_case_insensitive(left, right):
+    """Unicode-safe, case-insensitive email comparison using public APIs."""
+    return (left or "").casefold() == (right or "").casefold()
+
 
 #########################
 # MemberProfilePhotoForm Class
@@ -143,7 +149,9 @@ class DirectRecipientPasswordResetForm(PasswordResetForm):
         return (
             user
             for user in active_users
-            if _unicode_ci_compare(email, getattr(user, email_field_name))
+            if _emails_match_case_insensitive(
+                email, getattr(user, email_field_name, "")
+            )
         )
 
     def send_mail(

--- a/members/forms.py
+++ b/members/forms.py
@@ -8,6 +8,8 @@ from django.core.mail import EmailMultiAlternatives
 from django.template import loader
 from tinymce.widgets import TinyMCE
 
+from utils.email import enforce_noreply_from_email
+
 from .models import Biography, Member, SafetyReport
 from .utils.image_processing import generate_profile_thumbnails
 
@@ -120,7 +122,7 @@ class SetPasswordForm(forms.Form):
         return cleaned_data
 
 
-class DevModePasswordResetForm(PasswordResetForm):
+class DirectRecipientPasswordResetForm(PasswordResetForm):
     """Password reset form with OAuth account support.
 
     Password reset emails intentionally bypass EMAIL_DEV_MODE redirection so the
@@ -160,11 +162,12 @@ class DevModePasswordResetForm(PasswordResetForm):
         subject = loader.render_to_string(subject_template_name, context)
         subject = "".join(subject.splitlines())
         body = loader.render_to_string(email_template_name, context)
+        normalized_from_email = enforce_noreply_from_email(from_email)
 
         email_message = EmailMultiAlternatives(
             subject=subject,
             body=body,
-            from_email=from_email,
+            from_email=normalized_from_email,
             to=[to_email],
         )
 
@@ -172,13 +175,7 @@ class DevModePasswordResetForm(PasswordResetForm):
             html_email = loader.render_to_string(html_email_template_name, context)
             email_message.attach_alternative(html_email, "text/html")
 
-        try:
-            email_message.send()
-        except Exception:
-            logger.exception(
-                "Failed to send password reset email for recipient: %s",
-                to_email,
-            )
+        email_message.send()
 
 
 #########################

--- a/members/forms.py
+++ b/members/forms.py
@@ -1,5 +1,3 @@
-import logging
-
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import PasswordResetForm, _unicode_ci_compare
@@ -12,8 +10,6 @@ from utils.email import enforce_noreply_from_email
 
 from .models import Biography, Member, SafetyReport
 from .utils.image_processing import generate_profile_thumbnails
-
-logger = logging.getLogger(__name__)
 
 #########################
 # MemberProfilePhotoForm Class

--- a/members/forms.py
+++ b/members/forms.py
@@ -1,9 +1,17 @@
+import logging
+
 from django import forms
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import PasswordResetForm, _unicode_ci_compare
 from django.core.exceptions import ValidationError
+from django.core.mail import EmailMultiAlternatives
+from django.template import loader
 from tinymce.widgets import TinyMCE
 
 from .models import Biography, Member, SafetyReport
 from .utils.image_processing import generate_profile_thumbnails
+
+logger = logging.getLogger(__name__)
 
 #########################
 # MemberProfilePhotoForm Class
@@ -110,6 +118,67 @@ class SetPasswordForm(forms.Form):
         if p1 and p2 and p1 != p2:
             raise ValidationError("Passwords do not match.")
         return cleaned_data
+
+
+class DevModePasswordResetForm(PasswordResetForm):
+    """Password reset form with OAuth account support.
+
+    Password reset emails intentionally bypass EMAIL_DEV_MODE redirection so the
+    member who requested access always receives the reset link directly.
+    """
+
+    def get_users(self, email):
+        """Return active users matching email, including OAuth-only accounts.
+
+        Django's default PasswordResetForm excludes users with unusable passwords.
+        In this project, many members authenticate via OAuth first and therefore
+        start with an unusable local password. They should still be able to use
+        "Forgot your password?" to bootstrap a local password.
+        """
+        email_field_name = get_user_model().get_email_field_name()
+        active_users = get_user_model()._default_manager.filter(
+            **{
+                f"{email_field_name}__iexact": email,
+                "is_active": True,
+            }
+        )
+        return (
+            user
+            for user in active_users
+            if _unicode_ci_compare(email, getattr(user, email_field_name))
+        )
+
+    def send_mail(
+        self,
+        subject_template_name,
+        email_template_name,
+        context,
+        from_email,
+        to_email,
+        html_email_template_name=None,
+    ):
+        subject = loader.render_to_string(subject_template_name, context)
+        subject = "".join(subject.splitlines())
+        body = loader.render_to_string(email_template_name, context)
+
+        email_message = EmailMultiAlternatives(
+            subject=subject,
+            body=body,
+            from_email=from_email,
+            to=[to_email],
+        )
+
+        if html_email_template_name is not None:
+            html_email = loader.render_to_string(html_email_template_name, context)
+            email_message.attach_alternative(html_email, "text/html")
+
+        try:
+            email_message.send()
+        except Exception:
+            logger.exception(
+                "Failed to send password reset email for recipient: %s",
+                to_email,
+            )
 
 
 #########################

--- a/members/tests/test_password_reset.py
+++ b/members/tests/test_password_reset.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core import mail
+from django.test import override_settings
 from django.urls import reverse
 
 from members.models import Member
@@ -27,6 +28,27 @@ def test_password_reset_with_unknown_email_does_not_send(client):
     response = client.post(reverse("password_reset"), {"email": "ghost@example.com"})
     assert response.status_code == 302
     assert len(mail.outbox) == 0  # Silent fail, don't reveal user existence
+
+
+@pytest.mark.django_db
+def test_password_reset_sends_email_for_user_with_unusable_password(client):
+    member = Member.objects.create_user(
+        username="oauthonly",
+        email="oauthonly@example.com",
+        password="initialpassword",
+        membership_status="Full Member",
+    )
+    member.set_unusable_password()
+    member.save(update_fields=["password"])
+
+    response = client.post(
+        reverse("password_reset"),
+        {"email": "oauthonly@example.com"},
+    )
+
+    assert response.status_code == 302
+    assert len(mail.outbox) == 1
+    assert "Password reset" in mail.outbox[0].subject
 
 
 @pytest.mark.django_db
@@ -76,3 +98,27 @@ def test_password_reset_uses_canonical_url(client):
     if hasattr(mail.outbox[0], "alternatives") and mail.outbox[0].alternatives:
         html_body = mail.outbox[0].alternatives[0][0]
         assert "https://www.skylinesoaring.org/reset/" in html_body
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_DEV_MODE=True,
+    EMAIL_DEV_MODE_REDIRECT_TO="dev1@example.com,dev2@example.com",
+)
+def test_password_reset_bypasses_dev_mode_recipients(client):
+    Member.objects.create_user(
+        username="devmodeuser",
+        email="realmember@example.com",
+        password="oldpassword",
+        membership_status="Full Member",
+    )
+
+    response = client.post(
+        reverse("password_reset"),
+        {"email": "realmember@example.com"},
+    )
+
+    assert response.status_code == 302
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].to == ["realmember@example.com"]
+    assert "[DEV MODE]" not in mail.outbox[0].subject

--- a/members/views.py
+++ b/members/views.py
@@ -33,7 +33,7 @@ from utils.url_helpers import build_absolute_url, get_canonical_url
 from .decorators import active_member_required
 from .forms import (
     BiographyForm,
-    DevModePasswordResetForm,
+    DirectRecipientPasswordResetForm,
     MemberProfilePhotoForm,
     SafetyReportForm,
     SetPasswordForm,
@@ -1110,7 +1110,7 @@ class CustomPasswordResetView(auth_views.PasswordResetView):
     Issue #612: Fixes password manager domain mismatch between login and email URLs.
     """
 
-    form_class = DevModePasswordResetForm
+    form_class = DirectRecipientPasswordResetForm
 
     def form_valid(self, form):
         """Override to inject canonical URL before sending email."""

--- a/members/views.py
+++ b/members/views.py
@@ -33,6 +33,7 @@ from utils.url_helpers import build_absolute_url, get_canonical_url
 from .decorators import active_member_required
 from .forms import (
     BiographyForm,
+    DevModePasswordResetForm,
     MemberProfilePhotoForm,
     SafetyReportForm,
     SetPasswordForm,
@@ -1108,6 +1109,8 @@ class CustomPasswordResetView(auth_views.PasswordResetView):
 
     Issue #612: Fixes password manager domain mismatch between login and email URLs.
     """
+
+    form_class = DevModePasswordResetForm
 
     def form_valid(self, form):
         """Override to inject canonical URL before sending email."""


### PR DESCRIPTION
## Summary
This PR fixes tenant-observed forgot-password delivery behavior while preserving development safeguards for other email flows.

## What changed
- Allow active users with unusable local passwords (OAuth-first accounts) to receive forgot-password reset emails.
- Make forgot-password email delivery bypass EMAIL_DEV_MODE redirection, so reset links go to the actual member email.
- Keep all other operational emails on existing dev-mode redirection behavior.
- Add resolved-issue documentation for Issue #925.

## Files
- members/forms.py
- members/views.py
- members/tests/test_password_reset.py
- docs/resolved-issues/issue-925-password-reset-dev-mode-exception.md

## Validation
- pytest members/tests/test_password_reset.py -q
- Result: 5 passed

Fixes #925