### PR TITLE
fix(dev): load single-host settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,7 +175,8 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
+# IDE
+.vscode/settings.json
 # End of https://www.toptal.com/developers/gitignore/api/django
 
 # Copilot conversation saves - keep private!

--- a/manage.py
+++ b/manage.py
@@ -3,10 +3,14 @@
 
 import os
 import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
 
 
 def main():
     """Run administrative tasks."""
+    load_dotenv(Path(__file__).resolve().parent / ".env")
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "manage2soar.settings")
     try:
         from django.core.management import execute_from_command_line

--- a/manage2soar/settings_single_host.py
+++ b/manage2soar/settings_single_host.py
@@ -15,6 +15,7 @@ import re
 from pathlib import Path
 
 from django.contrib.messages import constants as messages
+from dotenv import load_dotenv
 
 # Import all base settings first
 # We'll override the storage-related ones below
@@ -22,6 +23,7 @@ from django.contrib.messages import constants as messages
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+load_dotenv(BASE_DIR / ".env")
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
@@ -45,6 +47,7 @@ INSTALLED_APPS = [
     "django.contrib.humanize",
     "reversion",
     "django_htmx",
+    "django_extensions",
     "tinymce",
     "social_django",
     "members",
@@ -57,6 +60,7 @@ INSTALLED_APPS = [
     "siteconfig",
     "knowledgetest",
     "utils",
+    "widget_tweaks",
 ]
 
 MIDDLEWARE = [
@@ -205,6 +209,8 @@ EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "False").lower() in ("true", "1", "ye
 EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@example.com")
+EMAIL_DEV_MODE = os.getenv("EMAIL_DEV_MODE", "false").lower() in ("true", "1", "yes")
+EMAIL_DEV_MODE_REDIRECT_TO = os.getenv("EMAIL_DEV_MODE_REDIRECT_TO", "")
 
 # Security settings for production
 # Only enable SSL-related settings if SSL is actually configured
@@ -212,6 +218,7 @@ SSL_ENABLED = os.getenv("SSL_ENABLED", "False").lower() in ("true", "1", "yes")
 
 if not DEBUG:
     if SSL_ENABLED:
+        SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
         SECURE_SSL_REDIRECT = True
         SESSION_COOKIE_SECURE = True
         CSRF_COOKIE_SECURE = True

--- a/manage2soar/settings_single_host.py
+++ b/manage2soar/settings_single_host.py
@@ -17,10 +17,6 @@ from pathlib import Path
 from django.contrib.messages import constants as messages
 from dotenv import load_dotenv
 
-# Import all base settings first
-# We'll override the storage-related ones below
-
-
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BASE_DIR / ".env")

--- a/manage2soar/wsgi.py
+++ b/manage2soar/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mange2soar.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "manage2soar.settings")
 
 application = get_wsgi_application()

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ ortools==9.15.6755
 packageurl-python==0.17.5
 packaging==25.0
 pathspec==1.0.4
-pillow==12.2.0
+pillow==12.3.0
 pip-api==0.0.34
 pip-requirements-parser==32.0.1
 pip_audit==2.9.0
@@ -80,7 +80,7 @@ proto-plus==1.26.1
 protobuf>=3.19.5,<7.0.0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,!=5.29.0,!=6.33.0,!=6.33.1,!=6.33.2,!=6.33.3,!=6.33.4
 psycopg2-binary==2.9.10
 py-serializable==2.1.0
-pyasn1==0.6.3
+pyasn1==0.6.4
 pyasn1_modules==0.4.2
 pycodestyle==2.14.0
 pycparser==2.22
@@ -115,7 +115,7 @@ ruamel.yaml.clib==0.2.14
 ruff==0.14.1
 safety==3.7.0
 safety-schemas==0.0.16
-setuptools==80.9.0
+setuptools==83.0.0
 shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ cyclonedx-python-lib==9.1.0
 defusedxml==0.7.1
 diff-match-patch==20241021
 distlib==0.4.0
-Django==5.2.14
+Django==5.2.15
 django-crispy-forms==2.4
 django-extensions==4.1
 django-htmx==1.23.2


### PR DESCRIPTION
Fixed WSGI settings typo, makes sure that .env is loaded before selecting settings so `settings_single_host.py` can run and added missing single host dependencies