### PR TITLE
feat(personal_charges): implement flight charges display and summary …

### DIFF
--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -108,7 +108,7 @@ def test_billing_navigation_is_hidden_when_disabled(client, treasurer):
     response = client.get("/")
 
     assert reverse("billing:ledger_list") not in response.content.decode()
-    assert reverse("logsheet:personal_charges") not in response.content.decode()
+    assert reverse("logsheet:personal_charges") in response.content.decode()
 
 
 def test_ledger_detail_posts_manual_charge_and_shows_audit(client, member, treasurer):

--- a/logsheet/templates/logsheet/personal_charges_summary.html
+++ b/logsheet/templates/logsheet/personal_charges_summary.html
@@ -7,6 +7,7 @@
     <a href="{% url 'logsheet:personal_charges_csv' %}" class="btn btn-outline-primary btn-sm">Export CSV</a>
   </div>
 
+  {% if billing_active %}
   <div class="card border-0 bg-body-tertiary mb-4">
     <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
       <div>
@@ -61,5 +62,83 @@
   <div class="alert alert-light border mt-4 mb-0 small" role="note">
     Questions about balances from before the ledger was introduced? Contact the treasurer.
   </div>
+  {% else %}
+  <div class="card border-0 bg-body-tertiary mb-4">
+    <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
+      <div>
+        <div class="text-uppercase text-muted small">Total charges accrued</div>
+      </div>
+      <div class="h3 mb-0 text-danger">${{ total_owed|floatformat:2 }}</div>
+    </div>
+  </div>
+
+  <div class="card border-0 shadow-sm mb-4">
+    <div class="card-header bg-light-subtle">
+      <h2 class="h5 mb-0">Flight charges</h2>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-hover table-sm align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            <th>Date</th>
+            <th>Glider</th>
+            <th class="text-end">Tow</th>
+            <th class="text-end">Rental</th>
+            <th class="text-end">Instruction</th>
+            <th class="text-end">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in flight_rows %}
+          <tr>
+            <td class="text-nowrap">{{ row.flight_date }}</td>
+            <td>{{ row.glider }}</td>
+            <td class="text-end">${{ row.tow_cost|floatformat:2 }}</td>
+            <td class="text-end">${{ row.rental_cost|floatformat:2 }}</td>
+            <td class="text-end">${{ row.instruction_cost|floatformat:2 }}</td>
+            <td class="text-end fw-semibold">${{ row.total_cost|floatformat:2 }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="6" class="text-muted text-center py-4">No operational flight charges recorded.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  {% if misc_charges %}
+  <div class="card border-0 shadow-sm">
+    <div class="card-header bg-light-subtle">
+      <h2 class="h5 mb-0">Miscellaneous charges</h2>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-hover table-sm align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            <th>Date</th>
+            <th>Item</th>
+            <th>Description</th>
+            <th class="text-end">Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for charge in misc_charges %}
+          <tr>
+            <td class="text-nowrap">{{ charge.date }}</td>
+            <td>{{ charge.chargeable_item.name }}</td>
+            <td>{{ charge.notes|default:charge.chargeable_item.name }}</td>
+            <td class="text-end fw-semibold">${{ charge.total_price|floatformat:2 }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endif %}
+
+  <div class="alert alert-light border mt-4 mb-0 small" role="note">
+    Billing is not active for this site. These are the charges you've accrued through flight operations; contact the treasurer or duty officer regarding payment.
+  </div>
+  {% endif %}
 </div>
 {% endblock %}

--- a/logsheet/tests/test_personal_charges_view.py
+++ b/logsheet/tests/test_personal_charges_view.py
@@ -155,14 +155,6 @@ class TestPersonalChargesView:
             rental_cost_actual="30.00",
             instruction_fee_actual="10.00",
         )
-        flight.is_chargeable = True
-        flight.save(
-            update_fields=[
-                "tow_cost_actual",
-                "rental_cost_actual",
-                "instruction_fee_actual",
-            ]
-        )
 
         client.force_login(self.member)
         response = client.get(reverse("logsheet:personal_charges"))
@@ -172,3 +164,12 @@ class TestPersonalChargesView:
         assert response.context["total_owed"] == Decimal("65.00")
         assert "Total charges accrued" in response.content.decode()
         assert "No ledger entries posted." not in response.content.decode()
