### PR TITLE
Juggle top-menu items around

### DIFF
--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -75,7 +75,10 @@ def _dedupe_resource_items(items):
     deduped = []
     for item in items:
         url = item.get("url")
-        if not url or url in seen_urls:
+        if url is None:
+            deduped.append(item)
+            continue
+        if url in seen_urls:
             continue
         seen_urls.add(url)
         deduped.append(item)
@@ -122,18 +125,15 @@ def _build_resources_nav_items(request, footer=None):
                     "title": page.effective_navbar_title(),
                     "url": page.get_absolute_url(),
                     "rank": page.navbar_rank,
+                    "is_promoted": True,
                 }
             )
 
+    # Separator between promoted pages and utility links.
+    items.append({"title": "---", "url": None, "rank": 800})
+
     if request.user.is_authenticated and is_active_member(request.user):
         # Relocated utility links (issue #746 IA update).
-        items.append(
-            {
-                "title": "Gliders and Towplanes",
-                "url": reverse("logsheet:equipment_list"),
-                "rank": 900,
-            }
-        )
         items.append(
             {
                 "title": "Report Website Issue",

--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -130,7 +130,13 @@ def _build_resources_nav_items(request, footer=None):
             )
 
     # Separator between promoted pages and utility links.
-    items.append({"title": "---", "url": None, "rank": 800})
+    # Only add if the user is authenticated and has at least one utility link to display.
+    if request.user.is_authenticated and (
+        is_active_member(request.user)
+        or getattr(request.user, "safety_officer", False)
+        or request.user.is_superuser
+    ):
+        items.append({"title": "---", "url": None, "rank": 800})
 
     if request.user.is_authenticated and is_active_member(request.user):
         # Relocated utility links (issue #746 IA update).

--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -76,7 +76,8 @@ def _dedupe_resource_items(items):
     for item in items:
         url = item.get("url")
         if url is None:
-            deduped.append(item)
+            if item.get("is_divider"):
+                deduped.append(item)
             continue
         if url in seen_urls:
             continue
@@ -118,8 +119,10 @@ def _build_resources_nav_items(request, footer=None):
         promoted_pages = promoted_pages.filter(is_public=True)
 
     promoted_pages = promoted_pages.order_by("navbar_rank", "id")
+    has_promoted_pages = False
     for page in promoted_pages:
         if page.can_user_access(request.user, access_request):
+            has_promoted_pages = True
             items.append(
                 {
                     "title": page.effective_navbar_title(),
@@ -129,16 +132,19 @@ def _build_resources_nav_items(request, footer=None):
                 }
             )
 
-    # Separator between promoted pages and utility links.
-    # Only add if the user is authenticated and has at least one utility link to display.
-    if request.user.is_authenticated and (
-        is_active_member(request.user)
-        or getattr(request.user, "safety_officer", False)
-        or request.user.is_superuser
-    ):
-        items.append({"title": "---", "url": None, "rank": 800})
+    has_member_utility_links = request.user.is_authenticated and is_active_member(
+        request.user
+    )
+    has_safety_utility_links = request.user.is_authenticated and (
+        getattr(request.user, "safety_officer", False) or request.user.is_superuser
+    )
 
-    if request.user.is_authenticated and is_active_member(request.user):
+    # Separator between promoted pages and utility links.
+    # Only add if there is at least one promoted page and at least one utility link.
+    if has_promoted_pages and (has_member_utility_links or has_safety_utility_links):
+        items.append({"title": "", "url": None, "rank": 800, "is_divider": True})
+
+    if has_member_utility_links:
         # Relocated utility links (issue #746 IA update).
         items.append(
             {
@@ -168,9 +174,7 @@ def _build_resources_nav_items(request, footer=None):
                 }
             )
 
-    if request.user.is_authenticated and (
-        getattr(request.user, "safety_officer", False) or request.user.is_superuser
-    ):
+    if has_safety_utility_links:
         items.append(
             {
                 "title": "Safety Dashboard",

--- a/cms/tests/test_context_processors.py
+++ b/cms/tests/test_context_processors.py
@@ -7,11 +7,12 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
+from django.template import Context, Template
 from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from cms.context_processors import footer_content
+from cms.context_processors import _dedupe_resource_items, footer_content
 from cms.models import HomePageContent, Page
 from siteconfig.models import SiteConfiguration
 
@@ -83,6 +84,13 @@ def test_resources_nav_includes_promoted_public_page_for_anonymous():
 
     titles = [item["title"] for item in context["resources_nav_items"]]
     assert "Weather Links" in titles
+
+    weather_item = next(
+        item
+        for item in context["resources_nav_items"]
+        if item["title"] == "Weather Links"
+    )
+    assert weather_item.get("is_promoted") is True
 
 
 @pytest.mark.django_db
@@ -169,6 +177,67 @@ def test_resources_nav_includes_member_footer_links_for_active_member():
 
 
 @pytest.mark.django_db
+def test_resources_nav_adds_divider_only_when_promoted_and_utility_links_exist():
+    member = User.objects.create_user(
+        username="member_divider_present",
+        password="testpass123",
+        membership_status="Full Member",
+    )
+    Page.objects.create(
+        title="Promoted Public",
+        slug="promoted-public",
+        is_public=True,
+        promote_to_navbar=True,
+        navbar_rank=10,
+    )
+
+    request = RequestFactory().get("/")
+    request.user = member
+    context = footer_content(request)
+
+    divider_items = [
+        item for item in context["resources_nav_items"] if item.get("is_divider")
+    ]
+    assert len(divider_items) == 1
+
+    promoted_index = next(
+        idx
+        for idx, item in enumerate(context["resources_nav_items"])
+        if item.get("is_promoted")
+    )
+    divider_index = next(
+        idx
+        for idx, item in enumerate(context["resources_nav_items"])
+        if item.get("is_divider")
+    )
+    utility_index = next(
+        idx
+        for idx, item in enumerate(context["resources_nav_items"])
+        if item["title"] == "Report Website Issue"
+    )
+
+    assert promoted_index < divider_index < utility_index
+
+
+@pytest.mark.django_db
+def test_resources_nav_omits_divider_when_no_promoted_pages():
+    member = User.objects.create_user(
+        username="member_divider_absent_no_promoted",
+        password="testpass123",
+        membership_status="Full Member",
+    )
+
+    request = RequestFactory().get("/")
+    request.user = member
+    context = footer_content(request)
+
+    divider_items = [
+        item for item in context["resources_nav_items"] if item.get("is_divider")
+    ]
+    assert divider_items == []
+
+
+@pytest.mark.django_db
 def test_resources_nav_dedupes_report_issue_link_from_footer():
     member = User.objects.create_user(
         username="member_footer_dedupe",
@@ -192,6 +261,53 @@ def test_resources_nav_dedupes_report_issue_link_from_footer():
         if item["url"] == "/cms/feedback/"
     ]
     assert len(report_issue_items) == 1
+
+
+def test_dedupe_resource_items_keeps_only_divider_for_url_less_items():
+    items = [
+        {"title": "Document Root", "url": "/cms/", "rank": 0},
+        {"title": "Divider", "url": None, "rank": 800, "is_divider": True},
+        {"title": "Malformed", "url": None, "rank": 810},
+        {"title": "Report Website Issue", "url": "/cms/feedback/", "rank": 910},
+        {
+            "title": "Report Website Issue Duplicate",
+            "url": "/cms/feedback/",
+            "rank": 911,
+        },
+    ]
+
+    deduped = _dedupe_resource_items(items)
+
+    assert {"title": "Malformed", "url": None, "rank": 810} not in deduped
+    assert any(item.get("is_divider") for item in deduped)
+    assert len([item for item in deduped if item.get("url") == "/cms/feedback/"]) == 1
+
+
+def test_resources_template_treats_title_dashes_as_link_without_is_divider():
+    template = Template(
+        """
+                {% for item in resources_nav_items %}
+                    {% if item.is_divider %}
+                        <hr class=\"dropdown-divider\">
+                    {% else %}
+                        <a class=\"dropdown-item\" href=\"{{ item.url }}\">{{ item.title }}</a>
+                    {% endif %}
+                {% endfor %}
+                """
+    )
+
+    rendered = template.render(
+        Context(
+            {
+                "resources_nav_items": [
+                    {"title": "---", "url": "/cms/dashes-page/", "rank": 10},
+                ]
+            }
+        )
+    )
+
+    assert 'href="/cms/dashes-page/"' in rendered
+    assert "dropdown-divider" not in rendered
 
 
 @pytest.mark.django_db

--- a/e2e_tests/test_homepage_and_resources.py
+++ b/e2e_tests/test_homepage_and_resources.py
@@ -57,10 +57,8 @@ def test_equipment_link_visible_for_active_member(client, django_user_model):
     client.force_login(user)
 
     resp = client.get(reverse("home"))
-    assert resp.status_code == 200
-
     content = resp.content.decode("utf-8")
-    assert "Gliders and Towplanes" in content
+    assert f'href="{reverse("logsheet:equipment_list")}"' in content
 
 
 @pytest.mark.django_db
@@ -76,7 +74,7 @@ def test_equipment_link_hidden_for_non_active_non_superuser(client, django_user_
     assert resp.status_code == 200
 
     content = resp.content.decode("utf-8")
-    assert "Gliders and Towplanes" not in content
+    assert f'href="{reverse("logsheet:equipment_list")}"' not in content
 
 
 @pytest.mark.django_db
@@ -96,4 +94,4 @@ def test_equipment_link_visible_for_superuser_even_if_not_active_member(
     assert resp.status_code == 200
 
     content = resp.content.decode("utf-8")
-    assert "Gliders and Towplanes" in content
+    assert f'href="{reverse("logsheet:equipment_list")}"' in content

--- a/e2e_tests/test_homepage_and_resources.py
+++ b/e2e_tests/test_homepage_and_resources.py
@@ -45,3 +45,55 @@ def test_resources_link_for_logged_in_user(client, django_user_model):
     assert 'href="/cms/"' in content or "href=\"{% url 'cms:resources' %}\"" in content
     # ensure Resources label exists somewhere
     assert "Resources" in content
+
+
+@pytest.mark.django_db
+def test_equipment_link_visible_for_active_member(client, django_user_model):
+    user = django_user_model.objects.create_user(
+        username="active_member_equipment",
+        password="pass",
+        membership_status="Full Member",
+    )
+    client.force_login(user)
+
+    resp = client.get(reverse("home"))
+    assert resp.status_code == 200
+
+    content = resp.content.decode("utf-8")
+    assert "Gliders and Towplanes" in content
+
+
+@pytest.mark.django_db
+def test_equipment_link_hidden_for_non_active_non_superuser(client, django_user_model):
+    user = django_user_model.objects.create_user(
+        username="inactive_member_equipment",
+        password="pass",
+        membership_status="Prospective Member",
+    )
+    client.force_login(user)
+
+    resp = client.get(reverse("home"))
+    assert resp.status_code == 200
+
+    content = resp.content.decode("utf-8")
+    assert "Gliders and Towplanes" not in content
+
+
+@pytest.mark.django_db
+def test_equipment_link_visible_for_superuser_even_if_not_active_member(
+    client, django_user_model
+):
+    user = django_user_model.objects.create_user(
+        username="superuser_equipment",
+        password="pass",
+        membership_status="Prospective Member",
+        is_superuser=True,
+        is_staff=True,
+    )
+    client.force_login(user)
+
+    resp = client.get(reverse("home"))
+    assert resp.status_code == 200
+
+    content = resp.content.decode("utf-8")
+    assert "Gliders and Towplanes" in content

--- a/templates/base.html
+++ b/templates/base.html
@@ -258,6 +258,9 @@
             </a>
             <ul class="dropdown-menu" aria-labelledby="equipmentDropdown">
               <li class="nav-item">
+                <a class="dropdown-item" href="{% url 'logsheet:equipment_list' %}">✈️ Gliders and Towplanes</a>
+              </li>
+              <li class="nav-item">
                 <a class="dropdown-item" href="{% url 'logsheet:maintenance_issues' %}">🔧 Maintenance Issues</a>
               </li>
               <li class="nav-item">
@@ -277,9 +280,13 @@
             </a>
             <ul class="dropdown-menu" aria-labelledby="resourcesDropdown">
               {% for item in resources_nav_items %}
-              <li>
-                <a class="dropdown-item" href="{{ item.url }}">{{ item.title }}</a>
-              </li>
+              {% if item.title == "---" %}
+                <hr class="dropdown-divider">
+              {% else %}
+                <li class="nav-item {% if item.is_promoted %}ps-3{% endif %}">
+                  <a class="dropdown-item" href="{{ item.url }}">{{ item.title }}</a>
+                </li>
+              {% endif %}
               {% empty %}
               <li><span class="dropdown-item-text text-muted">No resources available</span></li>
               {% endfor %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -285,8 +285,8 @@
               {% if item.is_divider %}
                 <li><hr class="dropdown-divider"></li>
               {% else %}
-                <li class="nav-item {% if item.is_promoted %}ps-3{% endif %}">
-                  <a class="dropdown-item" href="{{ item.url }}">{{ item.title }}</a>
+                <li class="nav-item">
+                  <a class="dropdown-item {% if item.is_promoted %}ps-3{% endif %}" href="{{ item.url }}">{{ item.title }}</a>
                 </li>
               {% endif %}
               {% empty %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -257,9 +257,11 @@
               Equipment
             </a>
             <ul class="dropdown-menu" aria-labelledby="equipmentDropdown">
+              {% if user.is_active_member %}
               <li class="nav-item">
                 <a class="dropdown-item" href="{% url 'logsheet:equipment_list' %}">✈️ Gliders and Towplanes</a>
               </li>
+              {% endif %}
               <li class="nav-item">
                 <a class="dropdown-item" href="{% url 'logsheet:maintenance_issues' %}">🔧 Maintenance Issues</a>
               </li>
@@ -281,7 +283,7 @@
             <ul class="dropdown-menu" aria-labelledby="resourcesDropdown">
               {% for item in resources_nav_items %}
               {% if item.title == "---" %}
-                <hr class="dropdown-divider">
+                <li><hr class="dropdown-divider"></li>
               {% else %}
                 <li class="nav-item {% if item.is_promoted %}ps-3{% endif %}">
                   <a class="dropdown-item" href="{{ item.url }}">{{ item.title }}</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -257,7 +257,7 @@
               Equipment
             </a>
             <ul class="dropdown-menu" aria-labelledby="equipmentDropdown">
-              {% if user.is_active_member %}
+              {% if user.is_active_member or user.is_superuser %}
               <li class="nav-item">
                 <a class="dropdown-item" href="{% url 'logsheet:equipment_list' %}">✈️ Gliders and Towplanes</a>
               </li>
@@ -282,7 +282,7 @@
             </a>
             <ul class="dropdown-menu" aria-labelledby="resourcesDropdown">
               {% for item in resources_nav_items %}
-              {% if item.title == "---" %}
+              {% if item.is_divider %}
                 <li><hr class="dropdown-divider"></li>
               {% else %}
                 <li class="nav-item {% if item.is_promoted %}ps-3{% endif %}">


### PR DESCRIPTION
## Navigation IA Improvements: Resources & Equipment Drawers

### Overview
This PR improves the information architecture (IA) of the top navigation menu by better organizing the **Resources** and **Equipment** drawers. The goal was to create a clearer visual distinction between dynamically promoted CMS pages and static utility links, while grouping equipment-related tools together.

### Changes

#### 1. Resources Drawer Enhancements
*   **Visual Separator**: Added a horizontal divider (`<hr>`) between the list of promoted CMS pages and the relocated utility links to prevent them from blending into a single long list.
*   **Promoted Pages Indentation**: Introduced a slight indentation for promoted pages using Bootstrap's `ps-3` class. This visually signals that these are dynamic content pages rather than top-level system utilities.
*   **Deduplication Logic Fix**: Updated the `_dedupe_resource_items` utility in context_processors.py to ensure that non-link items (like the new divider sentinel) are not accidentally filtered out during the deduplication process.

#### 2. Equipment Drawer Relocation
*   **Link Migration**: Moved the **"Gliders and Towplanes"** link from the Resources drawer to the **Equipment** drawer.
*   **Grouping**: This ensures that all equipment-related management tools (Maintenance Issues, Maintenance Log, Deadlines, and the Equipment List) are consolidated in one place for better discoverability.

### Technical Details
- **context_processors.py**: 
    - Added a sentinel item `{"title": "---", ...}` to act as the divider.
    - Added an `is_promoted: True` flag to promoted page items.
    - Refined `_dedupe_resource_items` to allow items with `url=None`.
- **base.html**: 
    - Updated the Resources loop to render the divider and apply conditional indentation.
    - Added the "Gliders and Towplanes" link to the Equipment dropdown menu.

### Verification Results
- [x] Verified that the horizontal line appears correctly in the Resources drawer.
- [x] Verified that promoted pages are slightly indented.
- [x] Verified that "Gliders and Towplanes" is now located under the Equipment menu and removed from Resources.