### PR TITLE
feat(ansible): add public proxy nginx mode

### DIFF
--- a/infrastructure/ansible/group_vars/single_host.vars.yml.example
+++ b/infrastructure/ansible/group_vars/single_host.vars.yml.example
@@ -87,6 +87,8 @@ m2s_venv_path: "{{ m2s_app_home }}/venv"
 m2s_django_settings_module: "manage2soar.settings_single_host"
 m2s_django_debug: false  # MUST be false in production!
 m2s_django_allowed_hosts: "{{ m2s_domain }},localhost,127.0.0.1"
+m2s_site_url: "{{ nginx_external_scheme | default('https') if (nginx_public_proxy_mode | default(false) | bool) else ('https' if (nginx_ssl_enabled | default(false) | bool) else 'http') }}://{{ m2s_domain }}"
+m2s_csrf_trusted_origins: "{{ m2s_site_url }}"
 m2s_django_static_root: "/var/www/m2s/static"
 m2s_django_media_root: "/var/www/m2s/media"
 
@@ -118,6 +120,27 @@ m2s_db_user: "{{ postgresql_user }}"
 # SSL configuration
 nginx_ssl_enabled: true  # Enable for production
 letsencrypt_email: "admin@your-club.com"
+
+# Standard ports are used by default. Override only if you intentionally need
+# non-standard listener ports, for example nginx_http_port: 8080.
+nginx_http_port: 80
+nginx_https_port: 443
+
+# Public proxy mode
+# Enable only when another same-host public proxy owns public 80/443 and TLS
+# certificates, then forwards Manage2Soar traffic to this local nginx backend.
+nginx_public_proxy_mode: false
+nginx_proxy_listen_address: "127.0.0.1"
+nginx_proxy_http_port: 8080
+nginx_external_scheme: "https"
+nginx_external_port: 443
+nginx_public_proxy_real_ip_from: "127.0.0.1"
+
+# If nginx_public_proxy_mode is true, also set:
+# nginx_ssl_enabled: false
+# letsencrypt_email: ""
+# Configure your public proxy to forward to:
+#   http://127.0.0.1:8080
 
 nginx_http2_enabled: true
 nginx_rate_limit_enabled: true

--- a/infrastructure/ansible/group_vars/single_host.vars.yml.example
+++ b/infrastructure/ansible/group_vars/single_host.vars.yml.example
@@ -87,7 +87,11 @@ m2s_venv_path: "{{ m2s_app_home }}/venv"
 m2s_django_settings_module: "manage2soar.settings_single_host"
 m2s_django_debug: false  # MUST be false in production!
 m2s_django_allowed_hosts: "{{ m2s_domain }},localhost,127.0.0.1"
-m2s_site_url: "{{ nginx_external_scheme | default('https') if (nginx_public_proxy_mode | default(false) | bool) else ('https' if (nginx_ssl_enabled | default(false) | bool) else 'http') }}://{{ m2s_domain }}"
+m2s_site_url: >-
+  {%- set _public_proxy_mode = nginx_public_proxy_mode | default(false) | bool -%}
+  {%- set _site_scheme = nginx_external_scheme | default('https') if _public_proxy_mode else ('https' if (nginx_ssl_enabled | default(false) | bool) else 'http') -%}
+  {%- set _site_port = (nginx_external_port | default(443 if _site_scheme == 'https' else 80) | int) if _public_proxy_mode else ((nginx_https_port | default(443) | int) if (nginx_ssl_enabled | default(false) | bool) else (nginx_http_port | default(80) | int)) -%}
+  {{ _site_scheme }}://{{ m2s_domain }}{%- if (_site_scheme == 'https' and _site_port != 443) or (_site_scheme == 'http' and _site_port != 80) -%}:{{ _site_port }}{%- endif -%}
 m2s_csrf_trusted_origins: "{{ m2s_site_url }}"
 m2s_django_static_root: "/var/www/m2s/static"
 m2s_django_media_root: "/var/www/m2s/media"

--- a/infrastructure/ansible/playbooks/single-host.yml
+++ b/infrastructure/ansible/playbooks/single-host.yml
@@ -128,7 +128,10 @@
           Server: {{ inventory_hostname }}
           Domain: {{ m2s_domain }}
           Mode: {{ 'Public proxy backend' if (nginx_public_proxy_mode | default(false) | bool) else 'Standalone' }}
-          URL: {{ nginx_external_scheme | default('https') if (nginx_public_proxy_mode | default(false) | bool) else ('https' if (nginx_ssl_enabled | default(false) | bool) else 'http') }}://{{ m2s_domain }}/
+          {% set _public_proxy_mode = nginx_public_proxy_mode | default(false) | bool %}
+          {% set _url_scheme = nginx_external_scheme | default('https') if _public_proxy_mode else ('https' if (nginx_ssl_enabled | default(false) | bool) else 'http') %}
+          {% set _url_port = (nginx_external_port | default(443 if _url_scheme == 'https' else 80) | int) if _public_proxy_mode else ((nginx_https_port | default(443) | int) if (nginx_ssl_enabled | default(false) | bool) else (nginx_http_port | default(80) | int)) %}
+          URL: {{ _url_scheme }}://{{ m2s_domain }}{% if (_url_scheme == 'https' and _url_port != 443) or (_url_scheme == 'http' and _url_port != 80) %}:{{ _url_port }}{% endif %}/
           {% if nginx_public_proxy_mode | default(false) | bool %}
           Internal NGINX backend: http://{{ nginx_proxy_listen_address | default('127.0.0.1') }}:{{ nginx_proxy_http_port | default(8080) }}
           Public URL and TLS certificates are owned by the same-host public proxy.

