### PR TITLE
Issue #946: periodic open-swap reminders + calendar/modal visibility

### DIFF
--- a/duty_roster/management/commands/remind_open_swap_requests.py
+++ b/duty_roster/management/commands/remind_open_swap_requests.py
@@ -29,7 +29,7 @@ class Command(BaseCronJobCommand):
         prefix = "[DRY RUN] " if dry_run else ""
         self.log_info(
             f"{prefix}Reminder candidates={summary['candidate_count']}, "
-            f"requests_notified={summary['request_count']}, "
+            f"requests_processed={summary['request_count']}, "
             f"emails_sent={summary['email_count']}, "
             f"skipped_no_recipients={summary['skipped_no_recipients']}"
         )

--- a/duty_roster/management/commands/remind_open_swap_requests.py
+++ b/duty_roster/management/commands/remind_open_swap_requests.py
@@ -1,0 +1,35 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from duty_roster.views_swap import send_periodic_open_swap_reminder_notifications
+from utils.management.commands.base_cronjob import BaseCronJobCommand
+
+
+class Command(BaseCronJobCommand):
+    help = "Send periodic reminder emails for open duty swap requests"
+    job_name = "remind_open_swap_requests"
+    max_execution_time = timedelta(
+        minutes=5
+    )  # Matches K8s CronJob activeDeadlineSeconds=300
+
+    def execute_job(self, *args, **options):
+        dry_run = options.get("dry_run", False)
+        today = timezone.now().date()
+
+        summary = send_periodic_open_swap_reminder_notifications(
+            today=today,
+            dry_run=dry_run,
+        )
+
+        if summary["candidate_count"] == 0:
+            self.log_info("No open swap requests matched reminder offsets today")
+            return
+
+        prefix = "[DRY RUN] " if dry_run else ""
+        self.log_info(
+            f"{prefix}Reminder candidates={summary['candidate_count']}, "
+            f"requests_notified={summary['request_count']}, "
+            f"emails_sent={summary['email_count']}, "
+            f"skipped_no_recipients={summary['skipped_no_recipients']}"
+        )

--- a/duty_roster/management/commands/remind_open_swap_requests.py
+++ b/duty_roster/management/commands/remind_open_swap_requests.py
@@ -10,8 +10,8 @@ class Command(BaseCronJobCommand):
     help = "Send periodic reminder emails for open duty swap requests"
     job_name = "remind_open_swap_requests"
     max_execution_time = timedelta(
-        minutes=5
-    )  # Matches K8s CronJob activeDeadlineSeconds=300
+        minutes=15
+    )  # Matches K8s CronJob activeDeadlineSeconds=900
 
     def execute_job(self, *args, **options):
         dry_run = options.get("dry_run", False)

--- a/duty_roster/templates/duty_roster/_calendar_table.html
+++ b/duty_roster/templates/duty_roster/_calendar_table.html
@@ -45,7 +45,7 @@
                 <div class="mb-1">
                   <span class="badge rounded-pill text-bg-warning"
                         title="Open coverage requests: {{ swap_summary.roles|join:', ' }}"
-                    aria-label="{{ swap_summary.count }} open swap request{{ swap_summary.count|pluralize }}">
+                    aria-label="{{ swap_summary.count }} open swap request{{ swap_summary.count|pluralize }}: {{ swap_summary.roles|join:', ' }}">
                     <i class="bi bi-arrow-left-right" aria-hidden="true"></i>
                     {{ swap_summary.count }} open
                   </span>

--- a/duty_roster/templates/duty_roster/_calendar_table.html
+++ b/duty_roster/templates/duty_roster/_calendar_table.html
@@ -40,6 +40,19 @@
               onclick="showModalWithLoading();">
             <div class="calendar-day-number">{{ day.day }}</div>
 
+            {% with swap_summary=open_swap_summary_by_date|dict_get:day %}
+              {% if swap_summary %}
+                <div class="mb-1">
+                  <span class="badge rounded-pill text-bg-warning"
+                        title="Open coverage requests: {{ swap_summary.roles|join:', ' }}"
+                        aria-label="{{ swap_summary.count }} open swap requests">
+                    <i class="bi bi-arrow-left-right" aria-hidden="true"></i>
+                    {{ swap_summary.count }} open
+                  </span>
+                </div>
+              {% endif %}
+            {% endwith %}
+
             {% if day in assignments_by_date %}
               {% with a=assignments_by_date|dict_get:day %}
                 {% if not a.confirmed and not a.is_confirmed %}

--- a/duty_roster/templates/duty_roster/_calendar_table.html
+++ b/duty_roster/templates/duty_roster/_calendar_table.html
@@ -45,7 +45,7 @@
                 <div class="mb-1">
                   <span class="badge rounded-pill text-bg-warning"
                         title="Open coverage requests: {{ swap_summary.roles|join:', ' }}"
