### PR TITLE
Fix issue 940: show edit path for empty instruction report essays

### DIFF
--- a/docs/resolved-issues/issue-940-empty-essay-edit.md
+++ b/docs/resolved-issues/issue-940-empty-essay-edit.md
@@ -1,0 +1,77 @@
+# Issue #940: Instruction Report Not Editable When Essay Is Empty
+
+## Status
+
+Complete.
+
+- Date: 2026-06-04
+- Branch: feature/issue-940-empty-essay-edit
+
+## Problem Summary
+
+Instructors could create a flight instruction report without entering essay text, but then had no visible way to edit that report from the member instruction record page.
+
+This looked like a same-date/multi-instructor routing problem at first, but the actual root cause was a UI rendering condition.
+
+## Root Cause
+
+The edit button in the member instruction record template was only rendered inside the essay-content block.
+
+- If `report_text` existed, the section (including Edit) was shown.
+- If `report_text` was empty, the section did not render at all.
+- Result: no edit affordance for an otherwise valid report.
+
+## Solution Implemented
+
+A minimal, low-risk template fix was applied.
+
+### Template behavior change
+
+File updated:
+- `templates/shared/member_instruction_record.html`
+
+Changes:
+1. The flight report header/edit section now renders when either:
+   - essay text exists, or
+   - the current user is the report instructor and report is within the 7-day edit window.
+2. For empty essay reports that are still editable, a neutral placeholder is shown:
+   - "No essay written yet."
+3. Existing edit policy is preserved:
+   - owner-only visibility
+   - 7-day time limit
+   - same report edit URL path
+
+### What did not change
+
+- No model changes
+- No database migration
+- No new route required
+- No changes to report save semantics
+
+## Test Coverage Added
+
+File updated:
+- `instructors/tests/test_member_instruction_record.py`
+
+New regression class:
+- `TestMemberInstructionRecordEmptyEssayEdit`
+
+New test scenarios:
+1. Owner sees edit link for empty-essay report within 7 days.
+2. Owner does not see edit link for empty-essay report after 7 days.
+3. Non-owner instructor does not see edit link for another instructor's empty-essay report.
+
+## Validation
+
+Targeted tests executed successfully:
+
+- `pytest instructors/tests/test_member_instruction_record.py -k EmptyEssay -q`
+- `pytest instructors/tests/test_member_instruction_record.py instructors/tests/test_obsolete_qualification_visibility.py -q`
+
+Result: all relevant tests passed.
+
+## Business Impact
+
+- Prevents a real workflow dead-end for instructors.
+- Reduces support noise from reports that appear "uneditable" after submission.
+- Keeps behavior predictable while preserving existing authorization and timing rules.

--- a/instructors/tests/test_member_instruction_record.py
+++ b/instructors/tests/test_member_instruction_record.py
@@ -149,3 +149,105 @@ class TestMemberInstructionRecordQualificationVisibility:
         codes = {mq.qualification.code for mq in visible}
         assert "SAFE2026" in codes
         assert "SAFE2025" not in codes