+
+        csv_response = client.get(reverse("logsheet:personal_charges_csv"))
+        assert csv_response.status_code == 200
+        rows = list(csv.reader(StringIO(csv_response.content.decode())))
+        assert rows[0] == ["Date", "Type", "Description", "Debit", "Credit", "Balance"]
+        assert rows[1][1] == "Flight"
+        assert rows[1][3] == "65.00"
+        assert rows[1][4] == ""
+        assert rows[1][5] == ""

--- a/logsheet/tests/test_personal_charges_view.py
+++ b/logsheet/tests/test_personal_charges_view.py
@@ -7,6 +7,7 @@ import pytest
 from django.urls import reverse
 
 from billing.services import post_manual_charge, post_manual_payment
+from logsheet.models import Airfield, Flight, Glider, Logsheet, Towplane
 from members.models import Member
 from siteconfig.models import MembershipStatus, SiteConfiguration
 
@@ -116,3 +117,58 @@ class TestPersonalChargesView:
         client.force_login(self.member)
         assert client.get(reverse("logsheet:personal_charges")).status_code == 200
         assert client.get(reverse("logsheet:personal_charges_csv")).status_code == 200
+
+    def test_member_statement_uses_live_operational_charges_when_billing_is_disabled(
+        self, client
+    ):
+        self.config.billing_app_enabled = False
+        self.config.save(update_fields=["billing_app_enabled"])
+
+        airfield = Airfield.objects.create(name="Test Airfield", identifier="KTEST")
+        glider = Glider.objects.create(
+            n_number="N11111",
+            make="Test",
+            model="Glider",
+            club_owned=True,
+            is_active=True,
+        )
+        towplane = Towplane.objects.create(
+            n_number="N22222",
+            make="Tow",
+            model="Plane",
+            club_owned=True,
+            is_active=True,
+        )
+        logsheet = Logsheet.objects.create(
+            log_date=date(2026, 7, 15),
+            airfield=airfield,
+            created_by=self.member,
+            finalized=True,
+        )
+        flight = Flight.objects.create(
+            logsheet=logsheet,
+            pilot=self.member,
+            glider=glider,
+            towplane=towplane,
+            launch_time="10:00:00",
+            tow_cost_actual="25.00",
+            rental_cost_actual="30.00",
+            instruction_fee_actual="10.00",
+        )
+        flight.is_chargeable = True
+        flight.save(
+            update_fields=[
+                "tow_cost_actual",
+                "rental_cost_actual",
+                "instruction_fee_actual",
+            ]
+        )
+
+        client.force_login(self.member)
+        response = client.get(reverse("logsheet:personal_charges"))
+
+        assert response.status_code == 200
+        assert response.context["billing_active"] is False
+        assert response.context["total_owed"] == Decimal("65.00")
+        assert "Total charges accrued" in response.content.decode()
+        assert "No ledger entries posted." not in response.content.decode()

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -726,29 +726,108 @@ def stats_dump_export_download(request, pk):
 
 @active_member_required
 def personal_charges_summary(request):
-    """Show the authenticated member's immutable billing statement."""
-    from billing.models import Ledger
-    from billing.services import get_balance, get_statement_rows
+    """Show the authenticated member's ledger statement or live operational charges."""
+    site_config = SiteConfiguration.objects.first()
+    billing_app_enabled = bool(site_config and site_config.billing_app_enabled)
 
-    ledger = Ledger.objects.filter(member=request.user).first()
+    if billing_app_enabled:
+        from billing.models import Ledger
+        from billing.services import get_balance, get_statement_rows
+
+        ledger = Ledger.objects.filter(member=request.user).first()
+
+        return render(
+            request,
+            "logsheet/personal_charges_summary.html",
+            {
+                "billing_active": True,
+                "statement_rows": list(reversed(get_statement_rows(ledger))),
+                "ledger_balance": get_balance(ledger) if ledger else Decimal("0.00"),
+            },
+        )
+
+    flight_rows, misc_charges = _get_personal_charge_data(
+        request.user, date(1900, 1, 1)
+    )
+    total_owed = sum(
+        (row["total_cost"] for row in flight_rows),
+        Decimal("0.00"),
+    ) + sum((charge.total_price for charge in misc_charges), Decimal("0.00"))
 
     return render(
         request,
         "logsheet/personal_charges_summary.html",
         {
-            "statement_rows": list(reversed(get_statement_rows(ledger))),
-            "ledger_balance": get_balance(ledger) if ledger else Decimal("0.00"),
+            "billing_active": False,
+            "flight_rows": flight_rows,
+            "misc_charges": misc_charges,
+            "total_owed": total_owed,
         },
     )
 
 
 @active_member_required
 def personal_charges_summary_csv(request):
