### PR TITLE
Fix #947: Use scheduled duty-date dropdowns for swap offers

### DIFF
--- a/duty_roster/forms.py
+++ b/duty_roster/forms.py
@@ -1,4 +1,5 @@
 import calendar
+from datetime import date
 
 from django import forms
 from django.db.models import Exists, OuterRef, Q
@@ -586,6 +587,13 @@ class DutySwapRequestForm(forms.ModelForm):
 class DutySwapOfferForm(forms.ModelForm):
     """Form for making an offer to help with a swap request."""
 
+    proposed_swap_date = forms.TypedChoiceField(
+        required=False,
+        coerce=lambda v: date.fromisoformat(v) if v else None,
+        empty_value=None,
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
+
     class Meta:
         model = DutySwapOffer
         fields = ["offer_type", "proposed_swap_date", "notes"]
@@ -613,6 +621,17 @@ class DutySwapOfferForm(forms.ModelForm):
         self.swap_request = swap_request
         self.offered_by = offered_by
         self.fields["proposed_swap_date"].required = False
+        self._available_swap_dates = self._get_available_swap_dates()
+
+        if self._available_swap_dates:
+            date_choices = [("", "Select one of your scheduled duty dates")] + [
+                (d.isoformat(), d.strftime("%a, %b %d, %Y"))
+                for d in self._available_swap_dates
+            ]
+        else:
+            date_choices = [("", "No eligible upcoming duty dates found")]
+
+        self.fields["proposed_swap_date"].choices = date_choices
 
         # Set choices on the field, not the widget
         # Make the swap option dynamic based on the request date
@@ -621,10 +640,65 @@ class DutySwapOfferForm(forms.ModelForm):
             if swap_request
             else "their date"
         )
-        self.fields["offer_type"].choices = [
-            ("cover", "Cover - I'll take this duty (no swap needed)"),
-            ("swap", f"Swap - I'll take {swap_date_str} if they take my date"),
-        ]
+        if self._available_swap_dates:
+            self.fields["offer_type"].choices = [
+                ("cover", "Cover - I'll take this duty (no swap needed)"),
+                ("swap", f"Swap - I'll take {swap_date_str} if they take my date"),
+            ]
+            self.fields["offer_type"].help_text = (
+                "Swap offers are available because you have eligible upcoming duty dates."
+            )
+        else:
+            self.fields["offer_type"].choices = [
+                ("cover", "Cover - I'll take this duty (no swap needed)"),
+            ]
+            self.fields["offer_type"].help_text = (
+                "No eligible upcoming duty dates were found for you, so only cover offers are available."
+            )
+
+    def _get_available_swap_dates(self):
+        """Return sorted upcoming duty dates where the offerer holds this same role."""
+        if not self.swap_request or not self.offered_by:
+            return []
+
+        today = timezone.localdate()
+        role = self.swap_request.role
+
+        if role == "DYNAMIC":
+            if not self.swap_request.dynamic_role_key:
+                return []
+
+            dates = (
+                DutyAssignmentRole.objects.filter(
+                    member=self.offered_by,
+                    role_key=self.swap_request.dynamic_role_key,
+                    assignment__date__gte=today,
+                )
+                .values_list("assignment__date", flat=True)
+                .distinct()
+                .order_by("assignment__date")
+            )
+            return list(dates)
+
+        role_field_map = {
+            "DO": "duty_officer",
+            "ADO": "assistant_duty_officer",
+            "INSTRUCTOR": "instructor",
+            "TOW": "tow_pilot",
+        }
+        role_field = role_field_map.get(role)
+        if not role_field:
+            return []
+
+        dates = (
+            DutyAssignment.objects.filter(
+                date__gte=today,
+                **{role_field: self.offered_by},
+            )
+            .values_list("date", flat=True)
+            .order_by("date")
+        )
+        return list(dates)
 
     def clean(self):
         from django.utils import timezone
@@ -634,9 +708,21 @@ class DutySwapOfferForm(forms.ModelForm):
         proposed_date = cleaned_data.get("proposed_swap_date")
 
         if offer_type == "swap" and not proposed_date:
+            if not self._available_swap_dates:
+                self.add_error(
+                    "proposed_swap_date",
+                    "You do not have any upcoming duty dates eligible for this swap.",
+                )
+                return cleaned_data
             self.add_error(
                 "proposed_swap_date",
                 "Please select a date for the swap.",
+            )
+
+        if proposed_date and proposed_date not in set(self._available_swap_dates):
+            self.add_error(
+                "proposed_swap_date",
+                "Please choose one of your eligible scheduled duty dates.",
             )
 
         if proposed_date:

