### PR TITLE
feat(knowledgetest): add delete pending test and zero-question preven…

### DIFF
--- a/knowledgetest/templates/written_test/create.html
+++ b/knowledgetest/templates/written_test/create.html
@@ -95,20 +95,65 @@
           <td>{{ form.must_include }}</td>
         </tr>
       </tbody>
-      <tfoot>
-        <tr>
-          <td colspan="3">
-            <button type="submit" class="btn btn-primary">
-              Create Test
-            </button>
-          </td>
-        </tr>
-      </tfoot>
     </table>
 
+    <div class="d-flex align-items-center mb-3">
+      <span id="question-count" class="fw-bold me-3">0 questions</span>
+      <span id="question-warning" class="text-danger d-none">No questions selected!</span>
+    </div>
+
+    <button type="submit" class="btn btn-primary" id="create-test-btn">
+      Create Test
+    </button>
+
     {% if form.non_field_errors %}
-    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+    <div class="alert alert-danger mt-3">{{ form.non_field_errors }}</div>
     {% endif %}
   </form>
 </div>
+
+<script>
+(function() {
+  var weightFields = document.querySelectorAll('input[name^="weight_"]');
+  var mustInclude = document.getElementById('id_must_include');
+  var countEl = document.getElementById('question-count');
+  var warningEl = document.getElementById('question-warning');
+  var submitBtn = document.getElementById('create-test-btn');
+
+  function updateCount() {
+    var total = 0;
+    weightFields.forEach(function(input) {
+      var val = parseInt(input.value, 10);
+      if (!isNaN(val)) {
+        total += val;
+      }
+    });
+    // Add must-include count (estimate from text)
+    if (mustInclude && mustInclude.value.trim()) {
+      var nums = mustInclude.value.trim().match(/\d+/g);
+      if (nums) {
+        total += nums.length;
+      }
+    }
+    countEl.textContent = total + ' question' + (total !== 1 ? 's' : '');
+    if (total === 0) {
+      warningEl.classList.remove('d-none');
+      submitBtn.disabled = true;
+      submitBtn.classList.add('disabled');
+    } else {
+      warningEl.classList.add('d-none');
+      submitBtn.disabled = false;
+      submitBtn.classList.remove('disabled');
+    }
+  }
+
+  weightFields.forEach(function(input) {
+    input.addEventListener('input', updateCount);
+  });
+  if (mustInclude) {
+    mustInclude.addEventListener('input', updateCount);
+  }
+  updateCount();
+})();
+</script>
 {% endblock %}

--- a/knowledgetest/templates/written_test/delete_assignment_confirm.html
+++ b/knowledgetest/templates/written_test/delete_assignment_confirm.html
@@ -17,7 +17,7 @@
             <li><strong>Assigned on:</strong> {{ assignment.assigned_at|date:"F j, Y" }}</li>
           </ul>
           <div class="alert alert-warning">
-            <strong>Warning:</strong> This action will also delete the test template and its questions.
+            <strong>Warning:</strong> This action will delete this test assignment. If there are no other assignments using this test template, the template and its questions will also be deleted.
             This cannot be undone.
           </div>
           <form method="post">

--- a/knowledgetest/templates/written_test/delete_assignment_confirm.html
+++ b/knowledgetest/templates/written_test/delete_assignment_confirm.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+<div class="container py-4">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="card border-danger">
+        <div class="card-header bg-danger text-white">
+          <h5 class="mb-0">Confirm Deletion</h5>
+        </div>
+        <div class="card-body">
+          <p class="mb-3">You are about to delete the following test assignment:</p>
+          <ul class="list-unstyled">
+            <li><strong>Student:</strong> {{ assignment.student }}</li>
+            <li><strong>Test:</strong> {{ assignment.template.name }}</li>
+            <li><strong>Assigned on:</strong> {{ assignment.assigned_at|date:"F j, Y" }}</li>
+          </ul>
+          <div class="alert alert-warning">
+            <strong>Warning:</strong> This action will also delete the test template and its questions.
+            This cannot be undone.
+          </div>
+          <form method="post">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-danger" onclick="return confirm('Are you sure you want to delete this test assignment?')">
+              Delete Test Assignment
+            </button>
+            <a href="{% url 'knowledgetest:quiz-pending' %}" class="btn btn-secondary">Cancel</a>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/knowledgetest/templates/written_test/instructor_recent.html
+++ b/knowledgetest/templates/written_test/instructor_recent.html
@@ -117,6 +117,14 @@
                        title="View student's instruction record">
                       📘 Record
                     </a>