-    """Export the authenticated member's ledger statement as CSV."""
-    from billing.models import Ledger
-    from billing.services import get_statement_rows
+    """Export the authenticated member's charges as ledger or live operational data."""
+    site_config = SiteConfiguration.objects.first()
+    billing_app_enabled = bool(site_config and site_config.billing_app_enabled)
 
-    ledger = Ledger.objects.filter(member=request.user).first()
+    if billing_app_enabled:
+        from billing.models import Ledger
+        from billing.services import get_statement_rows
+
+        ledger = Ledger.objects.filter(member=request.user).first()
+
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = (
+            f'attachment; filename="personal_charges_{timezone.localdate().isoformat()}.csv"'
+        )
+
+        writer = csv.writer(response)
+        writer.writerow(["Date", "Type", "Description", "Debit", "Credit", "Balance"])
+        for row in get_statement_rows(ledger):
+            entry = row["entry"]
+            writer.writerow(
+                [
+                    entry.effective_date.isoformat(),
+                    _sanitize_csv_cell(entry.get_kind_display()),
+                    _sanitize_csv_cell(entry.member_description),
+                    f"{entry.amount:.2f}" if entry.effect == "debit" else "",
+                    f"{entry.amount:.2f}" if entry.effect == "credit" else "",
+                    f"{row['running_balance']:.2f}",
+                ]
+            )
+
+        return response
+
+    flight_rows, misc_charges = _get_personal_charge_data(
+        request.user, date(1900, 1, 1)
+    )
+    combined_rows = []
+    for row in flight_rows:
+        flight = row["flight"]
+        combined_rows.append(
+            {
+                "date": row["flight_date"],
+                "type": "Flight",
+                "description": _sanitize_csv_cell(
+                    f"{flight.glider} — tow/rental/instruction"
+                ),
+                "amount": row["total_cost"],
+            }
+        )
+    for charge in misc_charges:
+        combined_rows.append(
+            {
+                "date": charge.date,
+                "type": _sanitize_csv_cell(charge.chargeable_item.name),
+                "description": _sanitize_csv_cell(
+                    charge.notes or charge.chargeable_item.name
+                ),
+                "amount": charge.total_price,
+            }
+        )
+    combined_rows.sort(key=lambda row: row["date"], reverse=True)
 
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = (
@@ -756,17 +835,14 @@ def personal_charges_summary_csv(request):
     )
 
     writer = csv.writer(response)
-    writer.writerow(["Date", "Type", "Description", "Debit", "Credit", "Balance"])
-    for row in get_statement_rows(ledger):
-        entry = row["entry"]
+    writer.writerow(["Date", "Type", "Description", "Amount"])
+    for row in combined_rows:
         writer.writerow(
             [
-                entry.effective_date.isoformat(),
-                _sanitize_csv_cell(entry.get_kind_display()),
-                _sanitize_csv_cell(entry.member_description),
-                f"{entry.amount:.2f}" if entry.effect == "debit" else "",
-                f"{entry.amount:.2f}" if entry.effect == "credit" else "",
-                f"{row['running_balance']:.2f}",
+                row["date"].isoformat(),
+                row["type"],
+                row["description"],
+                f"{row['amount']:.2f}",
             ]
         )
 

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -835,7 +835,7 @@ def personal_charges_summary_csv(request):
     )
 
     writer = csv.writer(response)
-    writer.writerow(["Date", "Type", "Description", "Amount"])
+    writer.writerow(["Date", "Type", "Description", "Debit", "Credit", "Balance"])
     for row in combined_rows:
         writer.writerow(
             [
@@ -843,6 +843,8 @@ def personal_charges_summary_csv(request):
                 row["type"],
                 row["description"],
                 f"{row['amount']:.2f}",
+                "",
+                "",
             ]
         )
 

--- a/logsheet/views.py
+++ b/logsheet/views.py
@@ -726,7 +726,7 @@ def stats_dump_export_download(request, pk):
 
 @active_member_required
 def personal_charges_summary(request):
-    """Show the authenticated member's ledger statement or live operational charges."""
+    """Show the authenticated member's ledger statement or recent operational charges."""
     site_config = SiteConfiguration.objects.first()
     billing_app_enabled = bool(site_config and site_config.billing_app_enabled)
 
