### PR TITLE
Security: bump httplib2 to 0.32.0 (Dependabot alert #82)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ greenlet==3.3.0
 gunicorn==23.0.0
 h11==0.16.0
 httpcore==1.0.9
-httplib2==0.31.0
+httplib2==0.32.0
 httpx==0.28.1
 icalendar==6.3.2
 identify==2.6.15


### PR DESCRIPTION
## Summary
- bump httplib2 from 0.31.0 to 0.32.0 in requirements.txt
- addresses Dependabot alert 82 (GHSA-j5g9-f88f-gfj3 / CVE-2026-59939)

## Validation
- /home/pb/Projects/skylinesoaring/.venv/bin/python -m pip check
- /home/pb/Projects/skylinesoaring/.venv/bin/python -c "import httplib2; print(httplib2.__version__)" (returns 0.32.0)