+                    {% if not assignment.attempt %}
+                    <a href="{% url 'knowledgetest:assignment-delete' assignment.pk %}"
+                       class="btn btn-outline-danger btn-sm ms-1"
+                       title="Delete pending test assignment"
+                       onclick="return confirm('Delete this pending test assignment?')">
+                      🗑️
+                    </a>
+                    {% endif %}
                   </td>
                 </tr>
               {% endfor %}

--- a/knowledgetest/templates/written_test/pending.html
+++ b/knowledgetest/templates/written_test/pending.html
@@ -23,6 +23,11 @@
       <a href="{% url 'knowledgetest:quiz-start' asn.template.pk %}" class="btn btn-primary">
         Start Test{% if asn.template.description %}: {{ asn.template.description|truncatechars:40 }}{% endif %}
       </a>
+      {% if not asn.attempt %}
+      <a href="{% url 'knowledgetest:assignment-delete' asn.pk %}" class="btn btn-outline-danger btn-sm ms-2">
+        Delete
+      </a>
+      {% endif %}
     </div>
   </div>
   {% endfor %}

--- a/knowledgetest/tests/test_knowledgetest.py
+++ b/knowledgetest/tests/test_knowledgetest.py
@@ -1,5 +1,6 @@
 import json
 from datetime import timedelta
+from decimal import Decimal
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -927,3 +928,215 @@ class PendingTestsViewAccessTests(TestCase):
         response = self.client.get(reverse("knowledgetest:quiz-pending"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["assignments"]), 1)
