### PR TITLE
Fix question count showing 0 on written test creation page

### DIFF
--- a/e2e_tests/e2e/test_knowledgetest_question_count.py
+++ b/e2e_tests/e2e/test_knowledgetest_question_count.py
@@ -1,0 +1,53 @@
+"""
+E2E test for the written test creation page's live question count.
+
+Regression test: the "N questions" counter uses a JS selector that only
+matched <input> elements, but the weight fields render as <select>
+dropdowns, so the counter always showed "0 questions" even when weights
+were selected.
+"""
+
+from knowledgetest.models import Question, QuestionCategory
+
+from .conftest import DjangoPlaywrightTestCase
+
+
+class TestKnowledgeTestQuestionCount(DjangoPlaywrightTestCase):
+    def _create_category_with_questions(self, code, description, count):
+        category = QuestionCategory.objects.create(code=code, description=description)
+        for i in range(count):
+            Question.objects.create(
+                qnum=1000 + i if code == "AAA" else 2000 + i,
+                category=category,
+                question_text=f"Question {i}",
+                option_a="A",
+                option_b="B",
+                option_c="C",
+                option_d="D",
+                correct_answer="A",
+            )
+        return category
+
+    def test_question_count_updates_when_selecting_weight(self):
+        self._create_category_with_questions("AAA", "Category AAA", 10)
+
+        self.create_test_member(
+            username="instructor1", is_superuser=True, instructor=True
+        )
+        self.login(username="instructor1")
+
+        self.page.goto(f"{self.live_server_url}/instructors/tests/create/")
+        self.page.wait_for_load_state("networkidle")
+
+        count_el = self.page.locator("#question-count")
+        assert count_el.text_content().strip() == "0 questions"
+
+        self.page.select_option('select[name="weight_AAA"]', "5")
+
+        self.page.wait_for_function(
+            "document.getElementById('question-count').textContent.trim() === '5 questions'"
+        )
+        assert count_el.text_content().strip() == "5 questions"
+
+        warning_el = self.page.locator("#question-warning")
+        assert "d-none" in (warning_el.get_attribute("class") or "")

--- a/knowledgetest/templates/written_test/create.html
+++ b/knowledgetest/templates/written_test/create.html
@@ -114,7 +114,7 @@
 
 <script>
 (function() {
-  var weightFields = document.querySelectorAll('input[name^="weight_"]');
+  var weightFields = document.querySelectorAll('input[name^="weight_"], select[name^="weight_"]');
   var mustInclude = document.getElementById('id_must_include');
   var countEl = document.getElementById('question-count');
   var warningEl = document.getElementById('question-warning');
@@ -149,6 +149,7 @@
 
   weightFields.forEach(function(input) {
     input.addEventListener('input', updateCount);
+    input.addEventListener('change', updateCount);
   });
   if (mustInclude) {
     mustInclude.addEventListener('input', updateCount);


### PR DESCRIPTION
Weight fields render as <select> dropdowns (forms.Select widget) but the JS live counter only queried 'input[name^="weight_"]', so selected weights were never counted and the page always showed '0 questions' even with valid selections.

- Update selector to also match select[name^="weight_"]
- Listen for both 'input' and 'change' events on the fields
- Add Playwright E2E test covering the live counter behavior