### PR TITLE
Upgrade TinyMCE to resolve Dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "tablesort": "^5.2.1",
-        "tinymce": "^8.2.1"
+        "tinymce": "^8.6.0"
       }
     },
     "node_modules/tablesort": {
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/tinymce": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-8.2.1.tgz",
-      "integrity": "sha512-gbZJH91f91jLfD39juLt/oiAMoaxwTquJMJZR0A1uzcOVrddo8hI/2Y+Uji0/vPudmbDxatnmfIG/9/j3KzP0g=="
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-8.6.0.tgz",
+      "integrity": "sha512-qODYoNL4cPIzNFpkEEQDm3DWI78I/nQXIPwUMHRN+q/LyT9Wzt7xis2Nfhk88kV6sibp6MJXPSaUDVNe02ZB/w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "tablesort": "^5.2.1",
-    "tinymce": "^8.2.1"
+    "tinymce": "^8.6.0"
   },
   "scripts": {
     "vendor:tablesort": "mkdir -p static/vendor && cp node_modules/tablesort/dist/tablesort.min.js static/vendor/tablesort.min.js"


### PR DESCRIPTION
## Summary
- upgrade tinymce from ^8.2.1 to ^8.6.0 in package.json
- refresh package-lock.json to resolve to tinymce@8.6.0

## Security impact
- remediates open Dependabot TinyMCE XSS alerts affecting versions < 8.5.1

## Validation
- full pytest suite passed locally (including E2E), per maintainer run
- targeted TinyMCE config tests passed: pytest cms/tests/test_tinymce_config.py -q