--- a/duty_roster/forms.py
+++ b/duty_roster/forms.py
@@ -599,9 +599,6 @@ class DutySwapOfferForm(forms.ModelForm):
         fields = ["offer_type", "proposed_swap_date", "notes"]
         widgets = {
             "offer_type": forms.RadioSelect(attrs={"class": "form-check-input"}),
-            "proposed_swap_date": forms.DateInput(
-                attrs={"type": "date", "class": "form-control"}
-            ),
             "notes": forms.Textarea(
                 attrs={
                     "class": "form-control",
@@ -617,6 +614,12 @@ class DutySwapOfferForm(forms.ModelForm):
         }
 
     def __init__(self, *args, swap_request=None, offered_by=None, **kwargs):
+        incoming_data = kwargs.get("data")
+        if incoming_data is not None and incoming_data.get("offer_type") != "swap":
+            mutable_data = incoming_data.copy()
+            mutable_data["proposed_swap_date"] = ""
+            kwargs["data"] = mutable_data
+
         super().__init__(*args, **kwargs)
         self.swap_request = swap_request
         self.offered_by = offered_by

--- a/duty_roster/forms.py
+++ b/duty_roster/forms.py
@@ -739,6 +739,7 @@ class DutySwapOfferForm(forms.ModelForm):
                 "proposed_swap_date",
                 "Please choose one of your eligible scheduled duty dates.",
             )
+            return cleaned_data
 
         if proposed_date:
             today = timezone.localdate()

--- a/duty_roster/forms.py
+++ b/duty_roster/forms.py
@@ -673,6 +673,7 @@ class DutySwapOfferForm(forms.ModelForm):
                     member=self.offered_by,
                     role_key=self.swap_request.dynamic_role_key,
                     assignment__date__gte=today,
+                    assignment__is_scheduled=True,
                 )
                 .values_list("assignment__date", flat=True)
                 .distinct()
@@ -693,6 +694,7 @@ class DutySwapOfferForm(forms.ModelForm):
         dates = (
             DutyAssignment.objects.filter(
                 date__gte=today,
+                is_scheduled=True,
                 **{role_field: self.offered_by},
             )
             .values_list("date", flat=True)

--- a/duty_roster/forms.py
+++ b/duty_roster/forms.py
@@ -615,10 +615,20 @@ class DutySwapOfferForm(forms.ModelForm):
 
     def __init__(self, *args, swap_request=None, offered_by=None, **kwargs):
         incoming_data = kwargs.get("data")
+        data_from_args = False
+        if incoming_data is None and args:
+            possible_data = args[0]
+            if hasattr(possible_data, "get"):
+                incoming_data = possible_data
+                data_from_args = True
+
         if incoming_data is not None and incoming_data.get("offer_type") != "swap":
             mutable_data = incoming_data.copy()
             mutable_data["proposed_swap_date"] = ""
-            kwargs["data"] = mutable_data
+            if data_from_args:
+                args = (mutable_data, *args[1:])
+            else:
+                kwargs["data"] = mutable_data
 
         super().__init__(*args, **kwargs)
         self.swap_request = swap_request

--- a/duty_roster/forms.py
+++ b/duty_roster/forms.py
@@ -741,7 +741,7 @@ class DutySwapOfferForm(forms.ModelForm):
             )
 
         if proposed_date:
-            today = timezone.now().date()
+            today = timezone.localdate()
             if proposed_date < today:
                 self.add_error(
                     "proposed_swap_date",

--- a/duty_roster/templates/duty_roster/swap/make_offer.html
+++ b/duty_roster/templates/duty_roster/swap/make_offer.html
@@ -70,6 +70,12 @@
                             {% if form.offer_type.errors %}
                             <div class="invalid-feedback d-block">{{ form.offer_type.errors.0 }}</div>
                             {% endif %}
+                            {% if form.offer_type.help_text %}
+                            <div class="form-text mt-2">
+                                <i class="fas fa-info-circle me-1"></i>
+                                {{ form.offer_type.help_text }}
+                            </div>
+                            {% endif %}
                         </div>
 
                         <!-- Swap Date Selection -->
@@ -83,7 +89,7 @@
                             {% endif %}
                             <div class="form-text">
                                 <i class="fas fa-info-circle me-1"></i>
-                                Pick a date when you're scheduled but {{ swap_request.requester.first_name }} could take over.
+                                Choose one of your scheduled upcoming duty dates that {{ swap_request.requester.first_name }} could take over.
                             </div>
                         </div>
 

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -519,6 +519,20 @@ class TestDutySwapOfferForm:
 
         assert offer_choices == ["cover"]
 
+    def test_cover_offer_ignores_stale_proposed_swap_date(self, swap_request, bob):
+        """Cover offers should validate even if stale swap date is posted."""
+        form = DutySwapOfferForm(
+            data={
+                "offer_type": "cover",
+                "proposed_swap_date": (date.today() + timedelta(days=60)).isoformat(),
+                "notes": "Covering this duty",
+            },
+            swap_request=swap_request,
+            offered_by=bob,
+        )
+
+        assert form.is_valid()
+
     def test_swap_offer_excludes_adhoc_dates_for_static_roles(
         self, swap_request, bob, bob_duty_assignment
     ):
@@ -1086,8 +1100,11 @@ class TestSwapOfferWorkflow:
         )
 
         assert response.status_code == 200
-        assert "Select a valid choice. swap is not one of the available choices." in (
-            response.content.decode()
+        errors = response.context["form"].errors
+        assert "offer_type" in errors
+        assert (
+            "Select a valid choice. swap is not one of the available choices."
+            in errors["offer_type"]
         )
         assert not DutySwapOffer.objects.filter(
             swap_request=dynamic_request,

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -457,37 +457,67 @@ class TestDutySwapRequestForm:
 class TestDutySwapOfferForm:
     """Tests for DutySwapOfferForm validation."""
 
-    def test_cover_offer_valid(self):
+    def test_cover_offer_valid(self, swap_request, bob):
         """Cover offer without swap date is valid."""
         form = DutySwapOfferForm(
             data={
                 "offer_type": "cover",
                 "notes": "Happy to help!",
-            }
+            },
+            swap_request=swap_request,
+            offered_by=bob,
         )
         assert form.is_valid()
 
-    def test_swap_offer_requires_date(self):
+    def test_swap_offer_requires_date(self, swap_request, bob, bob_duty_assignment):
         """Swap offer without proposed date is invalid."""
         form = DutySwapOfferForm(
             data={
                 "offer_type": "swap",
                 "notes": "",
-            }
+            },
+            swap_request=swap_request,
+            offered_by=bob,
         )
         assert not form.is_valid()
         assert "proposed_swap_date" in form.errors
 
-    def test_swap_offer_with_date_valid(self):
+    def test_swap_offer_with_date_valid(self, swap_request, bob, bob_duty_assignment):
         """Swap offer with proposed date is valid."""
         form = DutySwapOfferForm(
             data={
                 "offer_type": "swap",
-                "proposed_swap_date": date.today() + timedelta(days=30),
+                "proposed_swap_date": bob_duty_assignment.date.isoformat(),
                 "notes": "",
-            }
+            },
+            swap_request=swap_request,
+            offered_by=bob,
         )
         assert form.is_valid()
+
+    def test_swap_offer_dropdown_contains_offerer_scheduled_dates(
+        self, swap_request, bob, bob_duty_assignment
+    ):
+        """Swap date choices should be populated from the offerer's assignments."""
+        form = DutySwapOfferForm(swap_request=swap_request, offered_by=bob)
+
+        choice_values = {
+            value
+            for value, _label in form.fields["proposed_swap_date"].choices
+            if value
+        }
+
+        assert bob_duty_assignment.date.isoformat() in choice_values
+
+    def test_swap_offer_only_allows_cover_without_eligible_dates(
+        self, swap_request, bob
+    ):
+        """When no eligible duty dates exist, only cover should be offered."""
+        form = DutySwapOfferForm(swap_request=swap_request, offered_by=bob)
+
+        offer_choices = [value for value, _label in form.fields["offer_type"].choices]
+
+        assert offer_choices == ["cover"]
 
 
 # =============================================================================

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -1046,7 +1046,7 @@ class TestSwapOfferWorkflow:
         assert eligible.filter(pk=alice.pk).exists()
         assert not eligible.filter(pk=bob.pk).exists()
 
