### PR TITLE
feat(notification): implement deduplication for aging-logsheet notifi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,6 @@ infrastructure/ansible/group_vars/gcs_*/vault.yml
 infrastructure/ansible/group_vars/gcs_*/vars.yml
 .env.backup
 infrastructure/ansible/group_vars/all/vault.yml
+
+.mcp.json
+.claude.json

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -41,7 +41,9 @@ def test_ledger_list_requires_treasurer(client, member, treasurer):
     assert "Member Billing" in response.content.decode()
 
 
-def test_non_treasurer_cannot_access_treasurer_ledger_endpoints(client, member, treasurer):
+def test_non_treasurer_cannot_access_treasurer_ledger_endpoints(
+    client, member, treasurer
+):
     other_member = Member.objects.create_user(
         username="other-billing-member", is_active=True, membership_status="Full Member"
     )
@@ -80,8 +82,8 @@ def test_non_treasurer_cannot_access_treasurer_ledger_endpoints(client, member, 
         ).status_code
         == 403
     )
-entry.refresh_from_db()
-assert not LedgerEntry.objects.filter(reverses=entry).exists()
+    entry.refresh_from_db()
+    assert not LedgerEntry.objects.filter(reverses=entry).exists()
     assert not LedgerEntry.objects.filter(
         ledger__member=member, member_description="Unauthorized charge"
     ).exists()

--- a/duty_roster/management/commands/notify_aging_logsheets.py
+++ b/duty_roster/management/commands/notify_aging_logsheets.py
@@ -8,14 +8,13 @@ from django.utils.timezone import now
 from duty_roster.utils.email import get_email_config
 from logsheet.models import Logsheet
 from notifications.models import Notification
-
-# Stable fragment used to identify aging-logsheet notifications for deduplication
-_AGING_MSG_FRAGMENT = "aging logsheet"
-
 from utils.email import send_mail
 from utils.email_helpers import get_absolute_club_logo_url
 from utils.management.commands.base_cronjob import BaseCronJobCommand
 from utils.url_helpers import build_absolute_url
+
+# Canonical fragment used to identify aging-logsheet notifications for deduplication
+_AGING_MSG_FRAGMENT = "aging logsheet"
 
 
 class Command(BaseCronJobCommand):
@@ -124,7 +123,7 @@ class Command(BaseCronJobCommand):
             dismissed=False,
             message__icontains=_AGING_MSG_FRAGMENT,
             url="/logsheet/",
-        )
+        ).order_by("-created_at")
 
         if not candidates.exists():
             return Notification.objects.create(
@@ -133,14 +132,16 @@ class Command(BaseCronJobCommand):
                 url="/logsheet/",
             )
 
-        # Sort newest-first; the first entry is the canonical notification.
-        sorted_candidates = sorted(candidates, key=lambda n: n.created_at, reverse=True)
-        canonical = sorted_candidates[0]
-        extras = sorted_candidates[1:]
-
-        if extras:
-            extra_ids = [n.id for n in extras]
-            Notification.objects.filter(id__in=extra_ids).delete()
+        canonical = candidates.first()
+        if canonical is None:
+            return Notification.objects.create(
+                user=member,
+                message=f"You have {count} aging logsheet(s) that need finalization",
+                url="/logsheet/",
+            )
+        extras_to_remove = candidates.exclude(pk=canonical.pk)
+        if extras_to_remove.exists():
+            extras_to_remove.delete()
 
         new_message = f"You have {count} aging logsheet(s) that need finalization"
         if canonical.message != new_message:

--- a/duty_roster/management/commands/notify_aging_logsheets.py
+++ b/duty_roster/management/commands/notify_aging_logsheets.py
@@ -1,3 +1,5 @@
+"""Management command to notify duty officers about aging (unfinalized) logsheets."""
+
 from datetime import timedelta
 
 from django.template.loader import render_to_string
@@ -6,6 +8,10 @@ from django.utils.timezone import now
 from duty_roster.utils.email import get_email_config
 from logsheet.models import Logsheet
 from notifications.models import Notification
+
+# Stable fragment used to identify aging-logsheet notifications for deduplication
+_AGING_MSG_FRAGMENT = "aging logsheet"
+
 from utils.email import send_mail
 from utils.email_helpers import get_absolute_club_logo_url
 from utils.management.commands.base_cronjob import BaseCronJobCommand
@@ -13,11 +19,14 @@ from utils.url_helpers import build_absolute_url
 
 
 class Command(BaseCronJobCommand):
+    """Notify duty officers about logsheets that are 7+ days old and not finalized."""
+
     help = "Notify duty officers about logsheets that are 7+ days old and not finalized"
     job_name = "notify_aging_logsheets"
     max_execution_time = timedelta(minutes=15)  # Should be quick operation
 
     def add_arguments(self, parser):
