### PR TITLE
Fix CodeQL alert # 79 stack trace exposure in offline sync API

### DIFF
--- a/logsheet/api.py
+++ b/logsheet/api.py
@@ -297,7 +297,9 @@ def flights_sync(request):
             except Exception as e:
                 logger.exception(f"Error processing flight sync: {idempotency_key}")
                 result["status"] = "error"
-                result["error"] = str(e)
+                result["error"] = (
+                    "An internal error occurred while processing this flight."
+                )
 
             results.append(result)
 

--- a/logsheet/tests/test_offline_api.py
+++ b/logsheet/tests/test_offline_api.py
@@ -6,6 +6,7 @@ Part of Issue #315: PWA Fully-offline Logsheet data entry
 
 import json
 from datetime import date
+from unittest.mock import patch
 
 import pytest
 from django.test import Client
@@ -442,6 +443,44 @@ class TestFlightsSyncEndpoint:
 
         # Verify both flights created
         assert Flight.objects.filter(logsheet=logsheet).count() == 2
+
+    def test_unexpected_sync_exception_does_not_leak_internal_details(
+        self, db, authenticated_client, logsheet, active_member, glider, airfield
+    ):
+        """Unexpected sync exceptions should return a generic per-flight error message."""
+        url = reverse("logsheet:api_offline_flights_sync")
+        payload = {
+            "flights": [
+                {
+                    "idempotencyKey": "test-key-exception-no-leak",
+                    "action": "create",
+                    "data": {
+                        "logsheet_id": logsheet.id,
+                        "pilot_id": active_member.id,
+                        "glider_id": glider.id,
+                        "airfield_id": airfield.id,
+                        "flight_type": "solo",
+                    },
+                }
+            ]
+        }
+
+        with patch(
+            "logsheet.api._create_flight_from_offline",
+            side_effect=RuntimeError("SECRET_STACK_TRACE_DETAIL"),
+        ):
+            response = authenticated_client.post(
+                url, data=json.dumps(payload), content_type="application/json"
+            )
+
+        data = response.json()
+        assert data["success"] is True
+        assert data["results"][0]["status"] == "error"
+        assert (
+            data["results"][0]["error"]
+            == "An internal error occurred while processing this flight."
+        )
+        assert "SECRET_STACK_TRACE_DETAIL" not in response.content.decode("utf-8")
 
 
 class TestSyncStatusEndpoint:


### PR DESCRIPTION
Software developers often add stack traces to error messages, as a debugging aid. Whenever that error message occurs for an end user, the developer can use the stack trace to help identify how to fix the problem. In particular, stack traces can tell the developer more about the sequence of events that led to a failure, as opposed to merely the final state of the software when the error occurred.

Unfortunately, the same information can be useful to an attacker. The sequence of class names in a stack trace can reveal the structure of the application as well as any internal components it relies on. Furthermore, the error message at the top of a stack trace can include information such as server-side file names and SQL code that the application relies on, allowing an attacker to fine-tune a subsequent injection attack.

### Recommendation
Send the user a more generic error message that reveals less information. Either suppress the stack trace entirely, or log it only on the server.