-    def test_dynamic_swap_offer_requires_matching_role_assignment_on_proposed_date(
+    def test_dynamic_swap_offer_unavailable_without_matching_role_assignment(
         self, client, site_config, alice, bob
     ):
         """Dynamic swap offers are unavailable when offerer has no eligible scheduled date."""

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -519,6 +519,93 @@ class TestDutySwapOfferForm:
 
         assert offer_choices == ["cover"]
 
+    def test_swap_offer_excludes_adhoc_dates_for_static_roles(
+        self, swap_request, bob, bob_duty_assignment
+    ):
+        """Swap date choices should exclude ad-hoc assignments for static roles."""
+        adhoc_date = date.today() + timedelta(days=28)
+        DutyAssignment.objects.create(
+            date=adhoc_date,
+            tow_pilot=bob,
+            is_scheduled=False,
+        )
+
+        form = DutySwapOfferForm(swap_request=swap_request, offered_by=bob)
+        choice_values = {
+            value
+            for value, _label in form.fields["proposed_swap_date"].choices
+            if value
+        }
+
+        assert bob_duty_assignment.date.isoformat() in choice_values
+        assert adhoc_date.isoformat() not in choice_values
+
+    def test_swap_offer_excludes_adhoc_dates_for_dynamic_roles(
+        self, site_config, alice, bob
+    ):
+        """Dynamic swap date choices should include only scheduled assignments."""
+        site_config.enable_dynamic_duty_roles = True
+        site_config.save(update_fields=["enable_dynamic_duty_roles"])
+
+        role_definition = DutyRoleDefinition.objects.create(
+            site_configuration=site_config,
+            key="launch_coord",
+            display_name="Launch Coordinator",
+            is_active=True,
+            sort_order=10,
+        )
+        role_definition.qualification_requirements.create(
+            requirement_type="legacy_role_flag",
+            requirement_value="towpilot",
+            is_required=True,
+        )
+
+        original_date = date.today() + timedelta(days=10)
+        scheduled_date = date.today() + timedelta(days=18)
+        adhoc_date = date.today() + timedelta(days=22)
+
+        dynamic_request = DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=original_date,
+            role="DYNAMIC",
+            dynamic_role_key="launch_coord",
+            dynamic_role_label="Launch Coordinator",
+            request_type="general",
+            status="open",
+        )
+
+        scheduled_assignment = DutyAssignment.objects.create(
+            date=scheduled_date,
+            is_scheduled=True,
+        )
+        adhoc_assignment = DutyAssignment.objects.create(
+            date=adhoc_date,
+            is_scheduled=False,
+        )
+
+        DutyAssignmentRole.objects.create(
+            assignment=scheduled_assignment,
+            role_key="launch_coord",
+            member=bob,
+            role_definition=role_definition,
+        )
+        DutyAssignmentRole.objects.create(
+            assignment=adhoc_assignment,
+            role_key="launch_coord",
+            member=bob,
+            role_definition=role_definition,
+        )
+
+        form = DutySwapOfferForm(swap_request=dynamic_request, offered_by=bob)
+        choice_values = {
+            value
+            for value, _label in form.fields["proposed_swap_date"].choices
+            if value
+        }
+
+        assert scheduled_date.isoformat() in choice_values
+        assert adhoc_date.isoformat() not in choice_values
+
 
 # =============================================================================
 # View Access Tests
@@ -948,7 +1035,7 @@ class TestSwapOfferWorkflow:
     def test_dynamic_swap_offer_requires_matching_role_assignment_on_proposed_date(
         self, client, site_config, alice, bob
     ):
-        """Dynamic swap offers must propose a date where offerer has same dynamic role."""
+        """Dynamic swap offers are unavailable when offerer has no eligible scheduled date."""
         site_config.enable_dynamic_duty_roles = True
         site_config.save(update_fields=["enable_dynamic_duty_roles"])
 
@@ -985,7 +1072,8 @@ class TestSwapOfferWorkflow:
             status="open",
         )
 
-        # Bob is eligible in general for this dynamic role, but has no assignment on proposed date.
+        # Bob is eligible in general for this dynamic role, but has no scheduled
+        # assignment for this role, so swap option is unavailable.
         client.force_login(bob)
         url = reverse("duty_roster:make_swap_offer", args=[dynamic_request.id])
         response = client.post(
@@ -998,9 +1086,8 @@ class TestSwapOfferWorkflow:
         )
 
         assert response.status_code == 200