+        """Add command-line arguments to the argument parser."""
         super().add_arguments(parser)
         parser.add_argument(
             "--days",
@@ -27,6 +36,7 @@ class Command(BaseCronJobCommand):
         )
 
     def execute_job(self, *args, **options):
+        """Execute the aging logsheet notification command."""
         aging_days = options.get("days", 7)
         cutoff_date = now() - timedelta(days=aging_days)
 
@@ -95,8 +105,51 @@ class Command(BaseCronJobCommand):
         else:
             self.log_info("No notifications sent (dry run mode)")
 
+    def _upsert_aging_notification(self, member, count):
+        """Maintain exactly one undismissed aging-logsheet notification per member.
+
+        If no such notification exists, creates one.  If one or more exist,
+        keeps only the latest (by ``created_at``), updates its message with the
+        current count, and deletes any extras.
+
+        Args:
+            member: The Member instance to notify.
+            count: Number of aging logsheets to display in the message.
+
+        Returns:
+            The canonical (kept or created) Notification instance.
+        """
+        candidates = Notification.objects.filter(
+            user=member,
+            dismissed=False,
+            message__icontains=_AGING_MSG_FRAGMENT,
+            url="/logsheet/",
+        )
+
+        if not candidates.exists():
+            return Notification.objects.create(
+                user=member,
+                message=f"You have {count} aging logsheet(s) that need finalization",
+                url="/logsheet/",
+            )
+
+        # Sort newest-first; the first entry is the canonical notification.
+        sorted_candidates = sorted(candidates, key=lambda n: n.created_at, reverse=True)
+        canonical = sorted_candidates[0]
+        extras = sorted_candidates[1:]
+
+        if extras:
+            extra_ids = [n.id for n in extras]
+            Notification.objects.filter(id__in=extra_ids).delete()
+
+        new_message = f"You have {count} aging logsheet(s) that need finalization"
+        if canonical.message != new_message:
+            canonical.message = new_message
+            canonical.save(update_fields=["message"])
+        return canonical
+
     def _send_notification(self, member, logsheet_data):
-        """Send email and in-app notification to a duty officer about aging logsheets"""
+        """Send email and in-app notification to a duty officer about aging logsheets."""
 
         # Build email content
         logsheet_list = []
@@ -151,12 +204,10 @@ class Command(BaseCronJobCommand):
             )
 
         try:
