### PR TITLE
Security: bump bleach and cryptography to patched versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ asgiref==3.9.1
 Authlib==1.6.12
 bandit==1.8.6
 black==26.3.1
-bleach==6.3.0
+bleach==6.4.0
 boolean.py==5.0
 CacheControl==0.14.3
 cachetools==5.5.2
@@ -15,7 +15,7 @@ charset-normalizer==3.4.3
 click==8.3.0
 coverage==7.11.0
 crispy-bootstrap4==2025.6
-cryptography==46.0.7
+cryptography==48.0.1
 cyclonedx-python-lib==9.1.0
 defusedxml==0.7.1
 diff-match-patch==20241021


### PR DESCRIPTION
## Summary
Remediates the four open Dependabot alerts by updating vulnerable Python dependencies in `requirements.txt`.

## Changes
- `bleach` from `6.3.0` to `6.4.0`
- `cryptography` from `46.0.7` to `48.0.1`

## Alerts addressed
- Dependabot alert #60 (`cryptography`, high)
- Dependabot alert #61 (`bleach`, low)
- Dependabot alert #62 (`bleach`, medium)
- Dependabot alert #63 (`bleach`, medium)

## Validation
- Installed upgraded packages successfully in `.venv`
- Ran smoke test:
  - `pytest logsheet/tests/test_towplane_logbook_performance.py -q`
  - Result: 15 passed

## Notes
`python -m pip_audit -r requirements.txt` reports additional Django advisories with fixes in `Django==5.2.15` (currently pinned at `5.2.14`). Those are not part of the four requested Dependabot alerts and can be handled in a follow-up PR if desired.