+
+
+@pytest.mark.django_db
+class TestMemberInstructionRecordEmptyEssayEdit:
+    def setup_method(self):
+        MembershipStatus.objects.update_or_create(
+            name="Full Member", defaults={"is_active": True}
+        )
+
+        self.student = Member.objects.create_user(
+            username="empty_essay_student",
+            password="testpass123",
+            first_name="Alice",
+            last_name="Student",
+            membership_status="Full Member",
+            is_active=True,
+        )
+        self.instructor = Member.objects.create_user(
+            username="empty_essay_instructor",
+            password="testpass123",
+            first_name="Bob",
+            last_name="Instructor",
+            membership_status="Full Member",
+            is_active=True,
+            instructor=True,
+        )
+        self.other_instructor = Member.objects.create_user(
+            username="other_empty_essay_instructor",
+            password="testpass123",
+            first_name="Charlie",
+            last_name="Instructor",
+            membership_status="Full Member",
+            is_active=True,
+            instructor=True,
+        )
+
+    def test_owner_sees_edit_link_for_empty_essay_within_7_days(self, client):
+        report_date = timezone.localdate() - timedelta(days=2)
+        InstructionReport.objects.create(
+            student=self.student,
+            instructor=self.instructor,
+            report_date=report_date,
+            report_text="",
+        )
+
+        client.force_login(self.instructor)
+        response = client.get(
+            reverse("instructors:member_instruction_record", args=[self.student.pk])
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        edit_url = reverse(
+            "instructors:fill_instruction_report",
+            args=[self.student.pk, report_date.strftime("%Y-%m-%d")],
+        )
+        assert edit_url in content
+        assert "No essay written yet." in content
+
+    def test_owner_does_not_see_edit_link_for_empty_essay_after_7_days(self, client):
+        report_date = timezone.localdate() - timedelta(days=8)
+        InstructionReport.objects.create(
+            student=self.student,
+            instructor=self.instructor,
+            report_date=report_date,
+            report_text="",
+        )
+
+        client.force_login(self.instructor)
+        response = client.get(
+            reverse("instructors:member_instruction_record", args=[self.student.pk])
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        edit_url = reverse(
+            "instructors:fill_instruction_report",
+            args=[self.student.pk, report_date.strftime("%Y-%m-%d")],
+        )
+        assert edit_url not in content
+
+    def test_non_owner_does_not_see_edit_link_for_empty_essay(self, client):
+        report_date = timezone.localdate() - timedelta(days=2)
+        InstructionReport.objects.create(
+            student=self.student,
+            instructor=self.instructor,
+            report_date=report_date,
+            report_text="",
+        )
+
+        client.force_login(self.other_instructor)
+        response = client.get(
+            reverse("instructors:member_instruction_record", args=[self.student.pk])
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        edit_url = reverse(
+            "instructors:fill_instruction_report",
+            args=[self.student.pk, report_date.strftime("%Y-%m-%d")],
+        )
+        assert edit_url not in content

--- a/templates/shared/member_instruction_record.html
+++ b/templates/shared/member_instruction_record.html
@@ -268,7 +268,8 @@
 
       {# Essays for all blocks that have them #}
       {% for block in day.blocks %}
-      {% if block.report.report_text %}
+      {% if block.type == 'flight' %}
+      {% if block.report.report_text or request.user == block.report.instructor and block.days_ago <= 7 %}
       <div class="d-flex justify-content-between align-items-center">
         <h5>📝 Instructor Essay</h5>
         {# Edit button - only show if current user is the instructor and report is within 7 days #}
@@ -280,6 +281,7 @@
           </a>
         {% endif %}
       </div>
+      {% if block.report.report_text %}
       <div class="border p-3 bg-white card-body mb-2 cms-content" id="report-{{ block.report.report_date|date:'Y-m-d' }}">
         {{ block.report.report_text|safe }}
         <div class="mt-2 small text-muted">
@@ -294,6 +296,12 @@
           {% endif %}
         </div>
       </div>
+      {% else %}
+      <div class="border p-3 bg-light card-body mb-2 text-muted" id="report-{{ block.report.report_date|date:'Y-m-d' }}">
+        No essay written yet.
+      </div>
+      {% endif %}
+      {% endif %}
       {% elif block.report.notes %}
       <h5>📝 Notes</h5>
       <div class="border p-3 bg-white card-body mb-2 cms-content" id="report-{{ block.report.report_date|date:'Y-m-d' }}">


### PR DESCRIPTION
## Summary
This PR fixes the real root cause behind issue #940: when an instructor submitted a report with no essay text, the member instruction record page hid the entire essay section (including the Edit button), making the report appear uneditable.

## What changed
- Updated essay/edit rendering logic in `templates/shared/member_instruction_record.html` so flight report edit controls are shown when:
  - essay text exists, **or**
  - the report owner is viewing within the existing 7-day edit window.
- Added an empty-state placeholder message (`No essay written yet.`) when a report has no essay content but the block is still shown.
- Added targeted regression tests in `instructors/tests/test_member_instruction_record.py`:
  - owner sees edit link for empty essay within 7 days
  - owner does not see edit link after 7 days
  - non-owner does not see edit link for another instructor's empty essay report
- Added implementation documentation:
  - `docs/resolved-issues/issue-940-empty-essay-edit.md`

## Validation
- `pytest instructors/tests/test_member_instruction_record.py instructors/tests/test_obsolete_qualification_visibility.py -q`
- Result: 7 passed

## Notes
- No model/schema changes
- No migration required
- Existing owner-only + 7-day edit policy is preserved
