### PR TITLE
fix: update Django to 5.2.16 and tablib to 3.10.0 for security fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ cyclonedx-python-lib==9.1.0
 defusedxml==0.7.1
 diff-match-patch==20241021
 distlib==0.4.0
-Django==5.2.15
+Django==5.2.16
 django-crispy-forms==2.4
 django-extensions==4.1
 django-htmx==1.23.2
@@ -124,7 +124,7 @@ social-auth-core==4.7.0
 sortedcontainers==2.4.0
 sqlparse==0.5.4
 stevedore==5.5.0
-tablib==3.8.0
+tablib==3.10.0
 tenacity==9.1.2
 text-unidecode==1.3
 tinycss2==1.5.1


### PR DESCRIPTION
## Summary
  
This PR resolves **4 open Dependabot security alerts** by updating two vulnerable dependencies:

### Dependency Updates

| Package | Previous Version | New Version | Alerts Fixed | Severity |
|---------|-----------------|-------------|--------------|----------|
| Django | 5.2.15 | 5.2.16 | 84, 85, 86 | medium/low |
| tablib | 3.8.0 | 3.10.0 | 87 | medium |

### Details

- **Django 84**: Medium severity vulnerability - Django < 5.2.16
- **Django 85**: Low severity vulnerability - Django < 5.2.16  
- **Django 86**: Medium severity vulnerability - Django < 5.2.16
- **tablib 87**: Medium severity vulnerability - tablib < 3.10.0

### Changes Made

- Updated `Django==5.2.15` → `Django==5.2.16` in requirements.txt
- Updated `tablib==3.8.0` → `tablib==3.10.0` in requirements.txt

### Verification

- ✅ All pre-commit hooks passed (bandit, safety, trim trailing whitespace, etc.)
- ✅ No additional dependencies affected
- ✅ Both packages updated to their first patched versions

### Testing

Please verify the application still functions correctly after these updates:
1. Run `python manage.py migrate` if needed
2. Run the test suite: `pytest`
3. Verify CMS content rendering and any Django-related functionality