@@ -746,9 +746,15 @@ def personal_charges_summary(request):
             },
         )
 
-    flight_rows, misc_charges = _get_personal_charge_data(
-        request.user, date(1900, 1, 1)
-    )
+    days = request.GET.get("days")
+    try:
+        days = int(days) if days is not None else 365
+    except ValueError:
+        days = 365
+    days = max(1, min(days, 3650))
+    start_date = timezone.localdate() - timedelta(days=days)
+
+    flight_rows, misc_charges = _get_personal_charge_data(request.user, start_date)
     total_owed = sum(
         (row["total_cost"] for row in flight_rows),
         Decimal("0.00"),
@@ -759,6 +765,8 @@ def personal_charges_summary(request):
         "logsheet/personal_charges_summary.html",
         {
             "billing_active": False,
+            "days": days,
+            "start_date": start_date,
             "flight_rows": flight_rows,
             "misc_charges": misc_charges,
             "total_owed": total_owed,
@@ -768,7 +776,7 @@ def personal_charges_summary(request):
 
 @active_member_required
 def personal_charges_summary_csv(request):
-    """Export the authenticated member's charges as ledger or live operational data."""
+    """Export the authenticated member's charges as ledger or recent operational data."""
     site_config = SiteConfiguration.objects.first()
     billing_app_enabled = bool(site_config and site_config.billing_app_enabled)
 
@@ -800,9 +808,15 @@ def personal_charges_summary_csv(request):
 
         return response
 
-    flight_rows, misc_charges = _get_personal_charge_data(
-        request.user, date(1900, 1, 1)
-    )
+    days = request.GET.get("days")
+    try:
+        days = int(days) if days is not None else 365
+    except ValueError:
+        days = 365
+    days = max(1, min(days, 3650))
+    start_date = timezone.localdate() - timedelta(days=days)
+
+    flight_rows, misc_charges = _get_personal_charge_data(request.user, start_date)
     combined_rows = []
     for row in flight_rows:
         flight = row["flight"]

--- a/templates/base.html
+++ b/templates/base.html
@@ -336,11 +336,9 @@
               {% if user.towpilot %}
               <li><a class="dropdown-item" href="{% url 'logsheet:tow_pilot_logbook' %}">🛩️ My Tow Logbook</a></li>
               {% endif %}
-              {% if siteconfig and siteconfig.billing_app_enabled %}
               <li><a class="dropdown-item" href="{% url 'logsheet:personal_charges' %}">
                 <i class="fas fa-dollar-sign me-1"></i> My Flight Charges
               </a></li>
-              {% endif %}
               <li><a class="dropdown-item" href="{% url 'knowledgetest:quiz-pending' %}">📝 My Pending Tests</a></li>
               <li><a class="dropdown-item" href="{% url 'knowledgetest:member-test-history' %}">📊 My Test History</a></li>
               {% if not kiosk_mode %}


### PR DESCRIPTION
…for disabled billing
## Summary

Fixes #1013: When the billing app is disabled site-wide, members were unable to see their flight charges in the nav menu and dashboard. This PR ensures flight charges remain visible regardless of the billing apps enabled/disabled state.

## Changes

- **Nav visibility**: The My Flight Charges dropdown item now renders for active members unconditionally (removed billing_app_enabled guard in templates/base.html)
- **Dual-mode rendering** (logsheet/views.py): When the billing app is enabled, the existing ledger-based view continues unchanged. When disabled, it falls back to live flight-operation computation so members still see their charges.
- **New page template** (logsheet/templates/logsheet/personal_charges_summary.html): Separate HTML for operational mode when billing is off
- **Test coverage**: Regression tests added in billing/tests/test_views.py and logsheet/tests/test_personal_charges_view.py

## Testing

All targeted regression tests pass:

  source .venv/bin/activate && pytest logsheet/tests/test_personal_charges_view.py billing/tests/test_views.py -q
  10 passed, 11 warnings

## Files changed (5 files, +231 / -22 lines)

| File | Change |
|------|--------|
| templates/base.html | Removed billing_app_enabled nav guard (+2 lines removed) |
| logsheet/views.py | Added billing-agnostic flow for flight charges (+92 lines) |
| logsheet/templates/logsheet/personal_charges_summary.html | New operational-mode page (+79 lines) |
| billing/tests/test_views.py | Nav visibility regression test (+1 line) |
| logsheet/tests/test_personal_charges_view.py | Targeted regression suite (+55 lines) |

Closes #1013