### PR TITLE
Issue #945: display tow pilot under towplane on logsheet grid

### DIFF
--- a/logsheet/templates/logsheet/logsheet_manage.html
+++ b/logsheet/templates/logsheet/logsheet_manage.html
@@ -519,6 +519,12 @@
                           {{ flight.towplane }}
                         </small>
                       {% endif %}
+                      {% if flight.tow_pilot %}
+                        <small class="text-muted d-block">
+                          <i class="bi bi-person-badge me-1"></i>
+                          {{ flight.tow_pilot|full_display_name }}
+                        </small>
+                      {% endif %}
                       {% if flight.release_altitude %}
                         <small class="text-muted d-block">
                           <i class="bi bi-arrow-up me-1"></i>
@@ -531,10 +537,20 @@
 
                 <td class="towplane-col d-none d-lg-table-cell" data-sort="{% if flight.towplane %}{{ flight.towplane }}{% else %}{% endif %}">
                   {% if flight.towplane %}
-                    <span class="towplane-name">
-                      <i class="bi bi-airplane-engines text-warning me-1"></i>
-                      {{ flight.towplane }}
-                    </span>
+                    <div class="towplane-info">
+                      <span class="towplane-name">
+                        <i class="bi bi-airplane-engines text-warning me-1"></i>
+                        {{ flight.towplane }}
+                      </span>
+                      {% if flight.tow_pilot %}
+                        <div>
+                          <small class="text-muted">
+                            <i class="bi bi-person-badge me-1"></i>
+                            {{ flight.tow_pilot|full_display_name }}
+                          </small>
+                        </div>
+                      {% endif %}
+                    </div>
                   {% elif flight.is_incomplete %}
                     <span class="missing-data-badge" title="Missing: {{ flight.get_missing_fields|join:', ' }}">
                       <i class="bi bi-exclamation-triangle text-warning"></i>

--- a/logsheet/tests/test_non_tow_launch_validation.py
+++ b/logsheet/tests/test_non_tow_launch_validation.py
@@ -321,6 +321,45 @@ class TestTowplaneIsVirtual:
 
 
 @pytest.mark.django_db
+class TestManageLogsheetTowPilotDisplay:
+    def test_manage_view_displays_tow_pilot_for_flight(
+        self,
+        client,
+        logsheet,
+        pilot,
+        glider,
+        towplane,
+        duty_officer,
+    ):
+        tow_pilot_member = Member.objects.create(
+            username="grid_towpilot",
+            first_name="Grid",
+            last_name="Towpilot",
+            membership_status="Full Member",
+            towpilot=True,
+        )
+
+        Flight.objects.create(
+            logsheet=logsheet,
+            pilot=pilot,
+            glider=glider,
+            launch_method=Flight.LaunchMethod.TOWPLANE,
+            launch_time=time(10, 0),
+            landing_time=time(11, 0),
+            release_altitude=3000,
+            towplane=towplane,
+            tow_pilot=tow_pilot_member,
+        )
+
+        client.force_login(duty_officer)
+        response = client.get(reverse("logsheet:manage", args=[logsheet.pk]))
+
+        assert response.status_code == 200
+        assert towplane.n_number in response.content.decode()
+        assert "Grid Towpilot" in response.content.decode()
+
+
+@pytest.mark.django_db
 class TestFinalizationWithNonTowFlights:
     """Test logsheet finalization with non-tow launch methods."""
 

--- a/logsheet/tests/test_non_tow_launch_validation.py
+++ b/logsheet/tests/test_non_tow_launch_validation.py
@@ -353,10 +353,11 @@ class TestManageLogsheetTowPilotDisplay:
 
         client.force_login(duty_officer)
         response = client.get(reverse("logsheet:manage", args=[logsheet.pk]))
+        response_body = response.content.decode()
 
         assert response.status_code == 200
-        assert towplane.n_number in response.content.decode()
-        assert "Grid Towpilot" in response.content.decode()
+        assert towplane.n_number in response_body
+        assert "Grid Towpilot" in response_body
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- show each flight's tow pilot under towplane in the logsheet manage grid (desktop)
- include tow pilot in the mobile flight-row supplemental info
- add regression test to ensure manage view renders tow pilot for tow flights

## Testing
- `/home/pb/Projects/skylinesoaring/.venv/bin/python -m pytest logsheet/tests/test_non_tow_launch_validation.py::TestManageLogsheetTowPilotDisplay::test_manage_view_displays_tow_pilot_for_flight -q`
- `/home/pb/Projects/skylinesoaring/.venv/bin/python -m pytest logsheet/tests/test_non_tow_launch_validation.py -q`