+
+
+# ################################################################
+# Issue #969 Tests: Delete pending test & zero-question prevention
+# ################################################################
+
+
+class ZeroQuestionTestPreventionTests(TestCase):
+    """Tests for preventing zero-question test creation (issue #969)."""
+
+    def setUp(self):
+        self.cat = QuestionCategory.objects.create(code="ZZZ", description="Test Cat")
+        self.student = User.objects.create_user(
+            username="student-test", password="pass"
+        )
+        self.student.membership_status = "Full Member"
+        self.student.save()
+        self.client.login(username="student-test", password="pass")
+
+    def test_all_zero_weights_prevented(self):
+        """Setting all weights to zero should prevent test creation."""
+        # Get the categories that exist
+        code_list = list(QuestionCategory.objects.values_list("code", flat=True))
+        # Build form data with all weights at 0
+        data = {
+            "student": self.student.pk,
+            "pass_percentage": "100",
+            "description": "",
+            "must_include": "",
+        }
+        for code in code_list:
+            data[f"weight_{code}"] = 0
+
+        url = reverse("knowledgetest:create")
+        resp = self.client.post(url, data)
+        # Should re-render the form with an error
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(
+            "No questions selected",
+            str(resp.content),
+        )
+
+    def test_must_include_only_allows_creation(self):
+        """Only must-include question numbers should allow creation."""
+        code_list = list(QuestionCategory.objects.values_list("code", flat=True))
+        # Add a valid Q-number via must_include
+        data = {
+            "student": self.student.pk,
+            "pass_percentage": "100",
+            "description": "",
+            "must_include": "5, 42",
+        }
+        for code in code_list:
+            data[f"weight_{code}"] = 0
+
+        url = reverse("knowledgetest:create")
+        resp = self.client.post(url, data)
+        # Should redirect (success) because must-include provides questions
+        self.assertEqual(resp.status_code, 302)
+        # Verify template was created with the must-include questions
+        tmpl = WrittenTestTemplate.objects.filter(created_by=self.student).last()
+        self.assertIsNotNone(tmpl)
+
+    def test_non_zero_weight_allows_creation(self):
+        """At least one non-zero weight should allow creation."""
+        code_list = list(QuestionCategory.objects.values_list("code", flat=True))
+        # Set at least one weight > 0
+        data = {
+            "student": self.student.pk,
+            "pass_percentage": "100",
+            "description": "",
+            "must_include": "",
+        }
+        for code in code_list:
+            data[f"weight_{code}"] = 0
+        # Pick the first category and give it weight > 0
+        if code_list:
+            data[f"weight_{code_list[0]}"] = 1
+
+        url = reverse("knowledgetest:create")
+        resp = self.client.post(url, data)
+        # Should redirect (success)
+        self.assertEqual(resp.status_code, 302)
+
+
+class WrittenTestAssignmentDeleteTests(TestCase):
+    """Tests for deleting pending test assignments (issue #969)."""
+
+    def setUp(self):
+        self.instructor_user = User.objects.create_user(
+            username="instr-test", password="pass"
+        )
+        self.instructor.membership_status = "Full Member"
+        self.instructor.save()
+
+        self.staff_user = User.objects.create_user(
+            username="staff-test", password="pass", is_staff=True
+        )
+        self.student = User.objects.create_user(
+            username="student-delete", password="pass"
+        )
+        self.student.membership_status = "Full Member"
+        self.student.save()
+
+        # Create a test template and assignment
+        self.tmpl = WrittenTestTemplate.objects.create(
+            name="Test to Delete",
+            pass_percentage=Decimal("100"),
+            created_by=self.instructor_user,
+        )
+        self.assignment = WrittenTestAssignment.objects.create(
+            template=self.tmpl,
+            student=self.student,
+            instructor=self.instructor_user,
+        )
+        self.delete_url = reverse(
+            "knowledgetest:assignment-delete", args=[self.assignment.pk]
+        )
+
+    def test_instructor_can_delete_own_assignment(self):
+        """The assigning instructor should be able to delete their pending assignment."""
+        self.client.login(username="instr-test", password="pass")
+
+        # First GET the confirmation page
+        resp = self.client.get(self.delete_url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Confirm Deletion")
+
+        # POST to confirm deletion
+        resp = self.client.post(self.delete_url)
+        self.assertEqual(resp.status_code, 302)
+
+        # Assignment should be gone
+        self.assertFalse(
+            WrittenTestAssignment.objects.filter(pk=self.assignment.pk).exists()
+        )
+        # Template should also be gone (no remaining assignments)
+        self.assertFalse(WrittenTestTemplate.objects.filter(pk=self.tmpl.pk).exists())
+
+    def test_staff_can_delete_any_assignment(self):
+        """Staff users should be able to delete any pending assignment."""
+        self.client.login(username="staff-test", password="pass")
+
+        resp = self.client.post(self.delete_url)
+        self.assertEqual(resp.status_code, 302)
+
+        # Assignment and template should be deleted
+        self.assertFalse(
+            WrittenTestAssignment.objects.filter(pk=self.assignment.pk).exists()
+        )
+        self.assertFalse(WrittenTestTemplate.objects.filter(pk=self.tmpl.pk).exists())
+
+    def test_non_instructor_cannot_delete(self):
+        """A non-instructor, non-staff user should get 403."""
+        other_user = User.objects.create_user(username="other-test", password="pass")
+        self.client.login(username="other-test", password="pass")
+
+        resp = self.client.post(self.delete_url)
+        self.assertEqual(resp.status_code, 403)
+
+        # Assignment should still exist
+        self.assertTrue(
+            WrittenTestAssignment.objects.filter(pk=self.assignment.pk).exists()
+        )
+
+    def test_attempt_prevents_deletion(self):
+        """Assignments with attempts cannot be deleted."""
+        # Create an attempt tied to the template
+        attempt = WrittenTestAttempt.objects.create(
+            template=self.tmpl, student=self.student
+        )
+        self.assignment.attempt = attempt
+        self.assignment.save(update_fields=["attempt"])
+
+        self.client.login(username="instr-test", password="pass")
+
+        resp = self.client.post(self.delete_url)
+        # Should redirect back to pending (not delete)
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn("/pending/", resp.url)
+
+        # Assignment should still exist (cannot delete with active attempt)
+        self.assertTrue(
+            WrittenTestAssignment.objects.filter(pk=self.assignment.pk).exists()
+        )
+        # Template should also still exist
+        self.assertTrue(WrittenTestTemplate.objects.filter(pk=self.tmpl.pk).exists())
+
+    def test_delete_redirects_to_pending(self):
+        """Successful deletion redirects to the Pending Tests page."""
+        self.client.login(username="instr-test", password="pass")
+
+        resp = self.client.post(self.delete_url)
+        self.assertRedirects(
+            resp, reverse("knowledgetest:quiz-pending"), fetch_redirect_response=False
+        )
+
+    def test_student_can_delete_own_pending_assignment(self):
+        """The student who is assigned should be able to delete their own pending (unattempted) assignment."""
+        # Reset the assignment's attempt so it's still pending
+        self.assignment.attempt = None
+        self.assignment.save(update_fields=["attempt"])
+
+        self.client.login(username="student-delete", password="pass")
+
+        resp = self.client.post(self.delete_url)
+        self.assertEqual(resp.status_code, 302)
+
+        # Assignment and template should be deleted
+        self.assertFalse(
+            WrittenTestAssignment.objects.filter(pk=self.assignment.pk).exists()
+        )

--- a/knowledgetest/tests/test_knowledgetest.py
+++ b/knowledgetest/tests/test_knowledgetest.py
@@ -940,6 +940,27 @@ class ZeroQuestionTestPreventionTests(TestCase):
 
     def setUp(self):
         self.cat = QuestionCategory.objects.create(code="ZZZ", description="Test Cat")
+        # Create a couple of questions so weight-based selection and must-include Q-numbers are valid
+        Question.objects.create(
+            qnum=5,
+            category=self.cat,
+            question_text="Q5",
+            option_a="A",
+            option_b="B",
+            option_c="C",
+            option_d="D",
+            correct_answer="A",
+        )
+        Question.objects.create(
+            qnum=42,
+            category=self.cat,
+            question_text="Q42",
+            option_a="A",
+            option_b="B",
+            option_c="C",
+            option_d="D",
+            correct_answer="A",
+        )
         self.student = User.objects.create_user(
             username="student-test", password="pass"
         )
@@ -1020,8 +1041,8 @@ class WrittenTestAssignmentDeleteTests(TestCase):
         self.instructor_user = User.objects.create_user(
             username="instr-test", password="pass"
         )
-        self.instructor.membership_status = "Full Member"
-        self.instructor.save()
+        self.instructor_user.membership_status = "Full Member"
+        self.instructor_user.save()
 
         self.staff_user = User.objects.create_user(
             username="staff-test", password="pass", is_staff=True

--- a/knowledgetest/tests/test_knowledgetest.py
+++ b/knowledgetest/tests/test_knowledgetest.py
@@ -1033,6 +1033,46 @@ class ZeroQuestionTestPreventionTests(TestCase):
         # Should redirect (success)
         self.assertEqual(resp.status_code, 302)
 
+    def test_must_include_nonexistent_ids_prevented(self):
+        """Must-include with only non-existent question IDs must be rejected."""
+        code_list = list(QuestionCategory.objects.values_list("code", flat=True))
+        # Use invalid Q-numbers that don't match any existing question
+        data = {
+            "student": self.student.pk,
+            "pass_percentage": "100",
+            "description": "",
+            "must_include": "999",
+        }
+        for code in code_list:
+            data[f"weight_{code}"] = 0
+
+        url = reverse("knowledgetest:create")
+        resp = self.client.post(url, data)
+        # Should re-render the form with an error (no real questions to include)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(
+            "No questions selected",
+            str(resp.content),
+        )
+
+    def test_must_include_partial_invalid_ids_still_works(self):
+        """Must-include with some valid and some invalid IDs must still work."""
+        code_list = list(QuestionCategory.objects.values_list("code", flat=True))
+        # Mix valid (5) with invalid (999) Q-numbers
+        data = {
+            "student": self.student.pk,
+            "pass_percentage": "100",
+            "description": "",
+            "must_include": "5, 999",
+        }
+        for code in code_list:
+            data[f"weight_{code}"] = 0
+
+        url = reverse("knowledgetest:create")
+        resp = self.client.post(url, data)
+        # Should redirect (success) because at least one valid question exists
+        self.assertEqual(resp.status_code, 302)
+
 
 class WrittenTestAssignmentDeleteTests(TestCase):
     """Tests for deleting pending test assignments (issue #969)."""

--- a/knowledgetest/tests/test_knowledgetest.py
+++ b/knowledgetest/tests/test_knowledgetest.py
@@ -1085,9 +1085,12 @@ class WrittenTestAssignmentDeleteTests(TestCase):
         self.instructor_user.save()
 
         self.staff_user = User.objects.create_user(
-            username="staff-test", password="pass", is_staff=True
+            username="staff-test",
+            password="pass",
+            is_staff=True,
+            is_superuser=True,
+            membership_status="Full Member",
         )
-        self.student = User.objects.create_user(
             username="student-delete", password="pass"
         )
         self.student.membership_status = "Full Member"

--- a/knowledgetest/urls.py
+++ b/knowledgetest/urls.py
@@ -7,6 +7,7 @@ from .views import (
     InstructorRecentTestsView,
     MemberWrittenTestHistoryView,
     PendingTestsView,
+    WrittenTestAssignmentDeleteView,
     WrittenTestAttemptDeleteView,
     WrittenTestResultView,
     WrittenTestStartView,
@@ -38,5 +39,10 @@ urlpatterns = [
         "tests/<int:pk>/review/<int:student_pk>/",
         WrittenTestReviewView.as_view(),
         name="quiz-review",
+    ),
+    path(
+        "assignments/<int:pk>/delete/",
+        WrittenTestAssignmentDeleteView.as_view(),
+        name="assignment-delete",
     ),
 ]

--- a/knowledgetest/views.py
+++ b/knowledgetest/views.py
@@ -226,6 +226,15 @@ class CreateWrittenTestView(FormView):
             if data[f"weight_{code}"] > 0
         }
         total = sum(weights.values())
