### PR TITLE
Fix Pylance Optional warning in treasurer title test

### DIFF
--- a/logsheet/tests/test_member_charge_views.py
+++ b/logsheet/tests/test_member_charge_views.py
@@ -716,6 +716,8 @@ class FinancesViewChargeDisplayTestCase(TestCase):
         self.logsheet.finalized = True
         self.logsheet.save(update_fields=["finalized"])
         config = SiteConfiguration.objects.first()
+        if config is None:
+            self.fail("SiteConfiguration should exist for test setup")
         config.treasurer_title = "Cash"
         config.save(update_fields=["treasurer_title"])
 


### PR DESCRIPTION
## Summary
- fix two Pylance diagnostics in `logsheet/tests/test_member_charge_views.py`
- guard `SiteConfiguration.objects.first()` with an explicit `None` check before attribute access

## Why
Pylance flagged:
- `treasurer_title` is not a known attribute of `None`
- `save` is not a known attribute of `None`

This PR narrows the optional type in the test and preserves existing behavior.

## Validation
- `source /home/pb/Projects/skylinesoaring/.venv/bin/activate && pytest logsheet/tests/test_member_charge_views.py -k treasurer -q`
- Result: `12 passed, 33 deselected`
