### PR TITLE
Feature/issue 987 flight split requests

### DIFF
--- a/billing/periods.py
+++ b/billing/periods.py
@@ -155,23 +155,6 @@ def close_due_periods(now=None, dry_run=False):
         "log_date__year", "log_date__month"
     ).distinct():
         close_at = automatic_close_at(year, month)
-        if close_at is not None and now >= close_at:
-            period = BillingPeriod.objects.filter(year=year, month=month).first()
-            reopened = (
-                period
-                and period.events.filter(
-                    action=BillingPeriodEvent.Action.REOPENED
-                ).exists()
-            )
-            if period is None or (not period.is_closed and not reopened):
-                if dry_run:
-                    closed.append((year, month))
-                else:
-                    closed.append(
-                        close_period(
-                            year=year,
-                            month=month,
-                            reason="Automatically closed by the configured billing-period policy.",
-                        )
                     )
+                )
     return closed


### PR DESCRIPTION
Flight Split Requests
- Finalized flights can now have split changes requested after logsheet closing.
- A pilot or treasurer submits the split request; while the billing period is open, the proposed split partner must approve or reject it.
- After the billing period closes, a treasurer can approve or reject an existing request without partner approval.
- Closed-period treasurer decisions require a correction reason and create an auditable billing correction.
- Requests can be cancelled, expire after seven days, and cannot be created with the requester as their own partner.
- New split requests cannot be created after the billing period closes.
- Accepted requests create an auditable billing correction rather than changing posted charges directly.
- Members can view their billing statement and export it as CSV.

Billing Period Controls
- Billing periods can be closed manually by a treasurer or automatically at 11:59 PM in the club timezone.
- Automatic closing can be configured for:
  - An Nth weekday of the billing month or following month
  - A selected number of days before month end
- Treasurers can reopen a period when needed, with an audit reason.

resolves #987