+
+        # Guard: prevent creation of zero-question tests (issue #969)
+        if total == 0 and len(must) == 0:
+            form.add_error(
+                None,
+                "No questions selected. Set weights for at least one category or specify must-include question numbers.",
+            )
+            return self.form_invalid(form)
+
         MAX_QUESTIONS = 50
         import random
 
@@ -633,3 +642,74 @@ class InstructorRecentTestsView(ListView):
             }
         )
         return context
+
+
+# ################################################################
+# Delete pending test assignment
+# ################################################################
+
+
+@method_decorator(active_member_required, name="dispatch")
+class WrittenTestAssignmentDeleteView(View):
+    """Allow the assigning instructor (or staff) to delete a pending test assignment."""
+
+    template_name = "written_test/delete_assignment_confirm.html"
+
+    def _check_permission(self, user, asn):
+        """Check if user can delete this assignment.
+
+        Allowed if:
+        - User is staff, OR
+        - User is the instructor who created the assignment, OR
+        - User is the student assigned AND no attempt has been made yet
+        """
+        return (
+            user.is_staff
+            or (asn.instructor and asn.instructor == user)
+            or (asn.student == user and asn.attempt is None)
+        )
+
+    def get(self, request, pk):
+        asn = get_object_or_404(WrittenTestAssignment, pk=pk)
+        if not self._check_permission(request.user, asn):
+            return HttpResponseForbidden("Not allowed to delete this assignment.")
+        # Guard against deleting assignments that have been attempted
+        if asn.attempt is not None:
+            messages.error(
+                request,
+                "This test has already been attempted and cannot be deleted. "
+                "Contact staff if you need it removed.",
+            )
+            return redirect(reverse("knowledgetest:quiz-pending"))
+        return render(
+            request,
+            self.template_name,
+            {
+                "assignment": asn,
+            },
+        )
+
+    def post(self, request, pk):
+        asn = get_object_or_404(WrittenTestAssignment, pk=pk)
+        if not self._check_permission(request.user, asn):
+            return HttpResponseForbidden("Not allowed to delete this assignment.")
+        # Guard against deleting assignments that have been attempted
+        if asn.attempt is not None:
+            messages.error(
+                request,
+                "This test has already been attempted and cannot be deleted.",
+            )
+            return redirect(reverse("knowledgetest:quiz-pending"))
+        with transaction.atomic():
+            # Delete the assignment first (cascades through to template questions via
+            # WrittenTestTemplateQuestion's CASCADE) then delete the template.
+            tmpl = asn.template
+            asn.delete()
+            if not WrittenTestAssignment.objects.filter(template=tmpl).exists():
+                # No remaining assignments for this template, delete it too
+                tmpl.delete()
+        messages.success(
+            request,
+            f"Test assignment '{tmpl.name}' has been deleted.",
+        )
+        return redirect(reverse("knowledgetest:quiz-pending"))