-            # Always attempt in-app notification, even if email delivery fails.
-            Notification.objects.create(
-                user=member,
-                message=f"You have {len(logsheet_data)} aging logsheet(s) that need finalization",
-                url="/logsheet/",
-            )
+            # Upsert a single canonical in-app notification per user.
+            # Each cron run maintains exactly one undismissed aging-logsheet
+            # notification per member, updating the count instead of stacking.
+            self._upsert_aging_notification(member, len(logsheet_data))
             in_app_sent = True
         except Exception as e:
             self.log_error(

--- a/duty_roster/tests/test_duty_swap.py
+++ b/duty_roster/tests/test_duty_swap.py
@@ -67,6 +67,13 @@ def site_config(db):
 
 
 @pytest.fixture
+def email_dev_mode_disabled(settings):
+    """Disable email dev mode redirects for tests that assert direct recipients."""
+    settings.EMAIL_DEV_MODE = False
+    settings.EMAIL_DEV_MODE_REDIRECT_TO = ""
+
+
+@pytest.fixture
 def alice(db):
     """Create member Alice who will request a swap."""
     return Member.objects.create(
@@ -855,7 +862,7 @@ class TestSwapRequestCreation:
 
 
 @pytest.mark.django_db
-@override_settings(EMAIL_DEV_MODE=False)
+@pytest.mark.usefixtures("email_dev_mode_disabled")
 class TestSwapOfferWorkflow:
     """Tests for swap offer workflow."""
 

--- a/duty_roster/tests/test_instruction_request_emails.py
+++ b/duty_roster/tests/test_instruction_request_emails.py
@@ -12,7 +12,6 @@ from datetime import date, timedelta
 
 import pytest
 from django.core import mail
-from django.test.utils import override_settings
 from django.utils import timezone
 
 from duty_roster.models import DutyAssignment, InstructionSlot
@@ -134,8 +133,15 @@ def duty_assignment(instructor, db):
     )
 
 
+@pytest.fixture
+def email_dev_mode_disabled(settings):
+    """Disable email dev mode redirects for template/content email assertions."""
+    settings.EMAIL_DEV_MODE = False
+    settings.EMAIL_DEV_MODE_REDIRECT_TO = ""
+
+
 @pytest.mark.django_db
-@override_settings(EMAIL_DEV_MODE=False)
+@pytest.mark.usefixtures("email_dev_mode_disabled")
 class TestStudentInstructionRequestEmail:
     """Tests for student instruction request emails (with progress)."""
 
@@ -220,7 +226,7 @@ class TestStudentInstructionRequestEmail:
 
 
 @pytest.mark.django_db
-@override_settings(EMAIL_DEV_MODE=False)
+@pytest.mark.usefixtures("email_dev_mode_disabled")
 class TestRatedPilotInstructionRequestEmail:
     """Tests for rated pilot instruction request emails (with currency)."""
 
@@ -401,7 +407,7 @@ class TestRatedPilotInstructionRequestEmail:
 
 
 @pytest.mark.django_db
-@override_settings(EMAIL_DEV_MODE=False)
+@pytest.mark.usefixtures("email_dev_mode_disabled")
 class TestEmailContent:
     """Tests for general email content."""
 
@@ -472,7 +478,7 @@ class TestEmailContent:
 
 
 @pytest.mark.django_db
-@override_settings(EMAIL_DEV_MODE=False)
+@pytest.mark.usefixtures("email_dev_mode_disabled")
 class TestInstructionRequestDetails:
     """Tests for instruction request type and notes fields (Issue #464)."""
 

--- a/knowledgetest/tests/test_knowledgetest.py
+++ b/knowledgetest/tests/test_knowledgetest.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.shortcuts import resolve_url
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -719,18 +719,19 @@ class TestPresetViewIntegrationTests(TestCase):
         if Notification is not None:
             Notification.objects.all().delete()
 
-        response = self.client.post(
-            reverse("knowledgetest:create"),
-            {
-                "student": self.other_member.pk,
-                "pass_percentage": "100",
-                "description": "Assigned integration",
-                "must_include": "",
-                "weight_GF": "1",
-                "weight_ST": "0",
-            },
-            follow=False,
-        )
+        with override_settings(EMAIL_DEV_MODE_REDIRECT_TO="dev-null@example.com"):
+            response = self.client.post(
+                reverse("knowledgetest:create"),
+                {
+                    "student": self.other_member.pk,
+                    "pass_percentage": "100",
+                    "description": "Assigned integration",
+                    "must_include": "",
+                    "weight_GF": "1",
+                    "weight_ST": "0",
+                },
+                follow=False,
+            )
 
         self.assertEqual(response.status_code, 302)
         template = WrittenTestTemplate.objects.latest("pk")

--- a/utils/tests/test_notification_commands.py
+++ b/utils/tests/test_notification_commands.py
@@ -819,10 +819,6 @@ class TestCronJobIntegration(TransactionTestCase):
 class TestNotificationDedupe(TransactionTestCase):
     """Test deduplication of aging-logsheet notifications (issue #1005)."""
 
-    def setUp(self):
-        self.airfield = Airfield.objects.create(identifier="TST", name="Test")
-        self.cutoff = timezone.now() - timedelta(days=15)
-
     def test_dedupe_ignores_non_aging_notifications(self):
         """Non-aging notifications for the same member must survive dedup."""
         member = Member.objects.create(
@@ -874,7 +870,7 @@ class TestNotificationDedupe(TransactionTestCase):
         self.assertEqual(
             result.message, "You have 1 aging logsheet(s) that need finalization"
         )
-        self.assertIn(member.notifications.count(), [0, 1])
+        self.assertEqual(member.notifications.count(), 1)
 
     def test_upsert_updates_count(self):
         """When one aging notification exists, its count is updated."""

--- a/utils/tests/test_notification_commands.py
+++ b/utils/tests/test_notification_commands.py
@@ -814,3 +814,113 @@ class TestCronJobIntegration(TransactionTestCase):
 
         # High verbosity should produce more output
         assert len(high_output) >= len(low_output)
+
+
+class TestNotificationDedupe(TransactionTestCase):
+    """Test deduplication of aging-logsheet notifications (issue #1005)."""
+
+    def setUp(self):
+        self.airfield = Airfield.objects.create(identifier="TST", name="Test")
+        self.cutoff = timezone.now() - timedelta(days=15)
+
+    def test_dedupe_ignores_non_aging_notifications(self):
+        """Non-aging notifications for the same member must survive dedup."""
+        member = Member.objects.create(
+            username="iso_test",
+            email="iso@test.com",
+            first_name="Iso",
+            last_name="Test",
+        )
+
+        # Create a non-aging notification that should NOT be affected
+        Notification.objects.create(
+            user=member, message="Other important notice", url="/other/"
+        )
+        count_before = Notification.objects.filter(user=member).count()
+
+        # Also create aging notifications to dedupe
+        self._create_aging_notifications(member, count=2)
+        total_before = Notification.objects.count()  # non-aging + 2 aging
+
+        command = AgingLogsheetsCommand()
+
+        # Directly test dedup behavior (dedup logic doesn't depend on log sheet data)
+        with patch("sys.stdout", new_callable=StringIO):
+            command._upsert_aging_notification(member, count=3)
+
+        # The non-aging notification must still exist
+        other = Notification.objects.filter(
+            user=member, message__icontains="Other important notice"
+        )
+        self.assertTrue(other.exists())
+
+        # Total should be: 1 non-aging + 1 deduped aging = total_before - 1
+        remaining_for_user = Notification.objects.filter(user=member)
+        self.assertEqual(remaining_for_user.count(), total_before - 1)
+
+    def test_upsert_creates_when_none_exist(self):
+        """When no aging notifications exist, a new one is created."""
+        member = Member.objects.create(
+            username="create_test", email="create@test.com", first_name="Create"
+        )
+
+        self.assertEqual(Notification.objects.filter(user=member).count(), 0)
+
+        command = AgingLogsheetsCommand()
+        with patch("sys.stdout", new_callable=StringIO):
+            result = command._upsert_aging_notification(member, count=1)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            result.message, "You have 1 aging logsheet(s) that need finalization"
+        )
+        self.assertIn(member.notifications.count(), [0, 1])
+
+    def test_upsert_updates_count(self):
+        """When one aging notification exists, its count is updated."""
+        member = Member.objects.create(
+            username="update_test", email="update@test.com", first_name="Update"
+        )
+
+        # Create one aging notification with old count
+        self._create_aging_notifications(member, count=1)
+        old_notification = Notification.objects.get(user=member)
+        self.assertIn("1 aging logsheet", old_notification.message)
+
+        command = AgingLogsheetsCommand()
+        result = command._upsert_aging_notification(member, count=5)
+
+        # The same notification should be updated (not a new one created)
+        self.assertEqual(result.id, old_notification.id)
+        self.assertIn("5 aging logsheet", result.message)
+
+    def test_upsert_removes_extras(self):
+        """When multiple aging notifications exist, extras are deleted."""
+        member = Member.objects.create(
+            username="remove_test", email="remove@test.com", first_name="Remove"
+        )
+
+        self._create_aging_notifications(member, count=5)
+        self.assertEqual(Notification.objects.filter(user=member).count(), 5)
+
+        command = AgingLogsheetsCommand()
+        result = command._upsert_aging_notification(member, count=3)
+
+        # Only one notification should remain
+        remaining = Notification.objects.filter(user=member)
+        self.assertEqual(remaining.count(), 1)
+        last_remaining = remaining.first()
+        assert last_remaining is not None
+        self.assertIsNotNone(result)
+        self.assertEqual(result.id, last_remaining.id)
+
+    def _create_aging_notifications(self, member, count=3):
+        """Create *count* aging-logsheet in-app notifications for a member."""
+        base = timezone.now() - timedelta(hours=count)
+        for i in range(count):
+            Notification.objects.create(
+                user=member,
+                message=f"You have {i + 1} aging logsheet(s) that need finalization",
+                url="/logsheet/",
+                created_at=base + timedelta(hours=i),
+            )


### PR DESCRIPTION

Body
## Summary
This PR fixes notification stacking for unfinalized logsheets by ensuring each member has a single active aging-logsheet in-app notification that gets updated instead of duplicated.

Closes #1005.

## Problem
The notify_aging_logsheets cron command created a new in-app notification on each run.  
If logsheets remained unfinalized for multiple days, members accumulated repeated notifications for the same concern.

## What Changed
- Added canonical upsert behavior for aging-logsheet notifications in notify_aging_logsheets.py:
  - Match candidate notifications by user, undismissed status, message fragment, and /logsheet/ URL.
  - Create one notification when none exists.
  - Keep the newest notification as canonical when multiples exist.
  - Delete extras.
  - Update the canonical message count to current aging logsheet total.
- Updated send flow to use the new upsert path instead of unconditional create in notify_aging_logsheets.py.

## Tests Added and Updated
- Added dedicated dedupe coverage in test_notification_commands.py:
  - ignores non-aging notifications
  - creates when none exist
  - updates count on existing canonical notification
  - removes extras and leaves exactly one
- Included supporting test stability fixes in:
  - test_knowledgetest.py
  - test_views.py
  - test_duty_swap.py
  - test_instruction_request_emails.py

## Validation
- Focused dedupe tests:
  - pytest test_notification_commands.py -k TestNotificationDedupe -q
  - result: 4 passed
- Focused integration test:
  - pytest knowledgetest/tests/test_knowledgetest.py::TestPresetViewIntegrationTests::test_create_assigned_member_creates_assignment_and_notification -q
  - result: 1 passed
- Collection check:
  - pytest --collect-only -q
  - result: passes

## Impact
- Members now see one current aging-logsheet notification rather than a growing stack of duplicates.
- Existing non-aging notifications are not affected.
- Email reminder behavior remains unchanged.