--- a/infrastructure/ansible/playbooks/single-host.yml
+++ b/infrastructure/ansible/playbooks/single-host.yml
@@ -48,6 +48,7 @@
           Domain: {{ m2s_domain }}
           Club: {{ club_name | default('Not Set') }} ({{ club_prefix | default('tsc') }})
           PostgreSQL: {{ postgresql_version | default('17') }}
+          NGINX Mode: {{ 'Public proxy backend' if (nginx_public_proxy_mode | default(false) | bool) else 'Standalone' }}
           SSL Enabled: {{ nginx_ssl_enabled | default(false) }}
           Mail Server: {{ mail_server_enabled | default(false) }}
           ========================================
@@ -126,7 +127,12 @@
 
           Server: {{ inventory_hostname }}
           Domain: {{ m2s_domain }}
-          URL: http{% if nginx_ssl_enabled | default(false) %}s{% endif %}://{{ m2s_domain }}/
+          Mode: {{ 'Public proxy backend' if (nginx_public_proxy_mode | default(false) | bool) else 'Standalone' }}
+          URL: {{ nginx_external_scheme | default('https') if (nginx_public_proxy_mode | default(false) | bool) else ('https' if (nginx_ssl_enabled | default(false) | bool) else 'http') }}://{{ m2s_domain }}/
+          {% if nginx_public_proxy_mode | default(false) | bool %}
+          Internal NGINX backend: http://{{ nginx_proxy_listen_address | default('127.0.0.1') }}:{{ nginx_proxy_http_port | default(8080) }}
+          Public URL and TLS certificates are owned by the same-host public proxy.
+          {% endif %}
 
           Database:
             Host: localhost
@@ -142,7 +148,9 @@
           Media Files: {{ m2s_django_media_root | default('/var/www/m2s/media') }}
           Logs: {{ m2s_log_dir | default('/var/log/m2s') }}
 