--- a/knowledgetest/views.py
+++ b/knowledgetest/views.py
@@ -219,7 +219,10 @@ class CreateWrittenTestView(FormView):
         if data["must_include"]:
             import re
 
-            must = [int(n) for n in re.findall(r"\d+", data["must_include"])]
+            raw = [int(n) for n in re.findall(r"\d+", data["must_include"])]
+            # Normalize to existing question IDs and de-dup (issue #969)
+            valid_qnums = set(Question.objects.values_list("pk", flat=True))
+            must = list(dict.fromkeys(n for n in raw if n in valid_qnums))
         weights = {
             code: data[f"weight_{code}"]
             for code in QuestionCategory.objects.values_list("code", flat=True)
@@ -240,8 +243,7 @@ class CreateWrittenTestView(FormView):
 
         # If too many, randomly select down to 50 (must-includes always included)
         if total + len(must) > MAX_QUESTIONS:
-            # Remove duplicates in must
-            must = list(dict.fromkeys(must))
+            # de-dup was already done above when normalizing to existing IDs
             if len(must) >= MAX_QUESTIONS:
                 must = must[:MAX_QUESTIONS]
                 weights = {}
@@ -701,10 +703,12 @@ class WrittenTestAssignmentDeleteView(View):
             )
             return redirect(reverse("knowledgetest:quiz-pending"))
         with transaction.atomic():