-                        aria-label="{{ swap_summary.count }} open swap requests">
+                    aria-label="{{ swap_summary.count }} open swap request{{ swap_summary.count|pluralize }}">
                     <i class="bi bi-arrow-left-right" aria-hidden="true"></i>
                     {{ swap_summary.count }} open
                   </span>

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -205,6 +205,40 @@
   </div>
 
   {# Surge Alerts #}
+  {% if open_swap_requests %}
+  <div class="card border-0 shadow-sm mb-3">
+    <div class="card-header bg-light text-dark py-2 border-bottom">
+      <h6 class="mb-0 fw-semibold">
+        <i class="bi bi-arrow-left-right me-2" aria-hidden="true"></i>Open Swap Requests
+      </h6>
+    </div>
+    <div class="card-body p-3">
+      <p class="text-muted small mb-2">
+        {{ open_swap_requests|length }} open coverage request{{ open_swap_requests|length|pluralize }} for this day.
+      </p>
+      <ul class="list-group list-group-flush">
+        {% for swap_request in open_swap_requests %}
+        <li class="list-group-item px-0 py-2 d-flex justify-content-between align-items-start gap-2">
+          <div>
+            <div class="fw-semibold">{{ swap_request.get_role_title }}</div>
+            <small class="text-muted">
+              Requested by {{ swap_request.requester.full_display_name }}
+              {% if swap_request.request_type == 'direct' and swap_request.direct_request_to %}
+                · Direct to {{ swap_request.direct_request_to.full_display_name }}
+              {% endif %}
+            </small>
+          </div>
+          <a href="{% url 'duty_roster:swap_request_detail' request_id=swap_request.id %}"
+             class="btn btn-outline-primary btn-sm">
+            View
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+
   {% if show_surge_alert %}
   <div class="alert alert-warning d-flex align-items-center mb-3" role="alert">
     <i class="bi bi-exclamation-triangle-fill me-2" aria-hidden="true"></i>

--- a/duty_roster/templates/duty_roster/calendar_day_modal.html
+++ b/duty_roster/templates/duty_roster/calendar_day_modal.html
@@ -204,7 +204,7 @@
     </div>
   </div>
 
-  {# Surge Alerts #}
+  {# Open Swap Requests #}
   {% if open_swap_requests %}
   <div class="card border-0 shadow-sm mb-3">
     <div class="card-header bg-light text-dark py-2 border-bottom">

--- a/duty_roster/templates/duty_roster/emails/swap_reminder_periodic.html
+++ b/duty_roster/templates/duty_roster/emails/swap_reminder_periodic.html
@@ -25,7 +25,7 @@
                 {% if days_until <= 1 %}
                 <tr>
                     <td style="padding:14px 36px;background:#dc3545;color:#fff;font-weight:bold;text-align:center;">
-                        🚨 Urgent: {{ days_until }} day left
+                        🚨 Urgent: {{ days_until }} day{{ days_until|pluralize }} left
                     </td>
                 </tr>
                 {% elif days_until <= 3 %}

--- a/duty_roster/templates/duty_roster/emails/swap_reminder_periodic.html
+++ b/duty_roster/templates/duty_roster/emails/swap_reminder_periodic.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Swap Reminder</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+    <tr>
+        <td align="center" style="padding:20px 0;">
+            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,.1)">
+                <tr>
+                    <td style="padding:28px 36px;background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);text-align:center;">
+                        {% if club_logo_url %}
+                        <img src="{{ club_logo_url }}" alt="{{ club_name }}" style="max-height:60px;max-width:200px;height:auto;margin-bottom:12px;">
+                        {% endif %}
+                        <h1 style="margin:0;color:#fff;font-size:24px;">⏰ Swap Reminder</h1>
+                        <p style="margin:8px 0 0 0;color:#e6e6e6;font-size:16px;">
+                            {{ role_title }} · {{ swap_request.original_date|date:"l, F j, Y" }}
+                        </p>
+                    </td>
+                </tr>
+
+                {% if days_until <= 1 %}
+                <tr>
+                    <td style="padding:14px 36px;background:#dc3545;color:#fff;font-weight:bold;text-align:center;">
+                        🚨 Urgent: {{ days_until }} day left
+                    </td>
+                </tr>
+                {% elif days_until <= 3 %}
+                <tr>
+                    <td style="padding:14px 36px;background:#fd7e14;color:#fff;font-weight:bold;text-align:center;">
+                        ⚠️ Coming soon: {{ days_until }} days left
+                    </td>
+                </tr>
+                {% endif %}
+
+                <tr>
+                    <td style="padding:32px 36px;">
+                        <p style="margin:0 0 16px 0;color:#2d3748;font-size:16px;line-height:1.6;">
+                            Hi{% if recipient %} {{ recipient.first_name }}{% endif %},
+                        </p>
+
+                        <p style="margin:0 0 16px 0;color:#2d3748;font-size:16px;line-height:1.6;">
+                            This is a reminder that <strong>{{ swap_request.requester.full_display_name }}</strong>
+                            still needs coverage for a <strong>{{ role_title }}</strong> duty on
+                            <strong>{{ swap_request.original_date|date:"l, F j, Y" }}</strong>.
+                        </p>
+
+                        <p style="margin:0 0 18px 0;color:#4a5568;font-size:15px;line-height:1.6;">
+                            Time remaining: <strong>{{ days_until }} day{{ days_until|pluralize }}</strong>
+                        </p>
+
+                        {% if swap_request.notes %}
+                        <div style="background:#f7fafc;border-left:4px solid #667eea;padding:14px 16px;margin:0 0 18px 0;">
+                            <p style="margin:0;color:#4a5568;font-style:italic;">"{{ swap_request.notes }}"</p>
+                        </div>
+                        {% endif %}
+
+                        <div style="text-align:center;margin:26px 0;">
+                            <a href="{{ request_url }}" style="display:inline-block;background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);color:#fff;text-decoration:none;padding:12px 28px;border-radius:6px;font-weight:bold;">
+                                View Request / Make Offer
+                            </a>
+                        </div>
+
+                        <p style="margin:0;color:#718096;font-size:13px;line-height:1.6;">
+                            You're receiving this reminder because you're eligible to help, requested the swap,
+                            or manage roster operations.
+                        </p>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="background:#f4f4f4;padding:18px;text-align:center;color:#666;font-size:12px;">
+                        This is an automated message from {{ club_name }}.
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -2340,6 +2340,38 @@ class TestOpenSwapPeriodicReminders:
         assert summary["email_count"] >= 1
         assert captured["fail_silently"] is False
 
+    def test_periodic_reminder_continues_after_recipient_send_exception(
+        self, site_config, alice, bob, monkeypatch
+    ):
+        today = date(2026, 6, 18)
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today + timedelta(days=3),
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+
+        call_count = {"count": 0}
+
+        def _mock_send_mail(**_kwargs):
+            call_count["count"] += 1
+            if call_count["count"] == 1:
+                raise RuntimeError("smtp unavailable")
+            return 1
+
+        monkeypatch.setattr("duty_roster.views_swap.send_mail", _mock_send_mail)
+
+        summary = send_periodic_open_swap_reminder_notifications(
+            today=today,
+            day_offsets=(3,),
+        )
+
+        assert summary["candidate_count"] == 1
+        assert summary["request_count"] == 1
+        assert summary["email_count"] == 1
+        assert call_count["count"] >= 2
+
     def test_command_passes_dry_run_and_today(self, monkeypatch):
         captured = {}
 

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -2863,3 +2863,29 @@ class TestReminderRecipientFiltering:
 
         assert bob.id not in recipient_ids
         assert alice.id in recipient_ids
+
+    def test_direct_request_recipients_do_not_resolve_eligible_members(
+        self, site_config, alice, bob, monkeypatch
+    ):
+        swap_request = DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=date.today() + timedelta(days=7),
+            role="TOW",
+            request_type="direct",
+            direct_request_to=bob,
+            status="open",
+        )
+
+        def _fail_if_called(*_args, **_kwargs):
+            raise AssertionError("eligible member resolution should not run")
+
+        monkeypatch.setattr(
+            "duty_roster.views_swap.get_eligible_members_for_role",
+            _fail_if_called,
+        )
+
+        recipients = list(get_periodic_reminder_recipients(swap_request))
+        recipient_ids = {member.id for member in recipients}
+
+        assert bob.id in recipient_ids
+        assert alice.id in recipient_ids

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -2234,6 +2234,8 @@ class TestOpenSwapPeriodicReminders:
         assert any("Hi Bob" in html for html in html_payloads)
         assert any("Hi Charlie" in html for html in html_payloads)
         assert all("Reminder" in msg.subject for msg in mail.outbox)
+        assert all("View details:" in msg.body for msg in mail.outbox)
+        assert all(str(swap_request.original_date) in msg.body for msg in mail.outbox)
         assert all(
             f"/swap/request/{swap_request.pk}/" in msg.alternatives[0][0]
             for msg in mail.outbox

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -30,6 +30,8 @@ from duty_roster.models import (
 from duty_roster.views_swap import (
     _accept_offer_and_finalize,
     get_eligible_members_for_role,
+    get_open_swap_reminder_candidates,
+    send_periodic_open_swap_reminder_notifications,
     send_request_expired_notifications,
     update_duty_assignments,
 )
@@ -2136,6 +2138,140 @@ class TestSwapRequestExpiryCronjob:
 
 
 @pytest.mark.django_db
+class TestOpenSwapPeriodicReminders:
+    """Tests for periodic open swap reminder cadence and delivery."""
+
+    def test_candidate_selection_uses_exact_offsets(self, site_config, alice):
+        today = date(2026, 6, 18)
+
+        due_14 = DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today + timedelta(days=14),
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+        due_7 = DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today + timedelta(days=7),
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today + timedelta(days=2),
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today + timedelta(days=14),
+            role="TOW",
+            request_type="general",
+            status="fulfilled",
+        )
+
+        candidates = list(get_open_swap_reminder_candidates(today=today))
+        assert {req.pk for req in candidates} == {due_14.pk, due_7.pk}
+
+    @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+    def test_reminders_include_eligible_requester_and_rostermeister_deduped(
+        self, site_config, alice, bob, charlie
+    ):
+        today = date(2026, 6, 18)
+        charlie.rostermeister = True
+        charlie.save(update_fields=["rostermeister"])
+
+        Member.objects.create(
+            username="no_email_helper",
+            first_name="No",
+            last_name="Email",
+            email="",
+            membership_status="Full Member",
+            towpilot=True,
+        )
+
+        swap_request = DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today + timedelta(days=7),
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+
+        mail.outbox.clear()
+        summary = send_periodic_open_swap_reminder_notifications(
+            today=today,
+            day_offsets=(7,),
+        )
+
+        assert summary["candidate_count"] == 1
+        assert summary["request_count"] == 1
+        assert summary["email_count"] == 3
+
+        assert len(mail.outbox) == 3
+        html_payloads = [msg.alternatives[0][0] for msg in mail.outbox]
+        assert any("Hi Alice" in html for html in html_payloads)
+        assert any("Hi Bob" in html for html in html_payloads)
+        assert any("Hi Charlie" in html for html in html_payloads)
+        assert all("Reminder" in msg.subject for msg in mail.outbox)
+        assert all(
+            f"/swap/request/{swap_request.pk}/" in msg.alternatives[0][0]
+            for msg in mail.outbox
+        )
+
+    @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+    def test_dry_run_counts_emails_but_sends_nothing(self, site_config, alice, bob):
+        today = date(2026, 6, 18)
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today + timedelta(days=3),
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+
+        mail.outbox.clear()
+        summary = send_periodic_open_swap_reminder_notifications(
+            today=today,
+            day_offsets=(3,),
+            dry_run=True,
+        )
+
+        assert summary["candidate_count"] == 1
+        assert summary["request_count"] == 1
+        assert summary["email_count"] >= 2  # requester + at least one eligible helper
+        assert len(mail.outbox) == 0
+
+    def test_command_passes_dry_run_and_today(self, monkeypatch):
+        captured = {}
+
+        def _mock_sender(today=None, day_offsets=None, dry_run=False):
+            captured["today"] = today
+            captured["day_offsets"] = day_offsets
+            captured["dry_run"] = dry_run
+            return {
+                "candidate_count": 1,
+                "request_count": 1,
+                "email_count": 4,
+                "skipped_no_recipients": 0,
+            }
+
+        monkeypatch.setattr(
+            "duty_roster.management.commands.remind_open_swap_requests.send_periodic_open_swap_reminder_notifications",
+            _mock_sender,
+        )
+
+        call_command("remind_open_swap_requests", "--dry-run", verbosity=0)
+
+        assert captured["dry_run"] is True
+        assert isinstance(captured["today"], date)
+        assert captured["day_offsets"] is None
+
+
+@pytest.mark.django_db
 class TestVolunteerOpportunitiesEdgeCases:
     """Additional edge-case coverage for volunteer opportunities context."""
 
@@ -2253,3 +2389,73 @@ class TestVolunteerOpportunitiesEdgeCases:
         assert (
             not instr_holes
         ), "Should not show instructor hole to someone already serving as tow pilot that day"
+
+
+@pytest.mark.django_db
+class TestSwapVisibilityInCalendar:
+    """Open swap visibility in month cells and day modal (Issue #946)."""
+
+    def test_calendar_month_shows_open_swap_marker_badge(
+        self, client, site_config, alice
+    ):
+        duty_date = date.today() + timedelta(days=6)
+        DutyAssignment.objects.create(date=duty_date, is_scheduled=True)
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+
+        client.force_login(alice)
+        response = client.get(
+            reverse(
+                "duty_roster:duty_calendar_month",
+                kwargs={"year": duty_date.year, "month": duty_date.month},
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert "1 open" in content
+        assert "Open coverage requests: Tow Pilot" in content
+
+    def test_calendar_day_modal_shows_open_swap_section_with_links(
+        self, client, site_config, alice, bob
+    ):
+        duty_date = date.today() + timedelta(days=8)
+        DutyAssignment.objects.create(date=duty_date, is_scheduled=True)
+        swap_request = DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="direct",
+            direct_request_to=bob,
+            status="open",
+        )
+
+        client.force_login(bob)
+        response = client.get(
+            reverse(
+                "duty_roster:calendar_day_detail",
+                kwargs={
+                    "year": duty_date.year,
+                    "month": duty_date.month,
+                    "day": duty_date.day,
+                },
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert "Open Swap Requests" in content
+        assert "Requested by Alice Requester" in content
+        assert "Tow Pilot" in content
+        assert (
+            reverse(
+                "duty_roster:swap_request_detail",
+                kwargs={"request_id": swap_request.id},
+            )
+            in content
+        )

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -2245,6 +2245,32 @@ class TestOpenSwapPeriodicReminders:
         assert summary["email_count"] >= 2  # requester + at least one eligible helper
         assert len(mail.outbox) == 0
 
+    def test_email_count_only_includes_successful_deliveries(
+        self, site_config, alice, bob, monkeypatch
+    ):
+        today = date(2026, 6, 18)
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today + timedelta(days=3),
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+
+        monkeypatch.setattr(
+            "duty_roster.views_swap.send_mail",
+            lambda **_kwargs: 0,
+        )
+
+        summary = send_periodic_open_swap_reminder_notifications(
+            today=today,
+            day_offsets=(3,),
+        )
+
+        assert summary["candidate_count"] == 1
+        assert summary["request_count"] == 1
+        assert summary["email_count"] == 0
+
     def test_command_passes_dry_run_and_today(self, monkeypatch):
         captured = {}
 

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -2262,6 +2262,28 @@ class TestOpenSwapPeriodicReminders:
         assert summary["email_count"] >= 2  # requester + at least one eligible helper
         assert len(mail.outbox) == 0
 
+    @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+    def test_urgent_banner_pluralizes_day_label(self, site_config, alice, bob):
+        today = date(2026, 6, 18)
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today,
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+
+        mail.outbox.clear()
+        summary = send_periodic_open_swap_reminder_notifications(
+            today=today,
+            day_offsets=(0,),
+        )
+
+        assert summary["candidate_count"] == 1
+        assert len(mail.outbox) >= 1
+        html_payload = mail.outbox[0].alternatives[0][0]
+        assert "Urgent: 0 days left" in html_payload
+
     def test_email_count_only_includes_successful_deliveries(
         self, site_config, alice, bob, monkeypatch
     ):
@@ -2637,3 +2659,23 @@ class TestReminderRecipientFiltering:
         assert bob.id in recipient_ids
         assert alice.id in recipient_ids
         assert unrelated_helper.id not in recipient_ids
+
+    def test_inactive_direct_target_is_excluded_from_reminders(
+        self, site_config, alice, bob
+    ):
+        Member.objects.filter(pk=bob.pk).update(is_active=False)
+
+        swap_request = DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=date.today() + timedelta(days=7),
+            role="TOW",
+            request_type="direct",
+            direct_request_to=bob,
+            status="open",
+        )
+
+        recipients = list(get_periodic_reminder_recipients(swap_request))
+        recipient_ids = {member.id for member in recipients}
+
+        assert bob.id not in recipient_ids
+        assert alice.id in recipient_ids

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -2177,6 +2177,22 @@ class TestOpenSwapPeriodicReminders:
         candidates = list(get_open_swap_reminder_candidates(today=today))
         assert {req.pk for req in candidates} == {due_14.pk, due_7.pk}
 
+    def test_candidate_selection_allows_empty_offsets(self, site_config, alice):
+        today = date(2026, 6, 18)
+
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today + timedelta(days=14),
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+
+        candidates = list(
+            get_open_swap_reminder_candidates(today=today, day_offsets=())
+        )
+        assert candidates == []
+
     @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
     def test_reminders_include_eligible_requester_and_rostermeister_deduped(
         self, site_config, alice, bob, charlie

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -2310,6 +2310,36 @@ class TestOpenSwapPeriodicReminders:
         assert summary["request_count"] == 1
         assert summary["email_count"] == 0
 
+    def test_periodic_reminder_sends_with_fail_silently_false(
+        self, site_config, alice, bob, monkeypatch
+    ):
+        today = date(2026, 6, 18)
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=today + timedelta(days=3),
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+
+        captured = {}
+
+        def _mock_send_mail(**kwargs):
+            captured["fail_silently"] = kwargs.get("fail_silently")
+            return 1
+
+        monkeypatch.setattr("duty_roster.views_swap.send_mail", _mock_send_mail)
+
+        summary = send_periodic_open_swap_reminder_notifications(
+            today=today,
+            day_offsets=(3,),
+        )
+
+        assert summary["candidate_count"] == 1
+        assert summary["request_count"] == 1
+        assert summary["email_count"] >= 1
+        assert captured["fail_silently"] is False
+
     def test_command_passes_dry_run_and_today(self, monkeypatch):
         captured = {}
 

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -31,6 +31,7 @@ from duty_roster.views_swap import (
     _accept_offer_and_finalize,
     get_eligible_members_for_role,
     get_open_swap_reminder_candidates,
+    get_periodic_reminder_recipients,
     send_periodic_open_swap_reminder_notifications,
     send_request_expired_notifications,
     update_duty_assignments,
@@ -2485,3 +2486,110 @@ class TestSwapVisibilityInCalendar:
             )
             in content
         )
+
+    def test_calendar_month_hides_direct_request_from_unrelated_viewer(
+        self, client, site_config, alice, bob, charlie
+    ):
+        duty_date = date.today() + timedelta(days=11)
+        DutyAssignment.objects.create(date=duty_date, is_scheduled=True)
+
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="direct",
+            direct_request_to=bob,
+            status="open",
+        )
+
+        client.force_login(charlie)
+        response = client.get(
+            reverse(
+                "duty_roster:duty_calendar_month",
+                kwargs={"year": duty_date.year, "month": duty_date.month},
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert "1 open" in content
+        assert "2 open" not in content
+
+    def test_calendar_day_modal_hides_direct_request_from_unrelated_viewer(
+        self, client, site_config, alice, bob, charlie
+    ):
+        duty_date = date.today() + timedelta(days=12)
+        DutyAssignment.objects.create(date=duty_date, is_scheduled=True)
+
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="direct",
+            direct_request_to=bob,
+            status="open",
+        )
+
+        client.force_login(charlie)
+        response = client.get(
+            reverse(
+                "duty_roster:calendar_day_detail",
+                kwargs={
+                    "year": duty_date.year,
+                    "month": duty_date.month,
+                    "day": duty_date.day,
+                },
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert "Open Swap Requests" in content
+        assert "1 open coverage request" in content
+        assert "Direct to Bob Offerer" not in content
+
+
+@pytest.mark.django_db
+class TestReminderRecipientFiltering:
+    def test_inactive_rostermeister_is_excluded_from_reminders(
+        self, site_config, alice, bob
+    ):
+        inactive_rostermeister = Member.objects.create(
+            username="inactive_rm",
+            first_name="Inactive",
+            last_name="Rostermeister",
+            email="inactive-rm@example.com",
+            membership_status="Full Member",
+            rostermeister=True,
+        )
+        Member.objects.filter(pk=inactive_rostermeister.pk).update(is_active=False)
+        inactive_rostermeister.refresh_from_db(fields=["is_active"])
+
+        swap_request = DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=date.today() + timedelta(days=7),
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+
+        recipients = list(get_periodic_reminder_recipients(swap_request))
+        recipient_ids = {member.id for member in recipients}
+
+        assert bob.id in recipient_ids
+        assert alice.id in recipient_ids
+        assert inactive_rostermeister.id not in recipient_ids

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -2593,3 +2593,31 @@ class TestReminderRecipientFiltering:
         assert bob.id in recipient_ids
         assert alice.id in recipient_ids
         assert inactive_rostermeister.id not in recipient_ids
+
+    def test_direct_request_reminders_only_include_target_not_all_eligible(
+        self, site_config, alice, bob
+    ):
+        unrelated_helper = Member.objects.create(
+            username="unrelated_helper",
+            first_name="Unrelated",
+            last_name="Helper",
+            email="unrelated-helper@example.com",
+            membership_status="Full Member",
+            towpilot=True,
+        )
+
+        swap_request = DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=date.today() + timedelta(days=7),
+            role="TOW",
+            request_type="direct",
+            direct_request_to=bob,
+            status="open",
+        )
+
+        recipients = list(get_periodic_reminder_recipients(swap_request))
+        recipient_ids = {member.id for member in recipients}
+
+        assert bob.id in recipient_ids
+        assert alice.id in recipient_ids
+        assert unrelated_helper.id not in recipient_ids

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -2590,6 +2590,52 @@ class TestSwapVisibilityInCalendar:
         assert "1 open" in content
         assert "2 open" not in content
 
+    def test_calendar_month_shows_direct_request_to_staff_viewer(
+        self, client, site_config, alice, bob
+    ):
+        duty_date = date.today() + timedelta(days=11)
+        DutyAssignment.objects.create(date=duty_date, is_scheduled=True)
+
+        staff_viewer = Member.objects.create(
+            username="staff_viewer",
+            first_name="Staff",
+            last_name="Viewer",
+            email="staff-viewer@example.com",
+            membership_status="Full Member",
+            rostermeister=True,
+            is_staff=True,
+        )
+        Member.objects.filter(pk=staff_viewer.pk).update(is_staff=True)
+        staff_viewer.refresh_from_db(fields=["is_staff"])
+
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="direct",
+            direct_request_to=bob,
+            status="open",
+        )
+
+        client.force_login(staff_viewer)
+        response = client.get(
+            reverse(
+                "duty_roster:duty_calendar_month",
+                kwargs={"year": duty_date.year, "month": duty_date.month},
+            )
+        )
+
+        assert response.status_code == 200
+        summary = response.context["open_swap_summary_by_date"][duty_date]
+        assert summary["count"] == 2
+
     def test_calendar_day_modal_hides_direct_request_from_unrelated_viewer(
         self, client, site_config, alice, bob, charlie
     ):
@@ -2629,6 +2675,82 @@ class TestSwapVisibilityInCalendar:
         assert "Open Swap Requests" in content
         assert "1 open coverage request" in content
         assert "Direct to Bob Offerer" not in content
+
+    def test_calendar_day_modal_shows_direct_request_to_staff_viewer(
+        self, client, site_config, alice, bob
+    ):
+        duty_date = date.today() + timedelta(days=12)
+        DutyAssignment.objects.create(date=duty_date, is_scheduled=True)
+
+        staff_viewer = Member.objects.create(
+            username="staff_modal_viewer",
+            first_name="Staff",
+            last_name="ModalViewer",
+            email="staff-modal-viewer@example.com",
+            membership_status="Full Member",
+            rostermeister=True,
+            is_staff=True,
+        )
+        Member.objects.filter(pk=staff_viewer.pk).update(is_staff=True)
+        staff_viewer.refresh_from_db(fields=["is_staff"])
+
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="direct",
+            direct_request_to=bob,
+            status="open",
+        )
+
+        client.force_login(staff_viewer)
+        response = client.get(
+            reverse(
+                "duty_roster:calendar_day_detail",
+                kwargs={
+                    "year": duty_date.year,
+                    "month": duty_date.month,
+                    "day": duty_date.day,
+                },
+            )
+        )
+
+        assert response.status_code == 200
+        open_swap_requests = response.context["open_swap_requests"]
+        assert len(open_swap_requests) == 2
+        assert any(req.request_type == "direct" for req in open_swap_requests)
+
+    def test_calendar_month_swap_badge_aria_label_includes_roles(
+        self, client, site_config, alice
+    ):
+        duty_date = date.today() + timedelta(days=6)
+        DutyAssignment.objects.create(date=duty_date, is_scheduled=True)
+        DutySwapRequest.objects.create(
+            requester=alice,
+            original_date=duty_date,
+            role="TOW",
+            request_type="general",
+            status="open",
+        )
+
+        client.force_login(alice)
+        response = client.get(
+            reverse(
+                "duty_roster:duty_calendar_month",
+                kwargs={"year": duty_date.year, "month": duty_date.month},
+            )
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert 'aria-label="1 open swap request: Tow Pilot"' in content
 
 
 @pytest.mark.django_db

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -2372,6 +2372,83 @@ class TestOpenSwapPeriodicReminders:
         assert summary["email_count"] == 1
         assert call_count["count"] >= 2
 
+    @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+    def test_periodic_reminder_counts_skipped_request_as_processed(self, site_config):
+        today = date(2026, 6, 18)
+        requester = Member.objects.create(
+            username="no_email_requester",
+            first_name="No",
+            last_name="Requester",
+            email="",
+            membership_status="Full Member",
+        )
+        target = Member.objects.create(
+            username="no_email_target",
+            first_name="No",
+            last_name="Target",
+            email="",
+            membership_status="Full Member",
+        )
+        DutySwapRequest.objects.create(
+            requester=requester,
+            original_date=today + timedelta(days=3),
+            role="TOW",
+            request_type="direct",
+            direct_request_to=target,
+            status="open",
+        )
+
+        mail.outbox.clear()
+        summary = send_periodic_open_swap_reminder_notifications(
+            today=today,
+            day_offsets=(3,),
+        )
+
+        assert summary["candidate_count"] == 1
+        assert summary["request_count"] == 1
+        assert summary["skipped_no_recipients"] == 1
+        assert summary["email_count"] == 0
+        assert len(mail.outbox) == 0
+
+    def test_periodic_reminder_reuses_precomputed_rostermeister_ids(
+        self, site_config, alice, charlie, monkeypatch
+    ):
+        today = date(2026, 6, 18)
+        charlie.rostermeister = True
+        charlie.save(update_fields=["rostermeister"])
+        for offset in (3, 7):
+            DutySwapRequest.objects.create(
+                requester=alice,
+                original_date=today + timedelta(days=offset),
+                role="TOW",
+                request_type="general",
+                status="open",
+            )
+
+        captured_rostermeister_ids = []
+
+        def _mock_recipients(_swap_request, rostermeister_ids=None):
+            captured_rostermeister_ids.append(rostermeister_ids)
+            return [alice]
+
+        monkeypatch.setattr(
+            "duty_roster.views_swap.get_periodic_reminder_recipients",
+            _mock_recipients,
+        )
+
+        summary = send_periodic_open_swap_reminder_notifications(
+            today=today,
+            day_offsets=(3, 7),
+            dry_run=True,
+        )
+
+        assert summary["candidate_count"] == 2
+        assert summary["request_count"] == 2
+        assert captured_rostermeister_ids == [
+            (charlie.pk,),
+            (charlie.pk,),
+        ]
+
     def test_command_passes_dry_run_and_today(self, monkeypatch):
         captured = {}
 

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -1018,14 +1018,10 @@ def duty_calendar_view(request, year=None, month=None):
     active_statuses = set(get_active_membership_statuses())
     open_swap_summary_by_date = {}
 
-    for open_swap in (
-        DutySwapRequest.objects.filter(
-            status="open",
-            original_date__in=visible_dates,
-        )
-        .select_related("requester")
-        .order_by("original_date", "pk")
-    ):
+    for open_swap in DutySwapRequest.objects.filter(
+        status="open",
+        original_date__in=visible_dates,
+    ).order_by("original_date", "pk"):
         day_summary = open_swap_summary_by_date.setdefault(
             open_swap.original_date,
             {"count": 0, "roles": []},

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -1017,6 +1017,17 @@ def duty_calendar_view(request, year=None, month=None):
 
     active_statuses = set(get_active_membership_statuses())
     open_swap_summary_by_date = {}
+    static_swap_role_titles = {
+        "DO": (site_config.duty_officer_title if site_config else "Duty Officer"),
+        "ADO": (
+            site_config.assistant_duty_officer_title
+            if site_config
+            else "Assistant Duty Officer"
+        ),
+        "TOW": (site_config.towpilot_title if site_config else "Tow Pilot"),
+        "INSTRUCTOR": (site_config.instructor_title if site_config else "Instructor"),
+    }
+    role_title_cache = {}
 
     for open_swap in DutySwapRequest.objects.filter(
         status="open",
@@ -1027,7 +1038,24 @@ def duty_calendar_view(request, year=None, month=None):
             {"count": 0, "roles": []},
         )
         day_summary["count"] += 1
-        role_title = open_swap.get_role_title()
+        cache_key = (
+            open_swap.role,
+            open_swap.dynamic_role_key,
+            open_swap.dynamic_role_label,
+        )
+        if cache_key not in role_title_cache:
+            if open_swap.role == "DYNAMIC":
+                role_title_cache[cache_key] = (
+                    open_swap.dynamic_role_label
+                    or open_swap.dynamic_role_key
+                    or "Dynamic Role"
+                )
+            else:
+                role_title_cache[cache_key] = static_swap_role_titles.get(
+                    open_swap.role,
+                    open_swap.role.replace("_", " ").title(),
+                )
+        role_title = role_title_cache[cache_key]
         if role_title not in day_summary["roles"]:
             day_summary["roles"].append(role_title)
 

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -1016,6 +1016,24 @@ def duty_calendar_view(request, year=None, month=None):
     }
 
     active_statuses = set(get_active_membership_statuses())
+    open_swap_summary_by_date = {}
+
+    for open_swap in (
+        DutySwapRequest.objects.filter(
+            status="open",
+            original_date__in=visible_dates,
+        )
+        .select_related("requester")
+        .order_by("original_date", "pk")
+    ):
+        day_summary = open_swap_summary_by_date.setdefault(
+            open_swap.original_date,
+            {"count": 0, "roles": []},
+        )
+        day_summary["count"] += 1
+        role_title = open_swap.get_role_title()
+        if role_title not in day_summary["roles"]:
+            day_summary["roles"].append(role_title)
 
     intent_dates = set()
     instruction_dates = set()
@@ -1120,6 +1138,7 @@ def duty_calendar_view(request, year=None, month=None):
         "weeks": weeks,
         "assignments_by_date": assignments_by_date,
         "dynamic_role_assignments_by_date": dynamic_role_assignments_by_date,
+        "open_swap_summary_by_date": open_swap_summary_by_date,
         "has_upcoming_assignments": has_upcoming_assignments,
         "prev_year": prev_year,
         "prev_month": prev_month,
@@ -1381,6 +1400,15 @@ def calendar_day_detail(request, year, month, day):
             if role["member"].id == request.user.id
         ]
 
+    open_swap_requests = list(
+        DutySwapRequest.objects.filter(
+            status="open",
+            original_date=day_date,
+        )
+        .select_related("requester", "direct_request_to")
+        .order_by("created_at", "pk")
+    )
+
     return render(
         request,
         "duty_roster/calendar_day_modal.html",
@@ -1446,6 +1474,7 @@ def calendar_day_detail(request, year, month, day):
             "open_panel": open_panel,
             "dynamic_role_assignments": dynamic_role_assignments,
             "user_dynamic_role_assignments": user_dynamic_role_assignments,
+            "open_swap_requests": open_swap_requests,
         },
     )
 

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -1034,16 +1034,17 @@ def duty_calendar_view(request, year=None, month=None):
         original_date__in=visible_dates,
     )
     if request.user.is_authenticated:
-        open_swap_queryset = open_swap_queryset.filter(
-            models.Q(request_type="general")
-            | (
-                models.Q(request_type="direct")
-                & (
-                    models.Q(requester=request.user)
-                    | models.Q(direct_request_to=request.user)
+        if not (request.user.is_staff or getattr(request.user, "rostermeister", False)):
+            open_swap_queryset = open_swap_queryset.filter(
+                models.Q(request_type="general")
+                | (
+                    models.Q(request_type="direct")
+                    & (
+                        models.Q(requester=request.user)
+                        | models.Q(direct_request_to=request.user)
+                    )
                 )
             )
-        )
     else:
         open_swap_queryset = open_swap_queryset.filter(request_type="general")
 
@@ -1444,16 +1445,17 @@ def calendar_day_detail(request, year, month, day):
         original_date=day_date,
     )
     if request.user.is_authenticated:
-        open_swap_requests_queryset = open_swap_requests_queryset.filter(
-            models.Q(request_type="general")
-            | (
-                models.Q(request_type="direct")
-                & (
-                    models.Q(requester=request.user)
-                    | models.Q(direct_request_to=request.user)
+        if not (request.user.is_staff or getattr(request.user, "rostermeister", False)):
+            open_swap_requests_queryset = open_swap_requests_queryset.filter(
+                models.Q(request_type="general")
+                | (
+                    models.Q(request_type="direct")
+                    & (
+                        models.Q(requester=request.user)
+                        | models.Q(direct_request_to=request.user)
+                    )
                 )
             )
-        )
     else:
         open_swap_requests_queryset = open_swap_requests_queryset.filter(
             request_type="general"

--- a/duty_roster/views.py
+++ b/duty_roster/views.py
@@ -1029,10 +1029,25 @@ def duty_calendar_view(request, year=None, month=None):
     }
     role_title_cache = {}
 
-    for open_swap in DutySwapRequest.objects.filter(
+    open_swap_queryset = DutySwapRequest.objects.filter(
         status="open",
         original_date__in=visible_dates,
-    ).order_by("original_date", "pk"):
+    )
+    if request.user.is_authenticated:
+        open_swap_queryset = open_swap_queryset.filter(
+            models.Q(request_type="general")
+            | (
+                models.Q(request_type="direct")
+                & (
+                    models.Q(requester=request.user)
+                    | models.Q(direct_request_to=request.user)
+                )
+            )
+        )
+    else:
+        open_swap_queryset = open_swap_queryset.filter(request_type="general")
+
+    for open_swap in open_swap_queryset.order_by("original_date", "pk"):
         day_summary = open_swap_summary_by_date.setdefault(
             open_swap.original_date,
             {"count": 0, "roles": []},
@@ -1424,13 +1439,30 @@ def calendar_day_detail(request, year, month, day):
             if role["member"].id == request.user.id
         ]
 
-    open_swap_requests = list(
-        DutySwapRequest.objects.filter(
-            status="open",
-            original_date=day_date,
+    open_swap_requests_queryset = DutySwapRequest.objects.filter(
+        status="open",
+        original_date=day_date,
+    )
+    if request.user.is_authenticated:
+        open_swap_requests_queryset = open_swap_requests_queryset.filter(
+            models.Q(request_type="general")
+            | (
+                models.Q(request_type="direct")
+                & (
+                    models.Q(requester=request.user)
+                    | models.Q(direct_request_to=request.user)
+                )
+            )
         )
-        .select_related("requester", "direct_request_to")
-        .order_by("created_at", "pk")
+    else:
+        open_swap_requests_queryset = open_swap_requests_queryset.filter(
+            request_type="general"
+        )
+
+    open_swap_requests = list(
+        open_swap_requests_queryset.select_related(
+            "requester", "direct_request_to"
+        ).order_by("created_at", "pk")
     )
 
     return render(

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1217,6 +1217,7 @@ def get_periodic_reminder_recipients(swap_request):
 
     rostermeister_qs = Member.objects.filter(
         rostermeister=True,
+        is_active=True,
         membership_status__in=active_statuses,
     )
 

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1199,7 +1199,7 @@ def get_open_swap_reminder_candidates(today=None, day_offsets=None):
     )
 
 
-def get_periodic_reminder_recipients(swap_request):
+def get_periodic_reminder_recipients(swap_request, rostermeister_ids=None):
     """
     Return de-duplicated reminder recipients for an open swap request.
 
@@ -1210,11 +1210,12 @@ def get_periodic_reminder_recipients(swap_request):
     """
     active_statuses = get_active_membership_statuses()
 
-    rostermeister_qs = Member.objects.filter(
-        rostermeister=True,
-        is_active=True,
-        membership_status__in=active_statuses,
-    )
+    if rostermeister_ids is None:
+        rostermeister_ids = Member.objects.filter(
+            rostermeister=True,
+            is_active=True,
+            membership_status__in=active_statuses,
+        ).values_list("pk", flat=True)
 
     if swap_request.request_type == "direct" and swap_request.direct_request_to_id:
         recipient_ids = {swap_request.direct_request_to_id}
@@ -1227,7 +1228,7 @@ def get_periodic_reminder_recipients(swap_request):
         recipient_ids = set(eligible_members.values_list("pk", flat=True))
     if swap_request.requester_id:
         recipient_ids.add(swap_request.requester_id)
-    recipient_ids.update(rostermeister_qs.values_list("pk", flat=True))
+    recipient_ids.update(rostermeister_ids)
 
     if not recipient_ids:
         return Member.objects.none()
@@ -1262,13 +1263,25 @@ def send_periodic_open_swap_reminder_notifications(
 
     base_context = get_email_context_base()
     base_url = base_context.get("base_url", "http://localhost:8001")
+    active_statuses = get_active_membership_statuses()
+    rostermeister_ids = tuple(
+        Member.objects.filter(
+            rostermeister=True,
+            is_active=True,
+            membership_status__in=active_statuses,
+        ).values_list("pk", flat=True)
+    )
 
     for swap_request in candidates:
         recipients = [
             recipient
-            for recipient in get_periodic_reminder_recipients(swap_request)
+            for recipient in get_periodic_reminder_recipients(
+                swap_request,
+                rostermeister_ids=rostermeister_ids,
+            )
             if recipient.email
         ]
+        summary["request_count"] += 1
 
         if not recipients:
             logger.warning(
@@ -1339,8 +1352,6 @@ def send_periodic_open_swap_reminder_notifications(
                     swap_request.pk,
                     recipient.email,
                 )
-
-        summary["request_count"] += 1
 
     return summary
 

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1305,7 +1305,7 @@ def send_periodic_open_swap_reminder_notifications(
                 "duty_roster/emails/swap_reminder_periodic.html",
                 recipient_context,
             )
-            send_mail(
+            delivered_count = send_mail(
                 subject=subject,
                 message="",
                 html_message=html_content,
@@ -1313,7 +1313,14 @@ def send_periodic_open_swap_reminder_notifications(
                 recipient_list=[recipient.email],
                 fail_silently=True,
             )
-            summary["email_count"] += 1
+            if delivered_count:
+                summary["email_count"] += 1
+            else:
+                logger.warning(
+                    "Periodic swap reminder not delivered for request %s to %s",
+                    swap_request.pk,
+                    recipient.email,
+                )
 
         summary["request_count"] += 1
 

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1215,14 +1215,14 @@ def get_periodic_reminder_recipients(swap_request):
         dynamic_role_key=swap_request.dynamic_role_key,
     )
 
-    requester_qs = Member.objects.filter(pk=swap_request.requester_id)
     rostermeister_qs = Member.objects.filter(
         rostermeister=True,
         membership_status__in=active_statuses,
     )
 
     recipient_ids = set(eligible_members.values_list("pk", flat=True))
-    recipient_ids.update(requester_qs.values_list("pk", flat=True))
+    if swap_request.requester_id:
+        recipient_ids.add(swap_request.requester_id)
     recipient_ids.update(rostermeister_qs.values_list("pk", flat=True))
 
     if not recipient_ids:

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1209,12 +1209,6 @@ def get_periodic_reminder_recipients(swap_request):
     """
     active_statuses = get_active_membership_statuses()
 
-    eligible_members = get_eligible_members_for_role(
-        swap_request.role,
-        exclude_member=None,
-        dynamic_role_key=swap_request.dynamic_role_key,
-    )
-
     rostermeister_qs = Member.objects.filter(
         rostermeister=True,
         is_active=True,
@@ -1224,6 +1218,11 @@ def get_periodic_reminder_recipients(swap_request):
     if swap_request.request_type == "direct" and swap_request.direct_request_to_id:
         recipient_ids = {swap_request.direct_request_to_id}
     else:
+        eligible_members = get_eligible_members_for_role(
+            swap_request.role,
+            exclude_member=None,
+            dynamic_role_key=swap_request.dynamic_role_key,
+        )
         recipient_ids = set(eligible_members.values_list("pk", flat=True))
     if swap_request.requester_id:
         recipient_ids.add(swap_request.requester_id)

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -16,6 +16,7 @@ from django.db import models, transaction
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 
@@ -1284,7 +1285,11 @@ def send_periodic_open_swap_reminder_notifications(
             f"{role_title} coverage needed on {swap_request.original_date.strftime('%b %d')}"
         )
 
-        request_url = f"{base_url}/duty_roster/swap/request/{swap_request.pk}/"
+        request_path = reverse(
+            "duty_roster:swap_request_detail",
+            kwargs={"request_id": swap_request.pk},
+        )
+        request_url = f"{base_url}{request_path}"
 
         for recipient in recipients:
             recipient_context = {

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -7,7 +7,7 @@ for their scheduled duties and for other members to offer help.
 
 import calendar as _cal_lib
 import logging
-from datetime import date
+from datetime import date, timedelta
 
 from django.conf import settings
 from django.contrib import messages
@@ -43,6 +43,8 @@ from .utils.role_resolution import RoleResolutionService
 from .utils.roles import member_is_commercial_pilot
 
 logger = logging.getLogger("duty_roster.views_swap")
+
+SWAP_REMINDER_DAY_OFFSETS = (14, 7, 3, 1)
 
 
 def get_scheduling_config():
@@ -1177,6 +1179,145 @@ def get_email_context_base():
 def get_from_email():
     """Get the from email address for notifications."""
     return getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@example.com")
+
+
+def get_open_swap_reminder_candidates(today=None, day_offsets=None):
+    """Return open swap requests that should receive periodic reminders today."""
+    today = today or timezone.now().date()
+    offsets = tuple(day_offsets or SWAP_REMINDER_DAY_OFFSETS)
+    target_dates = [today + timedelta(days=offset) for offset in offsets]
+
+    return (
+        DutySwapRequest.objects.filter(
+            status="open",
+            original_date__gte=today,
+            original_date__in=target_dates,
+        )
+        .select_related("requester", "direct_request_to")
+        .order_by("original_date", "pk")
+    )
+
+
+def get_periodic_reminder_recipients(swap_request):
+    """
+    Return de-duplicated reminder recipients for an open swap request.
+
+    Recipient contract (Issue #946):
+      - all eligible members for the role,
+      - the requester,
+      - active rostermeisters.
+    """
+    active_statuses = get_active_membership_statuses()
+
+    eligible_members = get_eligible_members_for_role(
+        swap_request.role,
+        exclude_member=None,
+        dynamic_role_key=swap_request.dynamic_role_key,
+    )
+
+    requester_qs = Member.objects.filter(pk=swap_request.requester_id)
+    rostermeister_qs = Member.objects.filter(
+        rostermeister=True,
+        membership_status__in=active_statuses,
+    )
+
+    recipient_ids = set(eligible_members.values_list("pk", flat=True))
+    recipient_ids.update(requester_qs.values_list("pk", flat=True))
+    recipient_ids.update(rostermeister_qs.values_list("pk", flat=True))
+
+    if not recipient_ids:
+        return Member.objects.none()
+
+    return Member.objects.filter(pk__in=recipient_ids).order_by(
+        "last_name", "first_name"
+    )
+
+
+def send_periodic_open_swap_reminder_notifications(
+    today=None,
+    day_offsets=None,
+    dry_run=False,
+):
+    """Send periodic reminder emails for open swap requests at configured offsets."""
+    today = today or timezone.now().date()
+    candidates = list(
+        get_open_swap_reminder_candidates(today=today, day_offsets=day_offsets)
+    )
+
+    summary = {
+        "candidate_count": len(candidates),
+        "email_count": 0,
+        "request_count": 0,
+        "skipped_no_recipients": 0,
+    }
+
+    if not candidates:
+        return summary
+
+    base_context = get_email_context_base()
+    base_url = base_context.get("base_url", "http://localhost:8001")
+
+    for swap_request in candidates:
+        recipients = [
+            recipient
+            for recipient in get_periodic_reminder_recipients(swap_request)
+            if recipient.email
+        ]
+
+        if not recipients:
+            logger.warning(
+                "No reminder recipients with email for open swap request %s",
+                swap_request.pk,
+            )
+            summary["skipped_no_recipients"] += 1
+            continue
+
+        days_until = (swap_request.original_date - today).days
+        role_title = swap_request.get_role_title()
+        subject = (
+            f"⏰ Reminder ({days_until} day{'s' if days_until != 1 else ''} left): "
+            f"{role_title} coverage needed on {swap_request.original_date.strftime('%b %d')}"
+        )
+
+        request_url = f"{base_url}/duty_roster/swap/request/{swap_request.pk}/"
+
+        for recipient in recipients:
+            recipient_context = {
+                **base_context,
+                "swap_request": swap_request,
+                "recipient": recipient,
+                "role_title": role_title,
+                "days_until": days_until,
+                "request_url": request_url,
+                "is_direct_request": swap_request.request_type == "direct",
+            }
+
+            if dry_run:
+                logger.info(
+                    "[DRY RUN] Would send periodic swap reminder for request %s to %s",
+                    swap_request.pk,
+                    recipient.email,
+                )
+                summary["email_count"] += 1
+                continue
+
+            html_content = render_to_string(
+                "duty_roster/emails/swap_reminder_periodic.html",
+                recipient_context,
+            )
+            send_mail(
+                subject=subject,
+                message="",
+                html_message=html_content,
+                from_email=get_from_email(),
+                recipient_list=[recipient.email],
+                fail_silently=True,
+            )
+            summary["email_count"] += 1
+
+        summary["request_count"] += 1
+
+    return summary
 
 
 def send_swap_request_notifications(swap_request):

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1311,14 +1311,22 @@ def send_periodic_open_swap_reminder_notifications(
                 "duty_roster/emails/swap_reminder_periodic.html",
                 recipient_context,
             )
-            delivered_count = send_mail(
-                subject=subject,
-                message="",
-                html_message=html_content,
-                from_email=get_from_email(),
-                recipient_list=[recipient.email],
-                fail_silently=False,
-            )
+            try:
+                delivered_count = send_mail(
+                    subject=subject,
+                    message="",
+                    html_message=html_content,
+                    from_email=get_from_email(),
+                    recipient_list=[recipient.email],
+                    fail_silently=False,
+                )
+            except Exception:
+                logger.exception(
+                    "Periodic swap reminder failed for request %s to %s",
+                    swap_request.pk,
+                    recipient.email,
+                )
+                continue
             if delivered_count:
                 summary["email_count"] += 1
             else:

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1184,7 +1184,7 @@ def get_from_email():
 def get_open_swap_reminder_candidates(today=None, day_offsets=None):
     """Return open swap requests that should receive periodic reminders today."""
     today = today or timezone.now().date()
-    offsets = tuple(day_offsets or SWAP_REMINDER_DAY_OFFSETS)
+    offsets = SWAP_REMINDER_DAY_OFFSETS if day_offsets is None else tuple(day_offsets)
     target_dates = [today + timedelta(days=offset) for offset in offsets]
 
     return (

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1232,9 +1232,11 @@ def get_periodic_reminder_recipients(swap_request):
     if not recipient_ids:
         return Member.objects.none()
 
-    return Member.objects.filter(pk__in=recipient_ids).order_by(
-        "last_name", "first_name"
-    )
+    return Member.objects.filter(
+        pk__in=recipient_ids,
+        is_active=True,
+        membership_status__in=active_statuses,
+    ).order_by("last_name", "first_name")
 
 
 def send_periodic_open_swap_reminder_notifications(

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1317,7 +1317,7 @@ def send_periodic_open_swap_reminder_notifications(
                 html_message=html_content,
                 from_email=get_from_email(),
                 recipient_list=[recipient.email],
-                fail_silently=True,
+                fail_silently=False,
             )
             if delivered_count:
                 summary["email_count"] += 1

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1221,7 +1221,10 @@ def get_periodic_reminder_recipients(swap_request):
         membership_status__in=active_statuses,
     )
 
-    recipient_ids = set(eligible_members.values_list("pk", flat=True))
+    if swap_request.request_type == "direct" and swap_request.direct_request_to_id:
+        recipient_ids = {swap_request.direct_request_to_id}
+    else:
+        recipient_ids = set(eligible_members.values_list("pk", flat=True))
     if swap_request.requester_id:
         recipient_ids.add(swap_request.requester_id)
     recipient_ids.update(rostermeister_qs.values_list("pk", flat=True))

--- a/duty_roster/views_swap.py
+++ b/duty_roster/views_swap.py
@@ -1303,6 +1303,10 @@ def send_periodic_open_swap_reminder_notifications(
             kwargs={"request_id": swap_request.pk},
         )
         request_url = f"{base_url}{request_path}"
+        text_message = (
+            f"Reminder: {role_title} coverage needed on {swap_request.original_date.isoformat()}.\n"
+            f"View details: {request_url}"
+        )
 
         for recipient in recipients:
             recipient_context = {
@@ -1331,7 +1335,7 @@ def send_periodic_open_swap_reminder_notifications(
             try:
                 delivered_count = send_mail(
                     subject=subject,
-                    message="",
+                    message=text_message,
                     html_message=html_content,
                     from_email=get_from_email(),
                     recipient_list=[recipient.email],

--- a/e2e_tests/e2e/test_swap_visibility_calendar_modal.py
+++ b/e2e_tests/e2e/test_swap_visibility_calendar_modal.py
@@ -61,7 +61,9 @@ class TestSwapVisibilityCalendarModal(DjangoPlaywrightTestCase):
         )
         self.page.goto(f"{self.live_server_url}{calendar_url}")
 
-        marker = self.page.locator("span.badge:has-text('1 open')").first
+        marker = self.page.locator(
+            "span.badge[aria-label^='1 open swap request']"
+        ).first
         marker.wait_for(state="visible")
 
         marker_cell = marker.locator("xpath=ancestor::td[1]")

--- a/e2e_tests/e2e/test_swap_visibility_calendar_modal.py
+++ b/e2e_tests/e2e/test_swap_visibility_calendar_modal.py
@@ -1,0 +1,81 @@
+"""E2E coverage for open-swap visibility on calendar cells and day modal (Issue #946)."""
+
+from datetime import date, timedelta
+
+from django.urls import reverse
+
+from duty_roster.models import DutyAssignment, DutySwapRequest
+from e2e_tests.e2e.conftest import DjangoPlaywrightTestCase
+from siteconfig.models import SiteConfiguration
+
+
+class TestSwapVisibilityCalendarModal(DjangoPlaywrightTestCase):
+    def setUp(self):
+        super().setUp()
+        SiteConfiguration.objects.get_or_create(
+            defaults={
+                "club_name": "Test Soaring Club",
+                "club_abbreviation": "TSC",
+                "domain_name": "test.org",
+                "schedule_tow_pilots": True,
+                "schedule_duty_officers": True,
+                "schedule_instructors": True,
+                "schedule_assistant_duty_officers": True,
+            }
+        )
+
+    def test_open_swap_marker_and_day_modal_details_are_visible(self):
+        requester = self.create_test_member(
+            username="swap_marker_requester",
+            email="swap_marker_requester@example.com",
+            membership_status="Full Member",
+            towpilot=True,
+        )
+        viewer = self.create_test_member(
+            username="swap_marker_viewer",
+            email="swap_marker_viewer@example.com",
+            membership_status="Full Member",
+            towpilot=True,
+        )
+
+        duty_date = date.today() + timedelta(days=10)
+        DutyAssignment.objects.create(
+            date=duty_date,
+            tow_pilot=requester,
+            is_scheduled=True,
+        )
+
+        swap_request = DutySwapRequest.objects.create(
+            requester=requester,
+            original_date=duty_date,
+            role="TOW",
+            request_type="general",
+            status="open",
+            notes="Need coverage for family event",
+        )
+
+        self.login(username=viewer.username)
+        calendar_url = reverse(
+            "duty_roster:duty_calendar_month",
+            kwargs={"year": duty_date.year, "month": duty_date.month},
+        )
+        self.page.goto(f"{self.live_server_url}{calendar_url}")
+
+        marker = self.page.locator("span.badge:has-text('1 open')").first
+        marker.wait_for(state="visible")
+
+        marker_cell = marker.locator("xpath=ancestor::td[1]")
+        marker_cell.click()
+
+        self.page.locator("#calendarModal").wait_for(state="visible")
+        modal_body = self.page.locator("#modal-body")
+        modal_body.locator("text=Open Swap Requests").wait_for(state="visible")
+
+        assert modal_body.locator("text=Tow Pilot").count() >= 1
+        assert (
+            modal_body.locator("text=Requested by Test User").count() >= 1
+            or modal_body.locator("text=Requested by").count() >= 1
+        )
+
+        detail_path = reverse("duty_roster:swap_request_detail", args=[swap_request.pk])
+        assert modal_body.locator(f'a[href="{detail_path}"]').count() >= 1

--- a/k8s-cronjobs.yaml
+++ b/k8s-cronjobs.yaml
@@ -385,7 +385,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 300 # 5 minute timeout
+      activeDeadlineSeconds: 900 # 15 minute timeout
       template:
         spec:
           restartPolicy: Never

--- a/k8s-cronjobs.yaml
+++ b/k8s-cronjobs.yaml
@@ -370,6 +370,58 @@ spec:
                 secretName: gcp-sa-key
 
 ---
+# Daily: Reminder emails for open duty swap requests (3:20 AM UTC)
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: remind-open-swap-requests
+  namespace: default
+spec:
+  schedule: "20 3 * * *" # Daily at 3:20 AM UTC
+  timeZone: "UTC"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 300 # 5 minute timeout
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: remind-open-swap-requests
+              image: gcr.io/skyline-soaring-storage/skylinesoaring:latest
+              command:
+                - python
+                - manage.py
+                - remind_open_swap_requests
+                - --verbosity=1
+              workingDir: /app
+              env:
+                - name: GOOGLE_APPLICATION_CREDENTIALS
+                  value: /app/gcp-credentials.json
+              envFrom:
+                - secretRef:
+                    name: manage2soar-env
+              volumeMounts:
+                - name: gcp-sa-key
+                  mountPath: /app/gcp-credentials.json
+                  subPath: gcp-credentials.json
+                  readOnly: true
+              resources:
+                requests:
+                  memory: "64Mi"
+                  cpu: "50m"
+                limits:
+                  memory: "128Mi"
+                  cpu: "100m"
+          volumes:
+            - name: gcp-sa-key
+              secret:
+                secretName: gcp-sa-key
+
+---
 # Weekly: Late SPR Notifications (Monday 10:00 AM UTC)
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
## Summary
Implements the first complete pass of Issue #946 by adding:

1. **Periodic open-swap reminder pipeline** (14/7/3/1 day cadence)
2. **Daily cron command + K8s CronJob** for reminder delivery
3. **Calendar visibility** for open swaps in month cells
4. **Day-detail modal section** listing open swaps with direct links
5. **Unit + E2E test coverage** for reminders and visibility

## What changed

### Reminder pipeline
- Added offset-based reminder cadence (`14, 7, 3, 1` days before duty date)
- Added candidate selector and recipient expansion logic:
  - eligible role members
  - requester
  - active rostermeisters
  - de-duplicated + email-filtered
- Added periodic reminder sender with dry-run support

### Command + scheduler
- Added management command: `remind_open_swap_requests`
- Added K8s CronJob: `remind-open-swap-requests` (daily, 03:20 UTC)

### UI visibility
- Month calendar cells now show compact open-swap markers (`X open`)
- Day modal now includes an **Open Swap Requests** section with:
  - role
  - requester
  - direct-target info (when applicable)
  - link to request detail

### Email template
- Added `swap_reminder_periodic.html`

## Files touched
- `duty_roster/views_swap.py`
- `duty_roster/management/commands/remind_open_swap_requests.py` (new)
- `duty_roster/templates/duty_roster/emails/swap_reminder_periodic.html` (new)
- `k8s-cronjobs.yaml`
- `duty_roster/views.py`
- `duty_roster/templates/duty_roster/_calendar_table.html`
- `duty_roster/templates/duty_roster/calendar_day_modal.html`
- `duty_roster/tests/test_duty_swap.py`
- `e2e_tests/e2e/test_swap_visibility_calendar_modal.py` (new)

## Validation
Ran focused tests locally:
- `pytest duty_roster/tests/test_duty_swap.py -k "OpenSwapPeriodicReminders or SwapVisibilityInCalendar or SwapRequestExpiryCronjob"`
- `pytest e2e_tests/e2e/test_swap_visibility_calendar_modal.py -q`

Both passed.
