### PR TITLE
Issue #938: allow blackout date selection farther into future

### DIFF
--- a/duty_roster/templates/duty_roster/blackout_calendar.html
+++ b/duty_roster/templates/duty_roster/blackout_calendar.html
@@ -75,7 +75,7 @@
           <div class="card-body">
             <div class="row g-4">
               {% for month in months %}
-              <div class="col-12 col-lg-4">
+              <div class="col-12 col-lg-3">
                 <div class="calendar-month-container">
                   <div class="month-header text-center mb-3">
                     <h5 class="fw-bold text-primary mb-0">{{ month.label }}</h5>

--- a/duty_roster/tests.py
+++ b/duty_roster/tests.py
@@ -12,6 +12,7 @@ from duty_roster.models import (
     MemberBlackout,
 )
 from duty_roster.views import (
+    BLACKOUT_CALENDAR_MONTHS,
     _calculate_membership_duration,
     _has_performed_duty_detailed,
     calendar_refresh_response,
@@ -1705,6 +1706,13 @@ class BlackoutRoleChoiceSiteConfigTests(TestCase):
         self.assertEqual(response.status_code, 200)
         return {role for role, _label in response.context["role_percent_choices"]}
 
+    def test_blackout_calendar_shows_four_months(self):
+        self.client.force_login(self.member)
+        response = self.client.get(reverse("duty_roster:blackout_manage"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["months"]), BLACKOUT_CALENDAR_MONTHS)
+
     def test_hides_all_role_choices_when_all_schedule_flags_false(self):
         self.config.schedule_instructors = False
         self.config.schedule_tow_pilots = False
@@ -1984,3 +1992,36 @@ class BlackoutRoleChoiceSiteConfigTests(TestCase):
 
         role_choices = dict(response.context["role_percent_choices"])
         self.assertEqual(role_choices["towpilot"], "Tow Pilot (AM Tow, PM Tow)")
+
+    def test_post_rejects_blackout_dates_beyond_calendar_window(self):
+        self.client.force_login(self.member)
+
+        today = timezone.now().date()
+        out_of_window_date = (
+            today.replace(day=1) + timedelta(days=32 * BLACKOUT_CALENDAR_MONTHS)
+        ).replace(day=1)
+
+        response = self.client.post(
+            reverse("duty_roster:blackout_manage"),
+            data={
+                "blackout_dates": [out_of_window_date.isoformat()],
+                "preferred_day": "",
+                "dont_schedule": "",
+                "scheduling_suspended": "",
+                "suspended_reason": "",
+                "comment": "",
+                "instructor_percent": "100",
+                "max_assignments_per_month": "4",
+                "allow_weekend_double": "",
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            MemberBlackout.objects.filter(
+                member=self.member,
+                date=out_of_window_date,
+            ).exists()
+        )
+        self.assertContains(response, "Out-of-range dates were ignored")

--- a/duty_roster/tests.py
+++ b/duty_roster/tests.py
@@ -1997,9 +1997,16 @@ class BlackoutRoleChoiceSiteConfigTests(TestCase):
         self.client.force_login(self.member)
 
         today = timezone.now().date()
+        existing_date = today + timedelta(days=7)
         out_of_window_date = (
             today.replace(day=1) + timedelta(days=32 * BLACKOUT_CALENDAR_MONTHS)
         ).replace(day=1)
+
+        MemberBlackout.objects.create(
+            member=self.member,
+            date=existing_date,
+            note="Existing blackout that should be preserved",
+        )
 
         response = self.client.post(
             reverse("duty_roster:blackout_manage"),
@@ -2022,6 +2029,12 @@ class BlackoutRoleChoiceSiteConfigTests(TestCase):
             MemberBlackout.objects.filter(
                 member=self.member,
                 date=out_of_window_date,
+            ).exists()
+        )
+        self.assertTrue(
+            MemberBlackout.objects.filter(
+                member=self.member,
+                date=existing_date,
             ).exists()
         )
         self.assertContains(response, "Out-of-range dates were ignored")

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -450,10 +450,11 @@ def blackout_manage(request):
     all_other = Member.objects.exclude(id=member.id).filter(is_active=True)
 
     if request.method == "POST":
+        submitted_blackout_values = request.POST.getlist("blackout_dates")
         blackout_dates = set()
         invalid_date_count = 0
 
-        for raw_date in request.POST.getlist("blackout_dates"):
+        for raw_date in submitted_blackout_values:
             try:
                 blackout_dates.add(date.fromisoformat(raw_date))
             except ValueError:
@@ -478,6 +479,15 @@ def blackout_manage(request):
                 f"Blackout dates must be between {min_blackout_date} and "
                 f"{max_blackout_date}. Out-of-range dates were ignored.",
             )
+
+        if (
+            submitted_blackout_values
+            and not blackout_dates
+            and (invalid_date_count or out_of_window_dates)
+        ):
+            # Preserve existing blackouts when the submission only contained
+            # invalid/out-of-window entries.
+            blackout_dates = set(existing_dates)
 
         note = request.POST.get("default_note", "").strip()
 

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -92,18 +92,16 @@ TOW_INTENT_KEYS = {"club", "club_single", "club_two", "guest", "private"}
 
 
 def _calendar_month_start(base_date, offset_months):
-    """Return first day of month offset from base_date using month-sized jumps."""
-    return (base_date.replace(day=1) + timedelta(days=32 * offset_months)).replace(
-        day=1
-    )
+    """Return first day of month offset from base_date."""
+    month_index = (base_date.month - 1) + offset_months
+    year = base_date.year + (month_index // 12)
+    month = (month_index % 12) + 1
+    return date(year, month, 1)
 
 
 def _blackout_date_window(today):
     """Return inclusive blackout selection window used by UI and POST validation."""
-    last_month_start = _calendar_month_start(today, BLACKOUT_CALENDAR_MONTHS - 1)
-    max_date = (last_month_start + timedelta(days=32)).replace(day=1) - timedelta(
-        days=1
-    )
+    max_date = _calendar_month_start(today, BLACKOUT_CALENDAR_MONTHS) - timedelta(days=1)
     return today, max_date
 
 

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -85,9 +85,26 @@ ALLOWED_ROLES = [
     "commercial_pilot",
 ]
 MAX_PROPOSAL_RANGE_MONTHS = 12
+BLACKOUT_CALENDAR_MONTHS = 4
 
 # OpsIntent activity keys that contribute to tow demand/surge calculations.
 TOW_INTENT_KEYS = {"club", "club_single", "club_two", "guest", "private"}
+
+
+def _calendar_month_start(base_date, offset_months):
+    """Return first day of month offset from base_date using month-sized jumps."""
+    return (base_date.replace(day=1) + timedelta(days=32 * offset_months)).replace(
+        day=1
+    )
+
+
+def _blackout_date_window(today):
+    """Return inclusive blackout selection window used by UI and POST validation."""
+    last_month_start = _calendar_month_start(today, BLACKOUT_CALENDAR_MONTHS - 1)
+    max_date = (last_month_start + timedelta(days=32)).replace(day=1) - timedelta(
+        days=1
+    )
+    return today, max_date
 
 
 def _is_commercial_pilot_qualified(member):
@@ -262,9 +279,11 @@ def blackout_manage(request):
             weeks.append(week)
         return weeks
 
+    min_blackout_date, max_blackout_date = _blackout_date_window(today)
+
     months = []
-    for i in range(3):
-        m1 = (today.replace(day=1) + timedelta(days=32 * i)).replace(day=1)
+    for i in range(BLACKOUT_CALENDAR_MONTHS):
+        m1 = _calendar_month_start(today, i)
         months.append(
             {
                 "label": m1.strftime("%B %Y"),
@@ -431,9 +450,34 @@ def blackout_manage(request):
     all_other = Member.objects.exclude(id=member.id).filter(is_active=True)
 
     if request.method == "POST":
-        blackout_dates = set(
-            date.fromisoformat(d) for d in request.POST.getlist("blackout_dates")
-        )
+        blackout_dates = set()
+        invalid_date_count = 0
+
+        for raw_date in request.POST.getlist("blackout_dates"):
+            try:
+                blackout_dates.add(date.fromisoformat(raw_date))
+            except ValueError:
+                invalid_date_count += 1
+
+        out_of_window_dates = {
+            blackout_date
+            for blackout_date in blackout_dates
+            if blackout_date < min_blackout_date or blackout_date > max_blackout_date
+        }
+        blackout_dates -= out_of_window_dates
+
+        if invalid_date_count:
+            messages.error(
+                request,
+                "Some submitted blackout dates were invalid and were ignored.",
+            )
+
+        if out_of_window_dates:
+            messages.error(
+                request,
+                f"Blackout dates must be between {min_blackout_date} and "
+                f"{max_blackout_date}. Out-of-range dates were ignored.",
+            )
 
         note = request.POST.get("default_note", "").strip()
 


### PR DESCRIPTION
## Summary
- extend blackout calendar horizon from 3 to 4 months
- update blackout calendar layout for 4 month display on large screens
- enforce server-side blackout date window validation to match UI range
- add regression tests for month horizon and out-of-range blackout submissions

## Testing
- pytest suite run locally by user (reported green)
- targeted tests executed during implementation:
  - `pytest duty_roster/tests.py -k "blackout_calendar_shows_four_months or post_rejects_blackout_dates_beyond_calendar_window" -q`