+            # Capture name before deleting the assignment
+            tmpl = asn.template
             # Delete the assignment. If this was the last assignment for the template,
             # also delete the template (which CASCADES to WrittenTestTemplateQuestion rows).
             asn.delete()
-            if not WrittenTestAssignment.objects.filter(template=tmpl).exists():
+            if not WrittenTestAssignment.objects.filter(template_id=tmpl.pk).exists():
                 # No remaining assignments for this template, delete it too
                 tmpl.delete()
         messages.success(

--- a/knowledgetest/views.py
+++ b/knowledgetest/views.py
@@ -701,9 +701,8 @@ class WrittenTestAssignmentDeleteView(View):
             )
             return redirect(reverse("knowledgetest:quiz-pending"))
         with transaction.atomic():
-            # Delete the assignment first (cascades through to template questions via
-            # WrittenTestTemplateQuestion's CASCADE) then delete the template.
-            tmpl = asn.template
+            # Delete the assignment. If this was the last assignment for the template,
+            # also delete the template (which CASCADES to WrittenTestTemplateQuestion rows).
             asn.delete()
             if not WrittenTestAssignment.objects.filter(template=tmpl).exists():
                 # No remaining assignments for this template, delete it too


### PR DESCRIPTION
…tion (issue #969)

Part 1: Delete pending test assignment from instructor UI
- Add WrittenTestAssignmentDeleteView with permission checks for staff, assigning instructor, and assigned student
- Add confirmation template with warning about cascading deletion
- Add delete button in pending.html (student-facing) and instructor_recent.html (instructor-facing)
- Guard against deleting assignments with existing attempts

Part 2: Prevent zero-question test creation
- Add validation in CreateWrittenTestView.form_valid() to reject tests with no questions selected
- Update create.html with live question count display and JS that disables submit button when count is zero

Tests added for both features.