### PR TITLE
deps(cryptography): bump to 50.0.0 to fix CVE-2026-69247

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ charset-normalizer==3.4.3
 click==8.3.0
 coverage==7.11.0
 crispy-bootstrap4==2025.6
-cryptography==48.0.1
+cryptography==50.0.0
 cyclonedx-python-lib==9.1.0
 defusedxml==0.7.1
 diff-match-patch==20241021


### PR DESCRIPTION
## What

Bump `cryptography` from **48.0.1** → **50.0.0** in `requirements.txt`.

## Why

[**CVE-2026-69247** (GHSA-g6cj-pr64-35w5)](https://github.com/pietbarber/Manage2Soar/security/dependabot/83) — PKCS#7 EnvelopedData decryption exposes a **Bleichenbacher oracle** through distinguishable errors and timing in `pkcs7_decrypt_der`, `pkcs7_decrypt_pem`, and `pkcs7_decrypt_smime`.

Fixed in 50.0.0. This is the latest available release.

## Validation

- Installed 50.0.0 locally — import succeeds with no warnings
- **2297 tests passed** (1 pre-existing failure unrelated to this change — `EMAIL_DEV_MODE_REDIRECT_TO` config issue)
- All pre-commit hooks pass (safety, black, isort, trim-trailing-whitespace, etc.)

## Risk / rollout

- Transitive dependency upgrade only (no direct imports of `cryptography` in project code)
- 50.0.0 is the latest stable release
- Reversible: pin back to 48.0.1 if needed