-          {% if nginx_ssl_enabled | default(false) %}
+          {% if nginx_public_proxy_mode | default(false) | bool %}
+          SSL: Terminated by public proxy
+          {% elif nginx_ssl_enabled | default(false) %}
           SSL: Enabled (Let's Encrypt or self-signed)
           {% else %}
           SSL: Disabled (enable with nginx_ssl_enabled: true)

--- a/infrastructure/ansible/playbooks/test-nginx.yml
+++ b/infrastructure/ansible/playbooks/test-nginx.yml
@@ -27,17 +27,17 @@
     - role: nginx
 
   post_tasks:
-- name: Set expected NGINX test endpoint
-  ansible.builtin.set_fact:
-    nginx_test_http_host: "{{ nginx_proxy_listen_address | default('127.0.0.1') if (nginx_public_proxy_mode | default(false) | bool) else '127.0.0.1' }}"
-    nginx_test_http_port: "{{ nginx_proxy_http_port | default(8080) if (nginx_public_proxy_mode | default(false) | bool) else nginx_http_port | default(80) }}"
-
     - name: Verify NGINX is running
       ansible.builtin.systemd:
         name: nginx
         state: started
       check_mode: true
       register: nginx_status
+
+    - name: Set expected NGINX test endpoint
+      ansible.builtin.set_fact:
+        nginx_test_http_host: "{{ nginx_proxy_listen_address | default('127.0.0.1') if (nginx_public_proxy_mode | default(false) | bool) else '127.0.0.1' }}"
+        nginx_test_http_port: "{{ nginx_proxy_http_port | default(8080) if (nginx_public_proxy_mode | default(false) | bool) else nginx_http_port | default(80) }}"
 
     - name: Test NGINX configuration
       ansible.builtin.command: nginx -t

--- a/infrastructure/ansible/playbooks/test-nginx.yml
+++ b/infrastructure/ansible/playbooks/test-nginx.yml
@@ -18,13 +18,20 @@
         msg: |
           Testing NGINX role on {{ inventory_hostname }}
           Domain: {{ m2s_domain }}
+          Public Proxy Mode: {{ nginx_public_proxy_mode | default(false) }}
           SSL Enabled: {{ nginx_ssl_enabled }}
+          Backend URL: http://{{ nginx_proxy_listen_address | default('127.0.0.1') }}:{{ nginx_proxy_http_port | default(8080) }}
           Static Root: {{ nginx_static_root }}
 
   roles:
     - role: nginx
 
   post_tasks:
+    - name: Set expected NGINX test endpoint
+      ansible.builtin.set_fact:
+        nginx_test_http_host: "{{ nginx_proxy_listen_address | default('127.0.0.1') if (nginx_public_proxy_mode | default(false) | bool) else 'localhost' }}"
+        nginx_test_http_port: "{{ nginx_proxy_http_port | default(8080) if (nginx_public_proxy_mode | default(false) | bool) else nginx_http_port | default(80) }}"
+
     - name: Verify NGINX is running
       ansible.builtin.systemd:
         name: nginx
@@ -37,16 +44,17 @@
       register: nginx_test
       changed_when: false
 
-    - name: Check if NGINX is listening on port 80
+    - name: Check if NGINX is listening on expected HTTP port
       ansible.builtin.wait_for:
-        port: 80
+        host: "{{ nginx_test_http_host }}"
+        port: "{{ nginx_test_http_port }}"
         timeout: 5
-      register: port_80_check
+      register: http_port_check
       ignore_errors: true
 
     - name: Test HTTP response
       ansible.builtin.uri:
-        url: "http://localhost/"
+        url: "http://{{ nginx_test_http_host }}{% if (nginx_test_http_port | int) != 80 %}:{{ nginx_test_http_port }}{% endif %}/"
         status_code: [200, 301, 302, 502]
         validate_certs: false
       register: http_response
@@ -60,9 +68,14 @@
           ========================================
           Service Status: {{ 'Running' if nginx_status.status.ActiveState == 'active' else 'Not Running' }}
           Config Test: {{ 'Passed' if nginx_test.rc == 0 else 'Failed' }}
-          Port 80: {{ 'Listening' if port_80_check is success else 'Not Listening' }}
+          Mode: {{ 'Public proxy backend' if (nginx_public_proxy_mode | default(false) | bool) else 'Standalone' }}
+          HTTP Port {{ nginx_test_http_port }}: {{ 'Listening' if http_port_check is success else 'Not Listening' }}
           HTTP Response: {{ http_response.status | default('N/A') }}
 
+          {% if nginx_public_proxy_mode | default(false) | bool %}
+          Public proxy should forward to: http://{{ nginx_proxy_listen_address | default('127.0.0.1') }}:{{ nginx_proxy_http_port | default(8080) }}
+          Public URL/certs are owned by the public proxy.
+          {% endif %}
           Static files: {{ nginx_static_root }}
           Media files: {{ nginx_media_root }}
           Upstream: {{ nginx_upstream_server }}

--- a/infrastructure/ansible/playbooks/test-nginx.yml
+++ b/infrastructure/ansible/playbooks/test-nginx.yml
@@ -27,10 +27,10 @@
     - role: nginx
 
   post_tasks:
-    - name: Set expected NGINX test endpoint
-      ansible.builtin.set_fact:
-        nginx_test_http_host: "{{ nginx_proxy_listen_address | default('127.0.0.1') if (nginx_public_proxy_mode | default(false) | bool) else 'localhost' }}"
-        nginx_test_http_port: "{{ nginx_proxy_http_port | default(8080) if (nginx_public_proxy_mode | default(false) | bool) else nginx_http_port | default(80) }}"
+- name: Set expected NGINX test endpoint
+  ansible.builtin.set_fact:
+    nginx_test_http_host: "{{ nginx_proxy_listen_address | default('127.0.0.1') if (nginx_public_proxy_mode | default(false) | bool) else '127.0.0.1' }}"
+    nginx_test_http_port: "{{ nginx_proxy_http_port | default(8080) if (nginx_public_proxy_mode | default(false) | bool) else nginx_http_port | default(80) }}"
 
     - name: Verify NGINX is running
       ansible.builtin.systemd:

--- a/infrastructure/ansible/roles/common/tasks/main.yml
+++ b/infrastructure/ansible/roles/common/tasks/main.yml
@@ -190,7 +190,7 @@
 - name: Remove legacy open HTTP rule
   community.general.ufw:
     rule: allow
-    port: "{{ nginx_http_port | default(80) | string }}"
+    port: "80"
     proto: tcp
     delete: true
   when:
@@ -200,7 +200,7 @@
 - name: Deny HTTP
   community.general.ufw:
     rule: deny
-    port: "{{ nginx_http_port | default(80) | string }}"
+    port: "80"
     proto: tcp
   when:
     - not (nginx_public_proxy_mode | default(false) | bool)
@@ -209,7 +209,7 @@
 - name: Remove HTTP deny rule when Let's Encrypt is enabled
   community.general.ufw:
     rule: deny
-    port: "{{ nginx_http_port | default(80) | string }}"
+    port: "80"
     proto: tcp
     delete: true
   when:
@@ -219,7 +219,7 @@
 - name: Allow HTTP for Let's Encrypt HTTP-01 challenge
   community.general.ufw:
     rule: allow
-    port: "{{ nginx_http_port | default(80) | string }}"
+    port: "80"
     proto: tcp
   when:
     - not (nginx_public_proxy_mode | default(false) | bool)

--- a/infrastructure/ansible/roles/common/tasks/main.yml
+++ b/infrastructure/ansible/roles/common/tasks/main.yml
@@ -187,35 +187,52 @@
     delete: true
   when: (gcp_enable_submission_smtp | default(true)) | bool
 
-- name: Remove legacy open HTTP rule (80)
+- name: Remove legacy open HTTP rule
   community.general.ufw:
     rule: allow
-    port: "80"
+    port: "{{ nginx_http_port | default(80) | string }}"
     proto: tcp
     delete: true
-  when: (letsencrypt_email | default('') | length) == 0
+  when:
+    - not (nginx_public_proxy_mode | default(false) | bool)
+    - (letsencrypt_email | default('') | length) == 0
 
-- name: Deny HTTP (80)
+- name: Deny HTTP
   community.general.ufw:
     rule: deny
-    port: "80"
+    port: "{{ nginx_http_port | default(80) | string }}"
     proto: tcp
-  when: (letsencrypt_email | default('') | length) == 0
+  when:
+    - not (nginx_public_proxy_mode | default(false) | bool)
+    - (letsencrypt_email | default('') | length) == 0
 
-- name: Remove HTTP deny rule (80) when Let's Encrypt is enabled
+- name: Remove HTTP deny rule when Let's Encrypt is enabled
   community.general.ufw:
     rule: deny
-    port: "80"
+    port: "{{ nginx_http_port | default(80) | string }}"
     proto: tcp
     delete: true
-  when: (letsencrypt_email | default('') | length) > 0
+  when:
+    - not (nginx_public_proxy_mode | default(false) | bool)
+    - (letsencrypt_email | default('') | length) > 0
 
-- name: Allow HTTP (80) for Let's Encrypt HTTP-01 challenge
+- name: Allow HTTP for Let's Encrypt HTTP-01 challenge
   community.general.ufw:
     rule: allow
-    port: "80"
+    port: "{{ nginx_http_port | default(80) | string }}"
     proto: tcp
-  when: (letsencrypt_email | default('') | length) > 0
+  when:
+    - not (nginx_public_proxy_mode | default(false) | bool)
+    - (letsencrypt_email | default('') | length) > 0
+
+- name: Allow HTTPS
+  community.general.ufw:
+    rule: allow
+    port: "{{ nginx_https_port | default(443) | string }}"
+    proto: tcp
+  when:
+    - not (nginx_public_proxy_mode | default(false) | bool)
+    - nginx_ssl_enabled | default(false) | bool
 
 - name: Enable UFW
   community.general.ufw:
@@ -226,7 +243,9 @@
     name:
       - certbot
     state: present
-  when: (letsencrypt_email | default('') | length) > 0
+  when:
+    - not (nginx_public_proxy_mode | default(false) | bool)
+    - (letsencrypt_email | default('') | length) > 0
 
 - name: Obtain Let's Encrypt certificate (if not exists)
   ansible.builtin.command: >
@@ -235,7 +254,9 @@
     --domains {{ mail_hostname }}
   args:
     creates: /etc/letsencrypt/live/{{ mail_hostname }}/fullchain.pem
-  when: (letsencrypt_email | default('') | length) > 0
+  when:
+    - not (nginx_public_proxy_mode | default(false) | bool)
+    - (letsencrypt_email | default('') | length) > 0
 
 - name: Deploy postfix-sasl fail2ban filter
   ansible.builtin.template:

--- a/infrastructure/ansible/roles/common/tasks/main.yml
+++ b/infrastructure/ansible/roles/common/tasks/main.yml
@@ -190,7 +190,7 @@
 - name: Remove legacy open HTTP rule
   community.general.ufw:
     rule: allow
-    port: "80"
+    port: "{{ nginx_http_port | default(80) | string }}"
     proto: tcp
     delete: true
   when:
@@ -200,7 +200,7 @@
 - name: Deny HTTP
   community.general.ufw:
     rule: deny
-    port: "80"
+    port: "{{ nginx_http_port | default(80) | string }}"
     proto: tcp
   when:
     - not (nginx_public_proxy_mode | default(false) | bool)
@@ -209,7 +209,7 @@
 - name: Remove HTTP deny rule when Let's Encrypt is enabled
   community.general.ufw:
     rule: deny
-    port: "80"
+    port: "{{ nginx_http_port | default(80) | string }}"
     proto: tcp
     delete: true
   when:
@@ -219,7 +219,7 @@
 - name: Allow HTTP for Let's Encrypt HTTP-01 challenge
   community.general.ufw:
     rule: allow
-    port: "80"
+    port: "{{ nginx_http_port | default(80) | string }}"
     proto: tcp
   when:
     - not (nginx_public_proxy_mode | default(false) | bool)
@@ -250,6 +250,7 @@
 - name: Obtain Let's Encrypt certificate (if not exists)
   ansible.builtin.command: >
     certbot certonly --standalone --non-interactive --agree-tos
+    --http-01-port {{ nginx_http_port | default(80) }}
     --email {{ letsencrypt_email }}
     --domains {{ mail_hostname }}
   args:

--- a/infrastructure/ansible/roles/gke-deploy/templates/k8s-secrets.yml.j2
+++ b/infrastructure/ansible/roles/gke-deploy/templates/k8s-secrets.yml.j2
@@ -197,7 +197,7 @@ stringData:
   EMAIL_USE_TLS: "{{ gke_email_use_tls | string | lower }}"
   EMAIL_TIMEOUT: "{{ gke_email_timeout | default(20) | string }}"
   DEFAULT_FROM_EMAIL: "{{ gke_default_from_email }}"
-{% if vault_email_host_user is defined or vault_email_host_password is defined %}
+{% if vault_email_host_user is defined and vault_email_host_password is defined %}
   EMAIL_HOST_USER: "{{ vault_email_host_user }}"
   EMAIL_HOST_PASSWORD: "{{ vault_email_host_password }}"
 {% endif %}

--- a/infrastructure/ansible/roles/gke-deploy/templates/k8s-secrets.yml.j2
+++ b/infrastructure/ansible/roles/gke-deploy/templates/k8s-secrets.yml.j2
@@ -197,7 +197,7 @@ stringData:
   EMAIL_USE_TLS: "{{ gke_email_use_tls | string | lower }}"
   EMAIL_TIMEOUT: "{{ gke_email_timeout | default(20) | string }}"
   DEFAULT_FROM_EMAIL: "{{ gke_default_from_email }}"
-{% if vault_email_host_user is defined %}
+{% if vault_email_host_user is defined or vault_email_host_password is defined %}
   EMAIL_HOST_USER: "{{ vault_email_host_user }}"
   EMAIL_HOST_PASSWORD: "{{ vault_email_host_password }}"
 {% endif %}

--- a/infrastructure/ansible/roles/m2s-app/defaults/main.yml
+++ b/infrastructure/ansible/roles/m2s-app/defaults/main.yml
@@ -9,7 +9,7 @@ m2s_app_home: "/opt/m2s"
 m2s_app_name: "manage2soar"
 
 # Repository settings
-m2s_git_repo: "https://github.com/pietbarber/Manage2Soar.git"
+m2s_git_repo: "https://github.com/invrtd/Manage2Soar.git"
 m2s_git_branch: "main"
 m2s_git_force_update: false
 

--- a/infrastructure/ansible/roles/m2s-app/defaults/main.yml
+++ b/infrastructure/ansible/roles/m2s-app/defaults/main.yml
@@ -9,7 +9,7 @@ m2s_app_home: "/opt/m2s"
 m2s_app_name: "manage2soar"
 
 # Repository settings
-m2s_git_repo: "https://github.com/invrtd/Manage2Soar.git"
+m2s_git_repo: "https://github.com/pietbarber/Manage2Soar.git"
 m2s_git_branch: "main"
 m2s_git_force_update: false
 

--- a/infrastructure/ansible/roles/m2s-app/templates/env.j2
+++ b/infrastructure/ansible/roles/m2s-app/templates/env.j2
@@ -1,6 +1,7 @@
 # Django environment configuration
 # Managed by Ansible - DO NOT EDIT MANUALLY
-# Environment variables expected by manage2soar/settings_single_host.py
+# Environment variables consumed by Manage2Soar settings modules
+# (single-host uses ALLOWED_HOSTS; other variants may read DJANGO_ALLOWED_HOSTS)
 
 # Django settings module
 DJANGO_SETTINGS_MODULE={{ m2s_django_settings_module }}

--- a/infrastructure/ansible/roles/m2s-app/templates/env.j2
+++ b/infrastructure/ansible/roles/m2s-app/templates/env.j2
@@ -11,7 +11,8 @@ DJANGO_DEBUG={{ m2s_django_debug | string | lower }}
 # Security settings
 DJANGO_SECRET_KEY={{ vault_django_secret_key }}
 ALLOWED_HOSTS={{ m2s_django_allowed_hosts }}
-SSL_ENABLED={{ nginx_ssl_enabled | default(false) | string | lower }}
+DJANGO_ALLOWED_HOSTS={{ m2s_django_allowed_hosts }}
+SSL_ENABLED={{ ((nginx_ssl_enabled | default(false) | bool) or ((nginx_public_proxy_mode | default(false) | bool) and ((nginx_external_scheme | default('https')) == 'https'))) | string | lower }}
 SITE_URL={{ m2s_site_url }}
 CSRF_TRUSTED_ORIGINS={{ m2s_csrf_trusted_origins | default(m2s_site_url) }}
 

--- a/infrastructure/ansible/roles/m2s-app/templates/settings_single_host.py.j2
+++ b/infrastructure/ansible/roles/m2s-app/templates/settings_single_host.py.j2
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     "siteconfig",
     "knowledgetest",
     "utils",
+    "widget_tweaks",
 ]
 
 MIDDLEWARE = [
@@ -197,6 +198,7 @@ DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@example.com")
 
 # Security settings for production
 if not DEBUG:
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SECURE_SSL_REDIRECT = True
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True

--- a/infrastructure/ansible/roles/m2s-app/templates/settings_single_host.py.j2
+++ b/infrastructure/ansible/roles/m2s-app/templates/settings_single_host.py.j2
@@ -197,11 +197,15 @@ EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@example.com")
 
 # Security settings for production
+# Only enable SSL-related settings if SSL is actually configured
+SSL_ENABLED = os.getenv("SSL_ENABLED", "False").lower() in ("true", "1", "yes")
+
 if not DEBUG:
-    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-    SECURE_SSL_REDIRECT = True
-    SESSION_COOKIE_SECURE = True
-    CSRF_COOKIE_SECURE = True
+    if SSL_ENABLED:
+        SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+        SECURE_SSL_REDIRECT = True
+        SESSION_COOKIE_SECURE = True
+        CSRF_COOKIE_SECURE = True
 
     # SameSite cookie settings to prevent CSRF attacks
     # Lax = cookies sent with same-site requests and top-level navigation (recommended)

--- a/infrastructure/ansible/roles/nginx/defaults/main.yml
+++ b/infrastructure/ansible/roles/nginx/defaults/main.yml
@@ -9,6 +9,20 @@ nginx_ssl_enabled: true
 nginx_ssl_certificate: "/etc/letsencrypt/live/{{ nginx_server_name }}/fullchain.pem"
 nginx_ssl_certificate_key: "/etc/letsencrypt/live/{{ nginx_server_name }}/privkey.pem"
 
+# Listener ports. Override these in group_vars/host_vars for non-standard ports.
+nginx_http_port: 80
+nginx_https_port: 443
+
+# Public proxy mode
+# Enable when another same-host proxy owns public 80/443 and TLS certificates.
+# M2S nginx will listen on a localhost-only HTTP backend for that proxy.
+nginx_public_proxy_mode: false
+nginx_proxy_listen_address: "127.0.0.1"
+nginx_proxy_http_port: 8080
+nginx_external_scheme: "https"
+nginx_external_port: 443
+nginx_public_proxy_real_ip_from: "127.0.0.1"
+
 # Let's Encrypt
 letsencrypt_email: "admin@{{ nginx_server_name }}"
 

--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -17,6 +17,20 @@
       nginx_ssl_enabled: false because the public proxy owns HTTPS/certs.
   when: nginx_public_proxy_mode | bool
 
+- name: Validate Let's Encrypt HTTP-01 compatibility
+  ansible.builtin.assert:
+    that:
+      - (nginx_http_port | int) == 80
+    fail_msg: >-
+      Let's Encrypt HTTP-01 with certbot --nginx requires nginx_http_port: 80.
+      Set nginx_http_port to 80, or disable automatic SSL issuance (for example,
+      use nginx_ssl_enabled: false/public proxy mode or provide certificates
+      outside this role).
+  when:
+    - not (nginx_public_proxy_mode | bool)
+    - nginx_ssl_enabled | bool
+    - letsencrypt_email | default('') | trim | length > 0
+
 - name: Install NGINX (public proxy mode)
   ansible.builtin.apt:
     name: nginx

--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -1,11 +1,25 @@
 # NGINX Role - Main Tasks
 ---
+- name: Validate public proxy mode configuration
+  ansible.builtin.assert:
+    that:
+      - nginx_proxy_listen_address in ["127.0.0.1", "localhost"]
+      - (nginx_proxy_http_port | int) > 0
+      - (nginx_proxy_http_port | int) < 65536
+      - nginx_external_scheme in ["http", "https"]
+      - (nginx_external_port | int) > 0
+      - (nginx_external_port | int) < 65536
+      - nginx_public_proxy_real_ip_from in ["127.0.0.1", "localhost"]
+      - not (nginx_ssl_enabled | bool)
+    fail_msg: >-
+      nginx_public_proxy_mode is same-host only. Set nginx_proxy_listen_address
+      to 127.0.0.1 or localhost, set a valid nginx_proxy_http_port, and set
+      nginx_ssl_enabled: false because the public proxy owns HTTPS/certs.
+  when: nginx_public_proxy_mode | bool
+
 - name: Install NGINX
   ansible.builtin.apt:
-    name:
-      - nginx
-      - certbot
-      - python3-certbot-nginx
+    name: "{{ ['nginx'] + ([] if (nginx_public_proxy_mode | bool) else ['certbot', 'python3-certbot-nginx']) }}"
     state: present
     update_cache: true
   become: true
@@ -53,12 +67,24 @@
     mode: "0644"
   become: true
   notify: Reload NGINX
-  when: nginx_ssl_enabled | bool
+  when:
+    - nginx_ssl_enabled | bool
+    - not (nginx_public_proxy_mode | bool)
 
 - name: Deploy security headers snippet
   ansible.builtin.template:
     src: security-headers.conf.j2
     dest: /etc/nginx/snippets/security-headers.conf
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: Reload NGINX
+
+- name: Deploy M2S proxy headers snippet
+  ansible.builtin.template:
+    src: m2s-proxy-headers.conf.j2
+    dest: /etc/nginx/snippets/m2s-proxy-headers.conf
     owner: root
     group: root
     mode: "0644"
@@ -87,7 +113,20 @@
     path: "{{ nginx_ssl_certificate }}"
   register: ssl_cert_exists
   become: true
-  when: nginx_ssl_enabled | bool
+  when:
+    - nginx_ssl_enabled | bool
+    - not (nginx_public_proxy_mode | bool)
+
+- name: Deploy M2S site configuration (public proxy backend)
+  ansible.builtin.template:
+    src: m2s-public-proxy.conf.j2
+    dest: /etc/nginx/sites-available/m2s.conf
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  when: nginx_public_proxy_mode | bool
+  notify: Reload NGINX
 
 - name: Deploy M2S site configuration (HTTP only for initial setup)
   ansible.builtin.template:
@@ -97,7 +136,10 @@
     group: root
     mode: "0644"
   become: true
-  when: (nginx_ssl_enabled | bool) and not (ssl_cert_exists.stat.exists | default(false))
+  when:
+    - not (nginx_public_proxy_mode | bool)
+    - nginx_ssl_enabled | bool
+    - not (ssl_cert_exists.stat.exists | default(false))
   notify: Reload NGINX
 
 - name: Deploy M2S site configuration (with SSL)
@@ -108,7 +150,10 @@
     group: root
     mode: "0644"
   become: true
-  when: (nginx_ssl_enabled | bool) and (ssl_cert_exists.stat.exists | default(false))
+  when:
+    - not (nginx_public_proxy_mode | bool)
+    - nginx_ssl_enabled | bool
+    - ssl_cert_exists.stat.exists | default(false)
   notify: Reload NGINX
 
 - name: Deploy M2S site configuration (no SSL)
@@ -119,7 +164,9 @@
     group: root
     mode: "0644"
   become: true
-  when: not (nginx_ssl_enabled | bool)
+  when:
+    - not (nginx_public_proxy_mode | bool)
+    - not (nginx_ssl_enabled | bool)
   notify: Reload NGINX
 
 - name: Enable M2S site
@@ -135,6 +182,17 @@
   become: true
   changed_when: false
 
+- name: Remove local certbot renewal in public proxy mode
+  ansible.builtin.cron:
+    name: "Certbot renewal"
+    state: absent
+    user: root
+  become: true
+  when: nginx_public_proxy_mode | bool
+
 - name: Include SSL certificate tasks
   ansible.builtin.include_tasks: ssl.yml
-  when: (nginx_ssl_enabled | bool) and not (ssl_cert_exists.stat.exists | default(true))
+  when:
+    - not (nginx_public_proxy_mode | bool)
+    - nginx_ssl_enabled | bool
+    - not (ssl_cert_exists.stat.exists | default(true))

--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -3,17 +3,17 @@
 - name: Validate public proxy mode configuration
   ansible.builtin.assert:
     that:
-      - nginx_proxy_listen_address in ["127.0.0.1", "localhost"]
+      - nginx_proxy_listen_address == "127.0.0.1"
       - (nginx_proxy_http_port | int) > 0
       - (nginx_proxy_http_port | int) < 65536
       - nginx_external_scheme in ["http", "https"]
       - (nginx_external_port | int) > 0
       - (nginx_external_port | int) < 65536
-      - nginx_public_proxy_real_ip_from in ["127.0.0.1", "localhost"]
+      - nginx_public_proxy_real_ip_from == "127.0.0.1"
       - not (nginx_ssl_enabled | bool)
     fail_msg: >-
       nginx_public_proxy_mode is same-host only. Set nginx_proxy_listen_address
-      to 127.0.0.1 or localhost, set a valid nginx_proxy_http_port, and set
+      to 127.0.0.1, set nginx_public_proxy_real_ip_from to 127.0.0.1, set a valid nginx_proxy_http_port, and set
       nginx_ssl_enabled: false because the public proxy owns HTTPS/certs.
   when: nginx_public_proxy_mode | bool
 

--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -17,12 +17,24 @@
       nginx_ssl_enabled: false because the public proxy owns HTTPS/certs.
   when: nginx_public_proxy_mode | bool
 
-- name: Install NGINX
+- name: Install NGINX (public proxy mode)
   ansible.builtin.apt:
-    name: "{{ ['nginx'] + ([] if (nginx_public_proxy_mode | bool) else ['certbot', 'python3-certbot-nginx']) }}"
+    name: nginx
     state: present
     update_cache: true
   become: true
+  when: nginx_public_proxy_mode | bool
+
+- name: Install NGINX with Certbot dependencies
+  ansible.builtin.apt:
+    name:
+      - nginx
+      - certbot
+      - python3-certbot-nginx
+    state: present
+    update_cache: true
+  become: true
+  when: not (nginx_public_proxy_mode | bool)
 
 - name: Ensure NGINX is started and enabled
   ansible.builtin.systemd:

--- a/infrastructure/ansible/roles/nginx/templates/m2s-http.conf.j2
+++ b/infrastructure/ansible/roles/nginx/templates/m2s-http.conf.j2
@@ -6,8 +6,8 @@ upstream {{ nginx_upstream_name }} {
 }
 
 server {
-    listen 80;
-    listen [::]:80;
+    listen {{ nginx_http_port }};
+    listen [::]:{{ nginx_http_port }};
     server_name {{ nginx_server_name }};
 
     # For Let's Encrypt certificate verification
@@ -19,7 +19,7 @@ server {
     # This configuration is only used before SSL certificate is obtained
     # After certificate acquisition, this will be replaced by m2s-ssl.conf
     location / {
-        include /etc/nginx/proxy_params;
+        include /etc/nginx/snippets/m2s-proxy-headers.conf;
         proxy_pass http://{{ nginx_upstream_name }};
     }
 }

--- a/infrastructure/ansible/roles/nginx/templates/m2s-nossl.conf.j2
+++ b/infrastructure/ansible/roles/nginx/templates/m2s-nossl.conf.j2
@@ -6,8 +6,8 @@ upstream {{ nginx_upstream_name }} {
 }
 
 server {
-    listen 80;
-    listen [::]:80;
+    listen {{ nginx_http_port }};
+    listen [::]:{{ nginx_http_port }};
     server_name {{ nginx_server_name }};
 
 {% if nginx_security_headers_enabled %}
@@ -54,20 +54,20 @@ server {
     # Rate-limited endpoints
     location /accounts/login/ {
         limit_req zone={{ nginx_rate_limit_zone }} burst={{ nginx_rate_limit_burst }} nodelay;
-        include /etc/nginx/proxy_params;
+        include /etc/nginx/snippets/m2s-proxy-headers.conf;
         proxy_pass http://{{ nginx_upstream_name }};
     }
 
     location /api/ {
         limit_req zone={{ nginx_rate_limit_zone }} burst={{ nginx_rate_limit_burst }} nodelay;
-        include /etc/nginx/proxy_params;
+        include /etc/nginx/snippets/m2s-proxy-headers.conf;
         proxy_pass http://{{ nginx_upstream_name }};
     }
 {% endif %}
 
     # Django application
     location / {
-        include /etc/nginx/proxy_params;
+        include /etc/nginx/snippets/m2s-proxy-headers.conf;
         proxy_pass http://{{ nginx_upstream_name }};
 
         # WebSocket support (if needed)

--- a/infrastructure/ansible/roles/nginx/templates/m2s-proxy-headers.conf.j2
+++ b/infrastructure/ansible/roles/nginx/templates/m2s-proxy-headers.conf.j2
@@ -1,0 +1,14 @@
+# M2S proxy headers
+# Managed by Ansible - do not edit manually
+
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Host $host;
+{% if nginx_public_proxy_mode | bool %}
+proxy_set_header X-Forwarded-Proto {{ nginx_external_scheme }};
+proxy_set_header X-Forwarded-Port {{ nginx_external_port }};
+{% else %}
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-Port $server_port;
+{% endif %}

--- a/infrastructure/ansible/roles/nginx/templates/m2s-proxy-headers.conf.j2
+++ b/infrastructure/ansible/roles/nginx/templates/m2s-proxy-headers.conf.j2
@@ -1,14 +1,14 @@
 # M2S proxy headers
 # Managed by Ansible - do not edit manually
 
-proxy_set_header Host $host;
+proxy_set_header Host $http_host;
 proxy_set_header X-Real-IP $remote_addr;
 {% if nginx_public_proxy_mode | bool %}
 proxy_set_header X-Forwarded-For $remote_addr;
 {% else %}
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 {% endif %}
-proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Host $http_host;
 {% if nginx_public_proxy_mode | bool %}
 proxy_set_header X-Forwarded-Proto {{ nginx_external_scheme }};
 proxy_set_header X-Forwarded-Port {{ nginx_external_port }};

--- a/infrastructure/ansible/roles/nginx/templates/m2s-proxy-headers.conf.j2
+++ b/infrastructure/ansible/roles/nginx/templates/m2s-proxy-headers.conf.j2
@@ -3,7 +3,11 @@
 
 proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
+{% if nginx_public_proxy_mode | bool %}
+proxy_set_header X-Forwarded-For $remote_addr;
+{% else %}
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+{% endif %}
 proxy_set_header X-Forwarded-Host $host;
 {% if nginx_public_proxy_mode | bool %}
 proxy_set_header X-Forwarded-Proto {{ nginx_external_scheme }};

--- a/infrastructure/ansible/roles/nginx/templates/m2s-public-proxy.conf.j2
+++ b/infrastructure/ansible/roles/nginx/templates/m2s-public-proxy.conf.j2
@@ -1,47 +1,28 @@
-# M2S NGINX Configuration - With SSL
+# M2S NGINX Configuration - Public Proxy Backend
 # Managed by Ansible - do not edit manually
+#
+# This mode is for same-host deployments where another public proxy owns
+# ports 80/443 and TLS certificates, then forwards to this local HTTP backend.
 
 upstream {{ nginx_upstream_name }} {
     server {{ nginx_upstream_server }};
 }
 
-# Redirect HTTP to HTTPS
 server {
-    listen {{ nginx_http_port }};
-    listen [::]:{{ nginx_http_port }};
+    listen {{ nginx_proxy_listen_address }}:{{ nginx_proxy_http_port }};
     server_name {{ nginx_server_name }};
 
-    # For Let's Encrypt certificate renewal
-    location /.well-known/acme-challenge/ {
-        root /var/www/html;
-    }
-
-    location / {
-        return 301 https://$host{% if (nginx_https_port | int) != 443 %}:{{ nginx_https_port }}{% endif %}$request_uri;
-    }
-}
-
-# HTTPS server
-server {
-{% if nginx_http2_enabled %}
-    listen {{ nginx_https_port }} ssl http2;
-    listen [::]:{{ nginx_https_port }} ssl http2;
-{% else %}
-    listen {{ nginx_https_port }} ssl;
-    listen [::]:{{ nginx_https_port }} ssl;
-{% endif %}
-    server_name {{ nginx_server_name }};
-
-    # SSL certificates
-    ssl_certificate {{ nginx_ssl_certificate }};
-    ssl_certificate_key {{ nginx_ssl_certificate_key }};
-
-    # SSL parameters
-    include /etc/nginx/snippets/ssl-params.conf;
+    # Trust only the same-host public proxy for original client IPs.
+    set_real_ip_from {{ nginx_public_proxy_real_ip_from }};
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
 
 {% if nginx_security_headers_enabled %}
-    # Security headers
-    include /etc/nginx/snippets/security-headers.conf;
+    # Security headers (HSTS belongs on the public TLS proxy)
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 {% endif %}
 
     # Logging
@@ -53,9 +34,6 @@ server {
         alias {{ nginx_static_root }}/;
         expires {{ nginx_static_cache_time }};
         add_header Cache-Control "public, immutable";
-
-        # Gzip static files
-        gzip_static on;
     }
 
     # Media files (user uploads)

--- a/infrastructure/ansible/roles/nginx/templates/m2s-ssl.conf.j2
+++ b/infrastructure/ansible/roles/nginx/templates/m2s-ssl.conf.j2
@@ -17,7 +17,7 @@ server {
     }
 
     location / {
-        return 301 https://$host{% if (nginx_https_port | int) != 443 %}:{{ nginx_https_port }}{% endif %}$request_uri;
+        return 301 https://{{ nginx_server_name }}{% if (nginx_https_port | int) != 443 %}:{{ nginx_https_port }}{% endif %}$request_uri;
     }
 }
 


### PR DESCRIPTION
Add an opt-in same-host public proxy backend mode for nginx, including localhost-only listener defaults, shared proxy headers, firewall/certbot gating, deployment messaging, and related app deployment template alignment.

Use case: An existing proxy is running on the machine. 