### PR TITLE
Fix #950: Restore elapsed tach hours in towplane logbook and mark future deadlines

### DIFF
--- a/logsheet/models.py
+++ b/logsheet/models.py
@@ -1847,7 +1847,8 @@ class TowplaneCloseout(models.Model):
         ):
             start_tach = Decimal(str(self.start_tach))
             end_tach = Decimal(str(self.end_tach))
-            self.tach_time = (end_tach - start_tach).quantize(
+            elapsed_tach = max(end_tach - start_tach, Decimal("0.00"))
+            self.tach_time = elapsed_tach.quantize(
                 Decimal("0.01"),
                 rounding=ROUND_HALF_UP,
             )

--- a/logsheet/models.py
+++ b/logsheet/models.py
@@ -1840,6 +1840,7 @@ class TowplaneCloseout(models.Model):
 
     def save(self, *args, **kwargs):
         # Auto-compute elapsed tach when start/end readings are present.
+        derived_tach_time = False
         if (
             self.tach_time is None
             and self.start_tach is not None
@@ -1852,6 +1853,13 @@ class TowplaneCloseout(models.Model):
                 Decimal("0.01"),
                 rounding=ROUND_HALF_UP,
             )
+            derived_tach_time = True
+
+        if derived_tach_time and kwargs.get("update_fields") is not None:
+            update_fields = set(kwargs["update_fields"])
+            update_fields.add("tach_time")
+            kwargs["update_fields"] = update_fields
+
         super().save(*args, **kwargs)
 
 

--- a/logsheet/models.py
+++ b/logsheet/models.py
@@ -1838,6 +1838,21 @@ class TowplaneCloseout(models.Model):
     def __str__(self):
         return f"{self.towplane.n_number} on {self.logsheet.log_date}"
 
+    def save(self, *args, **kwargs):
+        # Auto-compute elapsed tach when start/end readings are present.
+        if (
+            self.tach_time is None
+            and self.start_tach is not None
+            and self.end_tach is not None
+        ):
+            start_tach = Decimal(str(self.start_tach))
+            end_tach = Decimal(str(self.end_tach))
+            self.tach_time = (end_tach - start_tach).quantize(
+                Decimal("0.01"),
+                rounding=ROUND_HALF_UP,
+            )
+        super().save(*args, **kwargs)
+
 
 ####################################################
 # MaintenanceIssue model

--- a/logsheet/templates/logsheet/equipment_logbook.html
+++ b/logsheet/templates/logsheet/equipment_logbook.html
@@ -106,7 +106,10 @@
                         <div class="mb-1 fw-semibold">Deadlines</div>
                         <ul class="mb-0">
                             {% for dl in row.deadlines %}
-                            <li>{{ dl.description }} — due {{ dl.due_date }}</li>
+                            <li class="{% if dl.is_future %}text-body-secondary bg-light-subtle px-1 rounded{% endif %}">
+                                {{ dl.description }} — due {{ dl.due_date }}
+                                {% if dl.is_future %}<span class="badge text-bg-secondary ms-1">Upcoming</span>{% endif %}
+                            </li>
                             {% endfor %}
                         </ul>
                         {% endif %}

--- a/logsheet/tests/test_towplane_logbook_performance.py
+++ b/logsheet/tests/test_towplane_logbook_performance.py
@@ -435,6 +435,39 @@ class TowplaneLogbookEdgeCasesTestCase(TestCase):
         # glider_tows should count all flights for the day
         self.assertEqual(day_data["glider_tows"], 2)
 
+    def test_elapsed_tach_uses_start_end_when_tach_time_missing(self):
+        """Elapsed tach should be derived from start/end when tach_time is null."""
+        log_date = date(2024, 8, 1)
+        logsheet = Logsheet.objects.create(
+            log_date=log_date,
+            airfield=self.airfield,
+            duty_officer=self.member,
+            created_by=self.member,
+        )
+
+        TowplaneCloseout.objects.create(
+            logsheet=logsheet,
+            towplane=self.towplane,
+            start_tach=100.0,
+            end_tach=101.7,
+            tach_time=None,
+        )
+
+        client = Client()
+        client.force_login(self.member)
+
+        response = client.get(
+            reverse("logsheet:towplane_logbook", args=[self.towplane.pk])
+        )
+        self.assertEqual(response.status_code, 200)
+        daily = response.context["daily"]
+
+        self.assertEqual(len(daily), 1)
+        day_data = daily[0]
+        self.assertEqual(day_data["day"], log_date)
+        self.assertEqual(day_data["day_hours"], 1.7)
+        self.assertEqual(day_data["cum_hours"], 101.7)
+
     def test_guest_towpilot_name(self):
         """
         Test that guest tow pilot names are correctly displayed.
@@ -868,6 +901,33 @@ class TowplaneMaintenanceOnlyDaysTestCase(TestCase):
         self.assertEqual(day_data["glider_tows"], 0)  # No flights
         self.assertEqual(len(day_data["deadlines"]), 1)
         self.assertEqual(day_data["deadlines"][0]["description"], DeadlineType.ANNUAL)
+
+    def test_future_deadline_is_marked_upcoming(self):
+        """Future deadlines should be tagged so templates can render muted styling."""
+        from django.utils import timezone
+
+        from logsheet.models import DeadlineType, MaintenanceDeadline
+
+        due_date = timezone.localdate() + timedelta(days=14)
+
+        MaintenanceDeadline.objects.create(
+            towplane=self.towplane,
+            description=DeadlineType.ANNUAL,
+            due_date=due_date,
+        )
+
+        client = Client()
+        client.force_login(self.member)
+
+        response = client.get(
+            reverse("logsheet:towplane_logbook", args=[self.towplane.pk])
+        )
+
+        self.assertEqual(response.status_code, 200)
+        daily = response.context["daily"]
+        self.assertEqual(len(daily), 1)
+        self.assertEqual(len(daily[0]["deadlines"]), 1)
+        self.assertTrue(daily[0]["deadlines"][0]["is_future"])
 
     def test_maintenance_on_flight_day_combines_correctly(self):
         """

--- a/logsheet/tests/test_towplane_logbook_performance.py
+++ b/logsheet/tests/test_towplane_logbook_performance.py
@@ -504,6 +504,31 @@ class TowplaneLogbookEdgeCasesTestCase(TestCase):
         self.assertEqual(day_data["day"], log_date)
         self.assertEqual(day_data["day_hours"], 0.0)
 
+    def test_save_update_fields_persists_derived_tach_time(self):
+        """Derived tach_time should persist when saving with update_fields."""
+        logsheet = Logsheet.objects.create(
+            log_date=date(2024, 8, 3),
+            airfield=self.airfield,
+            duty_officer=self.member,
+            created_by=self.member,
+        )
+
+        closeout = TowplaneCloseout.objects.create(
+            logsheet=logsheet,
+            towplane=self.towplane,
+            start_tach=None,
+            end_tach=None,
+            tach_time=None,
+        )
+
+        closeout.start_tach = 300.0
+        closeout.end_tach = 301.5
+        closeout.notes = "Updated tach readings"
+        closeout.save(update_fields=["start_tach", "end_tach", "notes"])
+
+        closeout.refresh_from_db()
+        self.assertEqual(float(closeout.tach_time), 1.5)
+
     def test_guest_towpilot_name(self):
         """
         Test that guest tow pilot names are correctly displayed.

--- a/logsheet/tests/test_towplane_logbook_performance.py
+++ b/logsheet/tests/test_towplane_logbook_performance.py
@@ -445,13 +445,16 @@ class TowplaneLogbookEdgeCasesTestCase(TestCase):
             created_by=self.member,
         )
 
-        TowplaneCloseout.objects.create(
+        closeout = TowplaneCloseout.objects.create(
             logsheet=logsheet,
             towplane=self.towplane,
             start_tach=100.0,
             end_tach=101.7,
             tach_time=None,
         )
+        # save() auto-computes tach_time when start/end are present; clear it to
+        # exercise the view-level fallback path for legacy null data.
+        TowplaneCloseout.objects.filter(pk=closeout.pk).update(tach_time=None)
 
         client = Client()
         client.force_login(self.member)
@@ -467,6 +470,39 @@ class TowplaneLogbookEdgeCasesTestCase(TestCase):
         self.assertEqual(day_data["day"], log_date)
         self.assertEqual(day_data["day_hours"], 1.7)
         self.assertEqual(day_data["cum_hours"], 101.7)
+
+    def test_elapsed_tach_clamps_negative_values_to_zero(self):
+        """Negative elapsed tach should never surface in towplane logbook output."""
+        log_date = date(2024, 8, 2)
+        logsheet = Logsheet.objects.create(
+            log_date=log_date,
+            airfield=self.airfield,
+            duty_officer=self.member,
+            created_by=self.member,
+        )
+
+        # Legacy bad data: negative stored tach_time
+        TowplaneCloseout.objects.create(
+            logsheet=logsheet,
+            towplane=self.towplane,
+            start_tach=200.0,
+            end_tach=199.0,
+            tach_time=-1.0,
+        )
+
+        client = Client()
+        client.force_login(self.member)
+
+        response = client.get(
+            reverse("logsheet:towplane_logbook", args=[self.towplane.pk])
+        )
+        self.assertEqual(response.status_code, 200)
+        daily = response.context["daily"]
+
+        self.assertEqual(len(daily), 1)
+        day_data = daily[0]
+        self.assertEqual(day_data["day"], log_date)
+        self.assertEqual(day_data["day_hours"], 0.0)
 
     def test_guest_towpilot_name(self):
         """

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -3637,6 +3637,7 @@ def _issues_by_day_for_glider(glider):
 
 
 def _deadlines_by_day_for_glider(glider):
+    today = timezone.localdate()
     qs = (
         MaintenanceDeadline.objects.filter(glider=glider)
         .annotate(day=TruncDate("due_date"))
@@ -3645,6 +3646,8 @@ def _deadlines_by_day_for_glider(glider):
     )
     bucket = {}
     for dl in qs:
+        dl = dict(dl)
+        dl["is_future"] = dl["day"] > today
         bucket.setdefault(dl["day"], []).append(dl)
     return bucket
 
@@ -3740,6 +3743,7 @@ def _issues_by_day_for_towplane(towplane):
 
 def _deadlines_by_day_for_towplane(towplane):
     """Get maintenance deadlines by due_date for a towplane."""
+    today = timezone.localdate()
     qs = (
         MaintenanceDeadline.objects.filter(towplane=towplane)
         .values("due_date", "id", "description")
@@ -3747,7 +3751,9 @@ def _deadlines_by_day_for_towplane(towplane):
     )
     bucket = {}
     for dl in qs:
+        dl = dict(dl)
         day = dl["due_date"]
+        dl["is_future"] = day > today
         bucket.setdefault(day, []).append(dl)
     return bucket
 
@@ -3808,11 +3814,19 @@ def towplane_logbook(request, pk: int):
     # Note: When multiple closeouts exist for the same day (e.g., from different
     # logsheets), we use the first logsheet's PK encountered. The closeouts are
     # ordered by log_date and logsheet_id, so this is deterministic.
+    def _elapsed_tach_hours(closeout):
+        if closeout.tach_time is not None:
+            return float(closeout.tach_time)
+        if closeout.start_tach is not None and closeout.end_tach is not None:
+            return float(closeout.end_tach - closeout.start_tach)
+        return 0.0
+
     daily_data = {}
     for c in closeouts:
         day = c.logsheet.log_date
         flight_info = flights_by_day.get(day, {"count": 0, "towpilots": set()})
         tow_count = flight_info["count"]
+        elapsed_tach = _elapsed_tach_hours(c)
 
         if day not in daily_data:
             # Convert tow pilot IDs to names (only when creating new day entry)
@@ -3829,7 +3843,7 @@ def towplane_logbook(request, pk: int):
             daily_data[day] = {
                 "day": day,
                 "logsheet_pk": c.logsheet.pk,
-                "day_hours": float(c.tach_time or 0),
+                "day_hours": elapsed_tach,
                 "cum_hours": float(c.end_tach) if c.end_tach is not None else None,
                 "glider_tows": tow_count,
                 "towpilots": towpilot_names,
@@ -3837,7 +3851,7 @@ def towplane_logbook(request, pk: int):
                 "deadlines": deadlines_by_day.get(day, []),
             }
         else:
-            daily_data[day]["day_hours"] += float(c.tach_time or 0)
+            daily_data[day]["day_hours"] += elapsed_tach
             # Only update cumulative hours when this closeout has a non-null end_tach.
             # This prevents later closeouts without an end_tach from overwriting a
             # previously recorded tach reading for the same day.

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -3816,9 +3816,9 @@ def towplane_logbook(request, pk: int):
     # ordered by log_date and logsheet_id, so this is deterministic.
     def _elapsed_tach_hours(closeout):
         if closeout.tach_time is not None:
-            return float(closeout.tach_time)
+            return max(float(closeout.tach_time), 0.0)
         if closeout.start_tach is not None and closeout.end_tach is not None:
-            return float(closeout.end_tach - closeout.start_tach)
+            return max(float(closeout.end_tach - closeout.start_tach), 0.0)
         return 0.0
 
     daily_data = {}


### PR DESCRIPTION
## Summary
Fixes Issue #950 by restoring elapsed tach-hour visibility in the towplane logbook when `tach_time` is missing, and improving deadline clarity by marking future deadlines as upcoming.

## What Changed
- Towplane closeouts now auto-compute `tach_time` from `end_tach - start_tach` when missing.
- Towplane logbook view now falls back to derived elapsed tach hours when `tach_time` is null.
- Deadline payloads now include an `is_future` flag.
- Equipment logbook template now visually mutes future deadlines and labels them as `Upcoming`.
- Added regression tests for:
  - elapsed tach fallback from start/end tach
  - future deadline upcoming flag behavior

## Validation
- `pytest logsheet/tests/test_towplane_logbook_performance.py -k "elapsed_tach_uses_start_end_when_tach_time_missing or future_deadline_is_marked_upcoming or deadline_appears_on_due_date" -q`
- `pytest logsheet/tests/test_towplane_logbook_performance.py logsheet/tests/test_manual_towplane_addition.py logsheet/tests/test_towplane_rental_setting.py -q`

## Issue
- Closes #950