### PR TITLE
fix(security): bump sqlparse 0.5.4 → 0.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -122,7 +122,7 @@ sniffio==1.3.1
 social-auth-app-django==5.6.0
 social-auth-core==4.7.0
 sortedcontainers==2.4.0
-sqlparse==0.5.4
+sqlparse==0.6.0
 stevedore==5.5.0
 tablib==3.10.0
 tenacity==9.1.2


### PR DESCRIPTION
## Summary
Bumps the transitive dependency `sqlparse` (required by Django) from **0.5.4 → 0.6.0**, resolving the new high-severity ReDoS vulnerability.

## Vulnerability
- **CVE-2026-59893** — ReDoS (CWE-1333) in the dollar-quoted literal / multiline comment regex (`sqlparse/keywords.py`).
- CVSS 7.5 (AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H) — a crafted SQL string can cause a denial of service in any app that parses SQL with the vulnerable version.
- Fixed in **0.6.0**.

## Closes
- Dependabot alerts # 88, # 89, # 90, # 91 (3 high, 1 moderate).

## Verification
- `pip install sqlparse==0.6.0` — installed cleanly.
- `python manage.py check` — no issues.
- `pytest cms/tests/` — **214 passed**.
- Advisory ReDoS payload (`"$" + "\\"*100 + "'"`) now parses in **~7 ms** (it hung/unbounded on 0.5.4).
- Confirmed `requirements.txt` is the only place pinning `sqlparse` in the repo.
- All pre-commit hooks passed, including `safety`.

## Risk
Low. `sqlparse` is a transitive dependency of Django (used for SQL parsing/query logging). The only change is a one-line version pin; 0.6.0 is the latest release and passes the project's checks and tests.