-        assert (
-            "You can only swap with a date where you hold this same dynamic role."
-            in (response.content.decode())
+        assert "Select a valid choice. swap is not one of the available choices." in (
+            response.content.decode()
         )
         assert not DutySwapOffer.objects.filter(
             swap_request=dynamic_request,

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -1100,12 +1100,9 @@ class TestSwapOfferWorkflow:
         )
 
         assert response.status_code == 200
-        errors = response.context["form"].errors
-        assert "offer_type" in errors
-        assert (
-            "Select a valid choice. swap is not one of the available choices."
-            in errors["offer_type"]
-        )
+        error_data = response.context["form"].errors.as_data()
+        assert "offer_type" in error_data
+        assert error_data["offer_type"][0].code == "invalid_choice"
         assert not DutySwapOffer.objects.filter(
             swap_request=dynamic_request,
             offered_by=bob,

--- a/e2e_tests/e2e/test_duty_swap_auto_accept.py
+++ b/e2e_tests/e2e/test_duty_swap_auto_accept.py
@@ -89,6 +89,13 @@ class TestDutySwapAutoAccept(DjangoPlaywrightTestCase):
         requester, offerer, swap_request = self._create_open_tow_swap_request()
         proposed_date = date.today() + timedelta(days=21)
 
+        # Ensure the offerer has an eligible scheduled date for the swap dropdown.
+        DutyAssignment.objects.create(
+            date=proposed_date,
+            tow_pilot=offerer,
+            is_scheduled=True,
+        )
+
         self.login(username=offerer.username)
         offer_url = reverse("duty_roster:make_swap_offer", args=[swap_request.pk])
         self.page.goto(f"{self.live_server_url}{offer_url}")
@@ -98,7 +105,9 @@ class TestDutySwapAutoAccept(DjangoPlaywrightTestCase):
         self.page.wait_for_function(
             "() => getComputedStyle(document.querySelector('#swap-date-section')).display !== 'none'"
         )
-        self.page.fill('input[name="proposed_swap_date"]', proposed_date.isoformat())
+        self.page.select_option(
+            'select[name="proposed_swap_date"]', proposed_date.isoformat()
+        )
         self.page.fill('textarea[name="notes"]', "Can trade with my duty date")
         self.page.get_by_role("button", name="Send Offer").click()
 

--- a/e2e_tests/e2e/test_dynamic_swap_full_flow.py
+++ b/e2e_tests/e2e/test_dynamic_swap_full_flow.py
@@ -71,10 +71,12 @@ class TestDynamicSwapFullFlow(DjangoPlaywrightTestCase):
         original_assignment = DutyAssignment.objects.create(
             date=original_date,
             tow_pilot=requester,
+            is_scheduled=True,
         )
         swap_assignment = DutyAssignment.objects.create(
             date=proposed_swap_date,
             tow_pilot=offerer,
+            is_scheduled=True,
         )
 
         DutyAssignmentRole.objects.create(
@@ -133,8 +135,8 @@ class TestDynamicSwapFullFlow(DjangoPlaywrightTestCase):
         self.page.wait_for_function(
             "() => getComputedStyle(document.querySelector('#swap-date-section')).display !== 'none'"
         )
-        self.page.fill(
-            'input[name="proposed_swap_date"]', proposed_swap_date.isoformat()
+        self.page.select_option(
+            'select[name="proposed_swap_date"]', proposed_swap_date.isoformat()
         )
         self.page.fill(
             'textarea[name="notes"]', "Happy to trade launch coordinator dates"


### PR DESCRIPTION
## Summary
Fixes #947 by replacing manual swap date entry with a dropdown of eligible scheduled duty dates when making a swap offer.

## What Changed
- Updated `DutySwapOfferForm` to populate `proposed_swap_date` choices from the offerer's upcoming assignments for the same role.
- Added dynamic-role-aware date filtering using `DutyAssignmentRole` role key matching.
- Enforced that submitted swap dates must be one of the eligible scheduled options.
- Added no-eligible-date UX behavior:
  - only `cover` offer type is available
  - clear helper text explains why swap is unavailable
- Updated offer template text/help to match dropdown workflow.
- Added/updated tests for:
  - valid swap with eligible selected date
  - required swap date validation
  - dropdown options include scheduled dates
  - cover-only behavior when no eligible dates exist

## Validation
- `pytest duty_roster/tests/test_duty_swap.py -k "DutySwapOfferForm or make_swap_offer" -q`
  - Result: `6 passed, 69 deselected`
