### PR TITLE
Add portable knowledge-test seed (question bank) with import/refresh tooling

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -11,6 +11,7 @@ This directory contains operational runbooks for system administrators managing 
 | [Deployment & Updates](deployment-updates.md) | Deploy new versions, rollbacks, zero-downtime updates | Weekly deployments, hotfixes |
 | [Troubleshooting Guide](troubleshooting.md) | Common issues and solutions | Production incidents |
 | [Training Syllabus Import](syllabus-import.md) | Copy a known-good syllabus from one tenant to an empty tenant | Onboarding a new club's curriculum |
+| [Knowledge Test Bank Import](knowledge-test-import.md) | Copy the written-test question bank (questions, templates, presets) from one tenant to another | Onboarding a new club's test bank |
 | [Ansible Playbook Guide](ansible-playbook-guide.md) | Complete reference for all Ansible playbooks | Reference |
 | [Database Operations](database-operations.md) | PostgreSQL backups, restoration, troubleshooting | Database changes, disaster recovery |
 | Security Operations *(coming soon)* | Secret rotation, vulnerability patching | Security incidents, monthly maintenance |

--- a/docs/runbooks/knowledge-test-import.md
+++ b/docs/runbooks/knowledge-test-import.md
@@ -52,9 +52,10 @@ unresolvable FK. The **refresh script sanitizes them at capture time**:
 | `Question.updated_by` (FK→`Member`) | Question | Member PK only valid in source tenant | set to `null` |
 | `WrittenTestTemplate.created_by` (FK→`User`) | WrittenTestTemplate | User PK only valid in source tenant | set to `null` |
 | `Question.media` (FileField) | Question | per-tenant GCS path (`{CLUB_PREFIX}/media/...`) | set to empty |
+| `WrittenTestTemplate.name` (display title) | WrittenTestTemplate | source names embed instructor names (e.g. "Test by <name> on <date>") | generalized to `Written test <pk>`; the meaningful test type is retained in the preserved `description` |
 
 Because of this, the seed loads cleanly into **any** tenant with no dangling
-`Member`/`User`/file references. **Trade-off:** the target tenant loses the
+`Member`/`User`/file references and no leaked source-club instructor names. **Trade-off:** the target tenant loses the
 "last updated by" attribution and any question images/files — a club that needs
 question media must upload it locally after import (there is no way to copy a
 per-tenant GCS object into another tenant's GCS layout from this seed).

--- a/docs/runbooks/knowledge-test-import.md
+++ b/docs/runbooks/knowledge-test-import.md
@@ -1,0 +1,284 @@
+# Knowledge Test Bank Import Runbook
+
+This runbook explains how to copy the **knowledge test "test bank"** (the large
+corpus of written-test questions, categories, test templates, and presets) out
+of one tenant (the reference `tenant-ssc` cluster) and import it into
+**another** tenant.
+
+It follows the **IaC-first** philosophy: the seed fixtures and the import/refresh
+scripts live **in the repo** so the operation is reproducible, reviewable, and
+does not depend on copying files around by hand.
+
+> This mirrors the [Training Syllabus Import](syllabus-import.md) runbook. The
+> two seeds are independent and do not interfere with each other.
+
+## 🎯 Quick Reference
+
+| Operation | Command |
+|-----------|---------|
+| **Refresh the repo seed from a source tenant** | `bash loaddata/knowledge-test-demo/refresh_seed_from_tenant.sh` |
+| Refresh from a specific source tenant | `bash loaddata/knowledge-test-demo/refresh_seed_from_tenant.sh tenant-ssc` |
+| **Import into an empty tenant (safe, recommended)** | `bash loaddata/knowledge-test-demo/import_knowledge_test_demo.sh` |
+| Force-load (upsert, **no delete**) | `bash loaddata/knowledge-test-demo/import_knowledge_test_demo.sh --force` |
+
+## What "the knowledge test bank" is
+
+The written-test engine is modeled by five models in the `knowledgetest` app.
+Four of them are **club-owned content** and safe to move between tenants; the
+fifth set (attempts/answers/assignments) is **member-specific history** and is
+**excluded** from this seed.
+
+| Model | Purpose | Row count in this seed |
+|-------|---------|------------------------|
+| `knowledgetest.QuestionCategory` | Categories/topics a question belongs to (PK = `code`) | 15 |
+| `knowledgetest.Question` | Individual questions (A–D, HTML, explanation) | 276 |
+| `knowledgetest.WrittenTestTemplate` | Named test templates (pass %, time limit) | 44 |
+| `knowledgetest.WrittenTestTemplateQuestion` | M2M through-table linking templates → questions (ordered) | 1752 |
+| `knowledgetest.TestPreset` | Presets of category weights (e.g. "Pilot") | 5 |
+
+> ⚠️ **Excluded (member-specific):** `WrittenTestAttempt`, `WrittenTestAnswer`,
+> `WrittenTestAssignment`. These record a *member's* performance and are tied to
+> `Member`/`User` rows that do not exist in the target tenant. Do **not** include
+> them when moving a test bank between clubs.
+
+## Cross-tenant sanitization (why this seed is portable)
+
+Two `knowledgetest` models point at identities that only exist in the **source**
+tenant. If left as-is, `loaddata` in another tenant would fail with an
+unresolvable FK. The **refresh script sanitizes them at capture time**:
+
+| Field | Model | Problem | Sanitization |
+|-------|-------|---------|--------------|
+| `Question.updated_by` (FK→`Member`) | Question | Member PK only valid in source tenant | set to `null` |
+| `WrittenTestTemplate.created_by` (FK→`User`) | WrittenTestTemplate | User PK only valid in source tenant | set to `null` |
+| `Question.media` (FileField) | Question | per-tenant GCS path (`{CLUB_PREFIX}/media/...`) | set to empty |
+
+Because of this, the seed loads cleanly into **any** tenant with no dangling
+`Member`/`User`/file references. **Trade-off:** the target tenant loses the
+"last updated by" attribution and any question images/files — a club that needs
+question media must upload it locally after import (there is no way to copy a
+per-tenant GCS object into another tenant's GCS layout from this seed).
+
+## Repo layout
+
+```
+loaddata/knowledge-test-demo/
+├── import_knowledge_test_demo.sh          # safe import script (preflight + load + verify)
+├── refresh_seed_from_tenant.sh            # refresh repo fixtures from a source tenant (with sanitization)
+├── knowledgetest.QuestionCategory.json    # 15 categories
+├── knowledgetest.Question.json            # 276 questions
+├── knowledgetest.WrittenTestTemplate.json # 44 templates
+├── knowledgetest.WrittenTestTemplateQuestion.json  # 1752 through-rows
+└── knowledgetest.TestPreset.json          # 5 presets
+```
+
+This is a **separate, named seed set**. Do not confuse it with the old
+`loaddata/knowledgetest_dump.json` (Issue #19), which **is not** portable (it
+carries `updated_by` Member PKs) and should not be used for cross-tenant import.
+
+---
+
+## Step 0 — Prerequisites
+
+- `kubectl` authenticated to the GKE cluster
+  (`gcloud auth login` + `gcloud container clusters get-credentials
+  manage2soar-cluster --region us-east1`).
+- You know the **target** tenant's namespace (e.g. `tenant-masa`) and, if
+  refreshing, the **source** tenant's namespace (default `tenant-ssc`).
+
+### Find a tenant's app pod
+
+```bash
+NS=tenant-masa   # <-- the tenant you mean
+POD=$(kubectl get pods -n "$NS" -o name \
+  | grep -E 'django-app' \
+  | grep -vE 'clearsessions|expire|notify|process|send|cron' \
+  | head -1 | sed -E 's#^pods?/##')
+```
+
+The long-running pod (not the cronjob one-shots) is the one to `exec` into. The
+Django container is named `django`.
+
+---
+
+## Step 1 — Refresh the repo seed from a source tenant
+
+Only needed **if you are (re)capturing** the seed (e.g. `tenant-ssc` added
+questions, or you want to seed from a different source club). The fixtures
+already committed in `loaddata/knowledge-test-demo/` were captured from
+`tenant-ssc`.
+
+```bash
+# From the default source (tenant-ssc):
+bash loaddata/knowledge-test-demo/refresh_seed_from_tenant.sh
+
+# Or from an explicit source namespace:
+bash loaddata/knowledge-test-demo/refresh_seed_from_tenant.sh tenant-ssc
+```
+
+The script:
+
+1. Dumps the five models via `dumpdata` **inside the source tenant's app pod**
+   (so DB credentials are correct), without `--natural-foreign` (deliberate —
+   FKs stay integer PKs so they can be nulled).
+2. Copies the JSON out with `kubectl cp`.
+3. **Sanitizes** (`updated_by`/`created_by` → null, `media` → empty) and prints
+   how many of each were nulled/stripped.
+4. Prints before/after object counts.
+
+It does **not** commit. Review the diff, then commit via a feature branch + PR
+(**never** push to `main` directly).
+
+---
+
+## Step 2 — Import into the target tenant
+
+The import script is **safe-by-default**. It:
+
+1. **Preflights**: counts the five models in the **target** tenant.
+2. **Aborts** (exit code 3) if the target already has questions, unless you pass
+   `--force`.
+3. Loads the five fixtures in dependency order
+   (Category → Question → Template → Through → Preset).
+4. **Verifies** that every fixture primary key is now present in the target, and
+   prints the resulting counts.
+
+### Recommended: run inside the target tenant's app pod
+
+```bash
+NS=tenant-masa   # <-- target tenant
+POD=$(kubectl get pods -n "$NS" -o name | grep -E 'django-app' \
+  | grep -vE 'clearsessions|expire|notify|process|send|cron' | head -1 | sed -E 's#^pods?/##')
+
+# The deployed image does not always ship the repo's loaddata/ tree, so copy it in:
+kubectl cp "loaddata/knowledge-test-demo" "$NS/$POD:/tmp/kseed" -c django
+
+kubectl exec -n "$NS" -c django "$POD" -- \
+  bash /tmp/kseed/import_knowledge_test_demo.sh
+```
+
+Expected output on a clean (empty) target:
+
+```
+==> Preflight: checking that the target tenant has no existing test bank
+    QuestionCategory:            0
+    Question:                    0
+    WrittenTestTemplate:         0
+    WrittenTestTemplateQuestion: 0
+    TestPreset:                  0
+
+==> Loading test bank fixtures (dependency order)
+    loaddata knowledgetest.QuestionCategory.json
+    ...
+==> Verifying that every fixture primary key is now present in the target
+                      QuestionCategory: fixture=15 present=   15  all_present=True
+                              Question: fixture=276 present=  276  all_present=True
+                   WrittenTestTemplate: fixture=44 present=   44  all_present=True
+           WrittenTestTemplateQuestion: fixture=1752 present= 1752  all_present=True
+                            TestPreset: fixture=5 present=    5  all_present=True
+
+==> Done. Knowledge test bank import complete.
+```
+
+Expected output on a tenant that **already** has a test bank (script refuses):
+
+```
+==> Preflight: checking that the target tenant has no existing test bank
+    QuestionCategory:            16
+    Question:                    276
+    ...
+
+ABORT: This tenant already has a knowledge test bank (276 questions).
+This script is meant for an EMPTY test bank.
+
+If you are absolutely sure you want to overwrite it, re-run with --force.
+NOTE: --force upserts by primary key and does NOT delete extra rows.
+```
+
+> 🖊️ **Per-club review:** the seed is the *reference club's* test bank. After
+> import, the receiving club **must review** categories, questions, templates,
+> and presets in the admin (`knowledgetest`) and adjust wording/answers to their
+> own syllabus and standards before using it to grade members.
+
+---
+
+## Rollback
+
+**Destructive delete** — confirm the target tenant is the right one first.
+Delete children before parents to respect FK constraints (the M2M through-table
+references both templates and questions).
+
+```bash
+NS=tenant-masa
+POD=$(kubectl get pods -n "$NS" -o name | grep -E 'django-app' \
+  | grep -vE 'clearsessions|expire|notify|process|send|cron' | head -1 | sed -E 's#^pods?/##')
+
+kubectl exec -n "$NS" -c django "$POD" -- python manage.py shell -c '
+from knowledgetest.models import (
+    WrittenTestTemplateQuestion, WrittenTestTemplate,
+    Question, QuestionCategory,
+)
+# Order matters: through-table first, then templates, then questions, then categories.
+WrittenTestTemplateQuestion.objects.delete()
+WrittenTestTemplate.objects.delete()
+Question.objects.delete()
+QuestionCategory.objects.delete()
+print("rolled back")
+'
+```
+
+> If the target tenant had **its own** pre-existing test bank that you upserted
+> over with `--force`, this rollback will also delete the club's original rows —
+> there is no way to distinguish them afterward. Prefer testing `--force` against
+> a scratch/demo tenant first.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `container django-app-demo is not valid for pod ...` | Wrong `-c` container name | Use `-c django` (container is named `django`) |
+| `ABORT: This tenant already has a knowledge test bank` | Target is not empty | Intended protection. Use `--force` only if you truly want an upsert, or roll back first. |
+| `django.core.exceptions.ImproperlyConfigured` | Ran `manage.py` without the tenant env | Run **inside** the tenant pod (env already set) — not locally with the wrong `DB_*`. |
+| `IntegrityError` on `loaddata` | Out-of-order load / stale rows | Load in the fixed order Category → Question → Template → Through → Preset; roll back and retry. |
+| `ERROR: fixture not found: ...` | Ran the script without the fixtures next to it | `kubectl cp` the whole `loaddata/knowledge-test-demo` dir first, then run the script from there. |
+| Verification shows a `missing` pk | Partial load / aborted mid-import | Roll back, re-run cleanly. |
+
+### `--force` semantics (important)
+
+`loaddata` **upserts by primary key**. For a non-empty target:
+
+- Fixture pks that already exist in the target are **replaced** with the fixture
+  values.
+- Target rows with pks **not** in the fixture are **left alone** (not deleted).
+- The result is a **mixture** of the target's original rows and the seed's rows.
+
+The post-load count is therefore **not** required to equal the fixture count;
+the script instead verifies that **every fixture pk is present**, which holds in
+both the empty and the collision cases.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | A fixture file is missing |
+| 2 | Unknown CLI argument |
+| 3 | Target not empty and `--force` not given |
+| 4 | Could not read pre-load counts |
+| 5 | Post-load verification failed (missing pk / unreadable counts) |
+
+---
+
+## Safety & policy reminders
+
+- **Never** commit to `main`. Use `feature/...` + PR.
+- **Never** `--force` against a tenant you are not sure about — it upserts by PK
+  and **does not delete** extra rows, so you can end up with a mixture of the
+  club's own and the seed's questions.
+- This runbook only moves **test-bank content** (categories, questions,
+  templates, presets). Member test **attempts/answers/assignments are
+  member-owned** and must not be copied between clubs.
+- After any `--force` upsert on a tenant that had its own bank, treat the result
+  as needing a **human review** before it is used to grade anyone.

--- a/loaddata/knowledge-test-demo/import_knowledge_test_demo.sh
+++ b/loaddata/knowledge-test-demo/import_knowledge_test_demo.sh
@@ -24,8 +24,15 @@
 #     target (holds whether the target started empty or with overlapping pks).
 #
 # Intended use (production / per-tenant):
-#   kubectl exec -n <tenant-ns> <app-pod> -- \
-#       bash /app/loaddata/knowledge-test-demo/import_knowledge_test_demo.sh
+#   The deployed image may not ship this repo's loaddata/ tree, so copy the
+#   seed into the pod first, then run it from the copied location:
+#     NS=<tenant-ns>
+#     POD=$(kubectl get pods -n "$NS" -o name | grep -E 'django-app' \
+#           | grep -vE 'clearsessions|expire|notify|process|send|cron' | head -1 \
+#           | sed -E 's#^pods?/##')
+#     kubectl cp "loaddata/knowledge-test-demo" "$NS/$POD:/tmp/kseed" -c django
+#     kubectl exec -n "$NS" -c django "$POD" -- bash /tmp/kseed/import_knowledge_test_demo.sh
+#   (See docs/runbooks/knowledge-test-import.md for the full walkthrough.)
 #
 # Local / dev use (with your Django env already active):
 #   bash loaddata/knowledge-test-demo/import_knowledge_test_demo.sh
@@ -171,11 +178,14 @@ for fname, model in MODELS:
 if failures:
     raise SystemExit(1)
 ' 2>&1
-)"
+)" || true
 
 echo "$VERIFY" | sed 's/^/    /'
 
-# The inner python exits non-zero on any missing pk; capture that.
+# The inner python exits non-zero on any missing pk, but the `|| true` above
+# keeps that status from tripping `set -e` (so the "MISSING pks" diagnostic
+# above is still captured into $VERIFY and printed). The all_present=True
+# checks below therefore drive the script's exit code.
 if [[ -z "$VERIFY" ]] || ! echo "$VERIFY" | grep -q "all_present=True"; then
     echo "    ERROR: at least one fixture primary key is missing from the target." >&2
     exit 5

--- a/loaddata/knowledge-test-demo/import_knowledge_test_demo.sh
+++ b/loaddata/knowledge-test-demo/import_knowledge_test_demo.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# import_knowledge_test_demo.sh
+#
+# Imports the portable knowledge-test "test bank" captured from the
+# tenant-ssc cluster (the large corpus of test questions) into the CURRENT
+# tenant (whichever DB this script's environment points at).
+#
+# The seed is ALREADY SANITIZED for cross-tenant import:
+#   * Question.updated_by            nulled  (Member only exists in source)
+#   * WrittenTestTemplate.created_by nulled  (User only exists in source)
+#   * Question.media                 nulled  (per-tenant GCS path)
+# So `loaddata` resolves cleanly against ANY tenant with no dangling Member
+# or File references.
+#
+# What it imports (dependency order):
+#   QuestionCategory -> Question -> WrittenTestTemplate ->
+#   WrittenTestTemplateQuestion (M2M through) -> TestPreset
+#
+# It is intentionally SAFE-BY-DEFAULT:
+#   * REFUSES to run if the target tenant already has a test bank (any
+#     Question rows) unless you explicitly pass --force.
+#   * Verifies after load that every fixture primary key is present in the
+#     target (holds whether the target started empty or with overlapping pks).
+#
+# Intended use (production / per-tenant):
+#   kubectl exec -n <tenant-ns> <app-pod> -- \
+#       bash /app/loaddata/knowledge-test-demo/import_knowledge_test_demo.sh
+#
+# Local / dev use (with your Django env already active):
+#   bash loaddata/knowledge-test-demo/import_knowledge_test_demo.sh
+#
+# Safety note: --force does NOT delete existing rows. loaddata upserts by
+# (model, pk); rows with the same pk are replaced, other rows are left alone.
+# If the target tenant has a genuinely different test bank you do not want to
+# clobber, do NOT use --force.
+
+set -euo pipefail
+
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        -f|--force) FORCE=1 ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg (see --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Resolve the fixture directory relative to this script, so the script works
+# both from the repo root and from inside the container image.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$SCRIPT_DIR"
+export FIXTURE_DIR
+
+# Load in dependency order (categories -> questions -> templates -> through -> presets).
+FIXTURES=(
+    "knowledgetest.QuestionCategory.json"
+    "knowledgetest.Question.json"
+    "knowledgetest.WrittenTestTemplate.json"
+    "knowledgetest.WrittenTestTemplateQuestion.json"
+    "knowledgetest.TestPreset.json"
+)
+
+for f in "${FIXTURES[@]}"; do
+    if [[ ! -f "$FIXTURE_DIR/$f" ]]; then
+        echo "ERROR: fixture not found: $FIXTURE_DIR/$f" >&2
+        exit 1
+    fi
+done
+
+echo "==> Preflight: checking that the target tenant has no existing test bank"
+
+# Django's `manage.py shell -c` prints a line like
+#     "95 objects imported automatically (use -v 2 for details)."
+# to STDOUT before our own print() runs. Filter it out so we only see the
+# five counts on a single line.
+EMPTY="$(
+    python manage.py shell -c '
+from knowledgetest.models import (
+    QuestionCategory, Question, WrittenTestTemplate,
+    WrittenTestTemplateQuestion, TestPreset,
+)
+print(
+    QuestionCategory.objects.count(),
+    Question.objects.count(),
+    WrittenTestTemplate.objects.count(),
+    WrittenTestTemplateQuestion.objects.count(),
+    TestPreset.objects.count(),
+)
+' 2>/dev/null | grep -EoE '^[0-9]+ [0-9]+ [0-9]+ [0-9]+ [0-9]+$' | head -n1 || true
+)"
+
+if [[ -z "$EMPTY" ]]; then
+    echo "    ERROR: could not read row counts from Django shell (unexpected output)." >&2
+    echo "    Refusing to proceed without a reliable empty-check." >&2
+    exit 4
+fi
+
+read -r PRE_CATS PRE_QNS PRE_TMPLS PRE_THRU PRE_PRESETS <<<"$EMPTY"
+echo "    QuestionCategory:            $PRE_CATS"
+echo "    Question:                    $PRE_QNS"
+echo "    WrittenTestTemplate:         $PRE_TMPLS"
+echo "    WrittenTestTemplateQuestion: $PRE_THRU"
+echo "    TestPreset:                  $PRE_PRESETS"
+
+# Question is the anchor for "does a test bank already exist?"
+if [[ "$PRE_QNS" -ne 0 ]]; then
+    if [[ "$FORCE" -eq 1 ]]; then
+        echo "    !! Existing test bank detected, but --force was given. Proceeding (upsert, no delete)."
+    else
+        echo
+        echo "ABORT: This tenant already has a knowledge test bank ($PRE_QNS questions)."
+        echo "This script is meant for an EMPTY test bank."
+        echo
+        echo "If you are absolutely sure you want to overwrite it, re-run with --force."
+        echo "NOTE: --force upserts by primary key and does NOT delete extra rows."
+        exit 3
+    fi
+fi
+
+echo
+echo "==> Loading test bank fixtures (dependency order)"
+for f in "${FIXTURES[@]}"; do
+    echo "    loaddata $f"
+    python manage.py loaddata "$FIXTURE_DIR/$f"
+done
+
+echo
+echo "==> Verifying that every fixture primary key is now present in the target"
+
+# `loaddata` upserts by primary key without deleting other rows. For an
+# EMPTY tenant this means post_count == fixture_count; for a NON-EMPTY
+# tenant with overlapping pks the counts will be higher than the fixture
+# (existing rows preserved) and the delta will be LOWER than the fixture
+# (overlapping pks were updated, not added). The invariant that holds for
+# BOTH cases is: every primary key from each fixture is now present in
+# the target database.
+
+VERIFY="$(
+    python manage.py shell -c '
+import json, os
+d = os.environ["FIXTURE_DIR"]
+from knowledgetest.models import (
+    QuestionCategory, Question, WrittenTestTemplate,
+    WrittenTestTemplateQuestion, TestPreset,
+)
+MODELS = [
+    ("knowledgetest.QuestionCategory.json",            QuestionCategory),
+    ("knowledgetest.Question.json",                    Question),
+    ("knowledgetest.WrittenTestTemplate.json",         WrittenTestTemplate),
+    ("knowledgetest.WrittenTestTemplateQuestion.json", WrittenTestTemplateQuestion),
+    ("knowledgetest.TestPreset.json",                  TestPreset),
+]
+failures = 0
+for fname, model in MODELS:
+    fixture_pks = {o["pk"] for o in json.load(open(os.path.join(d, fname)))}
+    present   = set(model.objects.values_list("pk", flat=True))
+    missing   = fixture_pks - present
+    updated   = fixture_pks & present
+    print(f"{model.__name__:>34}: fixture={len(fixture_pks)} present={len(present):>5}  "
+          f"all_present={not missing}")
+    if missing:
+        failures += 1
+        print(f"    MISSING pks ({len(missing)}): {sorted(missing)[:10]}")
+if failures:
+    raise SystemExit(1)
+' 2>&1
+)"
+
+echo "$VERIFY" | sed 's/^/    /'
+
+# The inner python exits non-zero on any missing pk; capture that.
+if [[ -z "$VERIFY" ]] || ! echo "$VERIFY" | grep -q "all_present=True"; then
+    echo "    ERROR: at least one fixture primary key is missing from the target." >&2
+    exit 5
+fi
+# Guard: make sure every one of the 5 models reported all_present=True.
+if ! echo "$VERIFY" | grep -c "all_present=True" | grep -q "^5$"; then
+    echo "    ERROR: not all 5 models verified." >&2
+    exit 5
+fi
+
+# Post-load counts (informational only).
+POST="$(
+    python manage.py shell -c '
+from knowledgetest.models import (
+    QuestionCategory, Question, WrittenTestTemplate,
+    WrittenTestTemplateQuestion, TestPreset,
+)
+print(
+    QuestionCategory.objects.count(),
+    Question.objects.count(),
+    WrittenTestTemplate.objects.count(),
+    WrittenTestTemplateQuestion.objects.count(),
+    TestPreset.objects.count(),
+)
+' 2>/dev/null | grep -EoE '^[0-9]+ [0-9]+ [0-9]+ [0-9]+ [0-9]+$' | head -n1 || true
+)"
+if [[ -n "$POST" ]]; then
+    read -r PC PQ PT PTH PP <<<"$POST"
+    echo
+    echo "    Post-load counts:"
+    echo "      QuestionCategory:            $PC   (pre: $PRE_CATS)"
+    echo "      Question:                    $PQ   (pre: $PRE_QNS)"
+    echo "      WrittenTestTemplate:         $PT   (pre: $PRE_TMPLS)"
+    echo "      WrittenTestTemplateQuestion: $PTH   (pre: $PRE_THRU)"
+    echo "      TestPreset:                  $PP   (pre: $PRE_PRESETS)"
+fi
+
+echo
+echo "==> Done. Knowledge test bank import complete."
+echo
+echo "NOTE: the seed is sanitized for portability. In this corpus, question"
+echo "media (images/files) and the member 'updated_by' attribution were nulled"
+echo "because they do not exist in the target tenant. If the target tenant"
+echo "had a pre-existing test bank with overlapping primary keys, those rows"
+echo "were UPDATED (not deleted) with the fixture content. Review the test"
+echo "bank in the admin to confirm the content meets this club's needs."

--- a/loaddata/knowledge-test-demo/knowledgetest.Question.json
+++ b/loaddata/knowledge-test-demo/knowledgetest.Question.json
@@ -1,0 +1,4694 @@
+[
+  {
+    "model": "knowledgetest.question",
+    "pk": 1,
+    "fields": {
+      "category": "GFH",
+      "question_text": "<p>A knot or sharp radius bend of a towline reduces rope strength by:</p>",
+      "option_a": "50%",
+      "option_b": "33%",
+      "option_c": "10%",
+      "option_d": "no appreciable reduction in strength",
+      "correct_answer": "A",
+      "explanation": "<p>\"A knot in the towline reduces its strength by up to 50 percent, and causes a high spot in the rope that is more susceptible to wear. Pay particular attention to the ring area to which the glider attaches because this is also a high-wear area.\"&nbsp;<a href=\"http://skylinesoaring.org/docs/Training_GFH-FAA_8083-13a.pdf\">Glider Flying Handbook</a>&nbsp;(2013), page 5-5 &nbsp;</p>",
+      "last_updated": "2013-09-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 2,
+    "fields": {
+      "category": "GF",
+      "question_text": "The primary function of the rudder is to:",
+      "option_a": "turn the glider",
+      "option_b": "counteract aileron drag",
+      "option_c": "assist in recovery from stalls and spins",
+      "option_d": "provide extra propulsion at the beginning of the aerotow",
+      "correct_answer": "B",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/\">Glider Flying Handbook, page 3-12</a>  </p><p>When you roll into a turn, the aileron on the inside of the turn is raised and the aileron on the outside of the turn is lowered. The lowered aileron on the outside increases the angle of attack and produces more lift for that wing. Since induced drag is a by-product of lift, the outside wing also produces more drag than the inside wing. This causes a yawing tendency toward the outside of the turn called adverse yaw. Coordinated use of rudder and aileron corrects for adverse yaw and aileron drag.<br /></p>",
+      "last_updated": "2011-04-27",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 3,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "What is the indicated never-exceed speed of the ASK-21 when flying at 20,000 feet MSL?",
+      "option_a": "151 knots",
+      "option_b": "144 knots",
+      "option_c": "132 knots",
+      "option_d": "121 knots",
+      "correct_answer": "D",
+      "explanation": "<p>V<sub>NE</sub> is determined by flight testing and depends on the structural characteristics of an aircraft under varying aerodynamic conditions.&nbsp; For most gliders, the never-exceed speed drops off significantly above 5000 MSL, but the actual limits are as specified in the Pilot Operating Handbook or equivalent document.&nbsp; These limits are also included for convenience in the SSC cockpit cards.</p>",
+      "last_updated": "2011-09-06",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 4,
+    "fields": {
+      "category": "WX",
+      "question_text": "A small wisp of a cloud may indicate the start of a growing:",
+      "option_a": "cumulus cloud",
+      "option_b": "stratus cloud",
+      "option_c": "squall line",
+      "option_d": "cirrus cloud",
+      "correct_answer": "A",
+      "explanation": "<a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/media/faa-h-8083-13.pdf\">Glider Flying Handbook</a>, page 9-7, figure 9-8, &quot;Life cycle of a typical thermal with cumulus cloud.&quot;&nbsp;",
+      "last_updated": "2012-11-28",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 5,
+    "fields": {
+      "category": "WX",
+      "question_text": "The cloud type that produces hazards such as hail, heavy rain, and violent updrafts is the",
+      "option_a": "nimbostratus",
+      "option_b": "cumulus",
+      "option_c": "cumulonimbus",
+      "option_d": "stratonimbus",
+      "correct_answer": "C",
+      "explanation": "<a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/media/faa-h-8083-13.pdf\">Glider Flying Handbook</a> , page G-2 definition for Cumulonimbus (CB)",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 6,
+    "fields": {
+      "category": "WX",
+      "question_text": "The best course of action for a sailplane that encounters a cumulonimbus cloud is to",
+      "option_a": "circle downwind of the cloud",
+      "option_b": "remain 1000 feet below the base of the cloud",
+      "option_c": "circle around the edges of the cloud",
+      "option_d": "leave the area",
+      "correct_answer": "D",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 7,
+    "fields": {
+      "category": "AMF",
+      "question_text": "<p>Unless supplemental oxygen is used, some deterioration of physical and mental performance occurs after prolonged flight at</p>",
+      "option_a": "10,000 to 14,000 MSL",
+      "option_b": "15,000 to 18,000 MSL",
+      "option_c": "20,000 to 25,000 MSL",
+      "option_d": "35,000 to 40,000 MSL",
+      "correct_answer": "A",
+      "explanation": "<p><a href=\"https://www.faa.gov/air_traffic/publications/atpubs/aim_html/chap8_section_1.html#$paragraph8-1-2\">AIM 8-1-2 Hypoxia</a></p>\r\n<p><span style=\"font-family: Arial;\"><strong>2. </strong>Although a deterioration in night vision occurs at a cabin pressure altitude as low as 5,000&thinsp;feet, other significant effects of altitude hypoxia usually do not occur in the normal healthy pilot below 12,000 feet. From 12,000 to 15,000 feet of altitude, judgment, memory, alertness, coordination and ability to make calculations are impaired, and headache, drowsiness, dizziness and either a sense of well-being (euphoria) or belligerence occur. The effects appear following increasingly shorter periods of exposure to increasing altitude. In fact, pilot performance can seriously deteriorate within 15&thinsp;minutes at 15,000 feet. </span></p>\r\n<p><a href=\"https://www.faa.gov/regulations_policies/handbooks_manuals/aviation/glider_handbook\">Glider Flying Handbook, page 10-12</a></p>\r\n<p>At around 20,000 feet MSL pilots might have only 10 minutes of &ldquo;useful consciousness.&rdquo; By 30,000 feet MSL, the timeframe for &ldquo;useful consciousness&rdquo; decreases to one minute or less.</p>",
+      "last_updated": "2024-02-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 8,
+    "fields": {
+      "category": "AMF",
+      "question_text": "<p>The greatest danger when flying at high altitudes is a condition known as</p>",
+      "option_a": "dehydration",
+      "option_b": "asphyxiation",
+      "option_c": "hyperventilation",
+      "option_d": "hypoxia",
+      "correct_answer": "D",
+      "explanation": "<p><a href=\"https://www.faa.gov/sites/faa.gov/files/regulations_policies/handbooks_manuals/aviation/glider_handbook/gfh_ch01.pdf\">Glider Flying Handbook, page 1-10</a></p>\r\n<p>High-altitude flying, which glider pilots encounter when mountain wave soaring or thermal soaring at high elevations, can place you in danger of becoming hypoxic. Oxygen starvation causes the brain and other vital organs to become impaired.</p>",
+      "last_updated": "2024-02-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 9,
+    "fields": {
+      "category": "AMF",
+      "question_text": "Rapid breathing, or hyperventilation, results from an inadequate supply of:",
+      "option_a": "carbon dioxide",
+      "option_b": "carbon monoxide",
+      "option_c": "oxygen",
+      "option_d": "nitrogen",
+      "correct_answer": "A",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/\">Glider Flying Handbook, page 1-12</a></p><p>Hyperventilation occurs when you are experiencing emotional stress, fright, or pain, and your breathing rate and depth increase although the carbon dioxide is already at a reduced level in the blood. The result is an excessive loss of carbon dioxide from your body, which can lead to unconsciousness due to the respiratory system&rsquo;s overriding mechanism to regain control of breathing.</p>  ",
+      "last_updated": "2011-04-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 11,
+    "fields": {
+      "category": "AMF",
+      "question_text": "The safest course of action for the pilot in command who is suffering from motion sickness is to:",
+      "option_a": "drink some water",
+      "option_b": "close the air vents",
+      "option_c": "take a dramamine tablet",
+      "option_d": "land the glider, when practicable",
+      "correct_answer": "D",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/\">Glider Flying Handbook, page 1-14</a> </p><p>It is important to remember that experiencing airsickness is no reflection on your ability as a pilot. Let your flight instructor know if you are prone to motion sickness since there are techniques that can be used to overcome this problem. For example, you may want to avoid lessons in turbulent conditions until you are more comfortable in the glider, or start with shorter flights and graduate to longer instruction periods. If you experience symptoms of motion sickness during a lesson, you can alleviate some of the discomfort by opening fresh air vents or by focusing on objects outside the glider. Although medication like Dramamine can prevent airsickness in passengers, it is not recommended while you are flying since it can cause drowsiness.</p><p>Although opening air vents is suitable for more minor cases of motion sickness, answer D is the best choice for solo flight.&nbsp; </p>",
+      "last_updated": "2011-04-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 12,
+    "fields": {
+      "category": "AMF",
+      "question_text": "Pilots suffering from chronic or acute fatigue just prior to a planned flight should:",
+      "option_a": "drink plenty of coffee",
+      "option_b": "eat a chocolate bar",
+      "option_c": "bring a can of redbull along for the flight",
+      "option_d": "stay on the ground",
+      "correct_answer": "D",
+      "explanation": "<p><a href=\"http://www.faa.gov/air_traffic/publications/atpubs/aim/aim0801.html#aim0801.html.1\"><strong>AIM 8-1-1</strong></a> </p><blockquote><p><strong>3. </strong>Chronic fatigue occurs when there is not enough time for full recovery between episodes of acute fatigue. Performance continues to fall off, and judgment becomes impaired so that unwarranted risks may be taken. Recovery from chronic fatigue requires a prolonged period of rest. </p></blockquote>",
+      "last_updated": "2012-02-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 13,
+    "fields": {
+      "category": "AMF",
+      "question_text": "The best way to prevent both dehydration and heat stroke is to carry and use",
+      "option_a": "salt tablets",
+      "option_b": "coffee",
+      "option_c": "soft drinks",
+      "option_d": "water",
+      "correct_answer": "D",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/\">Glider Flying Handbook, page 6-4</a>  </p><p>The glider pilot should carry water on every flight to prevent dehydration. The effects of dehydration on a pilot&rsquo;s performance are subtle, but can be dangerous and are especially a factor in warmer climates.<br /></p>",
+      "last_updated": "2011-04-27",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 14,
+    "fields": {
+      "category": "FAR",
+      "question_text": "<p>Any time the pilot is flying above 10,000 feet MSL (and 1,200 AGL) the visibility required for VFR flight is:</p>",
+      "option_a": "5 nautical miles",
+      "option_b": "1 statute miles",
+      "option_c": "3 statute mile",
+      "option_d": "5 statute miles",
+      "correct_answer": "D",
+      "explanation": "<p><a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr;sid=a635be1fbee6bf1e26ae2901773b2167;rgn=div5;view=text;node=14%3A2.0.1.3.10;idno=14;cc=ecfr#14:2.0.1.3.10.2.5.33\">&sect;&nbsp;91.155&nbsp;&nbsp;&nbsp;Basic VFR weather minimums.</a></p>\r\n<p>(a) Except as provided in paragraph (b) of this section and &sect;91.157, no person may operate an aircraft under VFR when the flight visibility is less, or at a distance from clouds that is less, than that prescribed for the corresponding altitude and class of airspace in the following table:</p>\r\n<table border=\"1\" width=\"100%\" cellspacing=\"1\" cellpadding=\"1\">\r\n<tbody>\r\n<tr>\r\n<th scope=\"col\">Airspace</th>\r\n<th scope=\"col\">Flight visibility</th>\r\n<th scope=\"col\">Distance from clouds</th>\r\n</tr>\r\n<tr>\r\n<td scope=\"row\" align=\"left\">Class E:</td>\r\n<td align=\"left\">&nbsp;</td>\r\n<td align=\"left\">&nbsp;</td>\r\n</tr>\r\n<tr>\r\n<td style=\"padding-left: 2em;\" scope=\"row\" align=\"left\">Less than 10,000 feet MSL</td>\r\n<td align=\"left\">3 statute miles</td>\r\n<td align=\"left\">500 feet below.<br />1,000 feet above.<br />2,000 feet horizontal</td>\r\n</tr>\r\n<tr>\r\n<td style=\"padding-left: 2em;\" scope=\"row\" align=\"left\"><span style=\"color: #ff0000;\">At or above 10,000 feet MSL</span></td>\r\n<td align=\"left\"><span style=\"color: #ff0000;\"><strong>5 statute miles</strong></span></td>\r\n<td align=\"left\">1,000 feet below.<br />1,000 feet above.<br />1 statute mile horizontal.</td>\r\n</tr>\r\n</tbody>\r\n</table>",
+      "last_updated": "2024-04-28",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 15,
+    "fields": {
+      "category": "GFH",
+      "question_text": "How many feet in altitude will a sailplane lose in 15 nautical miles if its L/D ratio is 22:1",
+      "option_a": "4,145",
+      "option_b": "4,600",
+      "option_c": "5,500",
+      "option_d": "8,090",
+      "correct_answer": "A",
+      "explanation": "<p>Use the following equation:&nbsp;</p><table border=\"0\"><tbody><tr><td><p>&nbsp;Number of feet in a nautical mile x number of nautical miles</p><hr /><p style=\"text-align: center\">glide ratio</p></td><td>(6080 * 15) <hr />22</td><td>= 4145</td></tr></tbody></table>",
+      "last_updated": "2013-03-14",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 16,
+    "fields": {
+      "category": "AMF",
+      "question_text": "Proper clothing is an important consideration",
+      "option_a": "in the summer",
+      "option_b": "in the winter",
+      "option_c": "for long flights",
+      "option_d": "for all flights",
+      "correct_answer": "D",
+      "explanation": "Whether it&#39;s blowing snow, or it&#39;s scorching heat, a pilot really needs to consider his clothing choices before a flight.&nbsp;",
+      "last_updated": "2012-02-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 17,
+    "fields": {
+      "category": "GF",
+      "question_text": "If the towplane should lose power during the takeoff roll, what action should be taken by the sailplane pilot?",
+      "option_a": "an immediate release and turn to the left",
+      "option_b": "an immediate release and straight ahead stop, avoiding the towplane to the left, if necessary",
+      "option_c": "an immediate release and turn to the right",
+      "option_d": "an immediate release and straight ahead stop, avoiding the towplane to the right, if necessary",
+      "correct_answer": "D",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/\">Glider Flying Handbook pages 7-4 and 7-5 </a> </p><p>Situation 1. If the towrope breaks or is inadvertently released prior to the towplane&rsquo;s liftoff, the standard procedure is for the towplane to continue the takeoff and clear the runway, or abort the takeoff and remain on the left side of the runway. If the towplane loses power during the takeoff, the towpilot should maneuver the towplane to the left side of the runway. If the glider is still on the runway, the glider pilot should pull the release, decelerate using the wheel brake, and be prepared to maneuver to the right side of the runway.<br /><br /></p>",
+      "last_updated": "2011-04-27",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 18,
+    "fields": {
+      "category": "GF",
+      "question_text": "The purpose of clearing turns is to:",
+      "option_a": "check for thermals",
+      "option_b": "check for traffic",
+      "option_c": "reduce airspeed",
+      "option_d": "check flight controls",
+      "correct_answer": "B",
+      "explanation": "A clearing turn is done to check for traffic before maneuvers such as minimum controllable airspeed, stalls and spins.&nbsp;",
+      "last_updated": "2012-05-02",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 19,
+    "fields": {
+      "category": "GF",
+      "question_text": "When a side slip is performed during a crosswind landing, the ground track should be: ",
+      "option_a": "sideways, in the direction of the lowered wing",
+      "option_b": "in the opposite direction of the crosswind",
+      "option_c": "a gentle curve towards the runway centerline",
+      "option_d": "straight and parallel to the runway and the sailplane's longitudinal axis",
+      "correct_answer": "D",
+      "explanation": "The point of the side slip is to counteract any crosswind, while maintaining the runway&#39;s extended centerline. &nbsp;The difference between a side slip and crabbing is that the side slip counteracts the crosswind while maintaining the aircraft&#39;s longitudinal axis along the ground track. &nbsp;Crabbing is when the aircraft&#39;s nose is pointed upwind to maintain ground track.&nbsp;",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 20,
+    "fields": {
+      "category": "GF",
+      "question_text": "<p>If too much altitude is lost on the base leg and it looks like you will not make it to the runway:</p>",
+      "option_a": "<p>Close the spoilers, fly no slower than best L/D corrected for wind until time to flare</p>",
+      "option_b": "<p>Head directly for a short final, look for safest spots to make a controlled touchdown short of the runway</p>",
+      "option_c": "<p>Be prepared to intentionally ground-loop the glider after a controlled touchdown if necessary to avoid hitting objects head-on</p>",
+      "option_d": "<p>All of the above</p>",
+      "correct_answer": "D",
+      "explanation": "<p>If you have misjudged your pattern and will not make the runway, you may be out of good choices.&nbsp; Slowing down below best L/D speed does not stretch the glide.&nbsp; Attempting a low turn to final risks catching a wingtip or skidding into a turn resulting in a spin.&nbsp; Your choice of touchdown spots should prioritize minimizing the likelihood of injury.</p>",
+      "last_updated": "2026-03-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 21,
+    "fields": {
+      "category": "GF",
+      "question_text": "<p>Practice manuevers should be entered at an altitude no lower than:</p>",
+      "option_a": "1,500 feet AGL",
+      "option_b": "As required to complete by 1,500 feet AGL",
+      "option_c": "1,000 feet AGL",
+      "option_d": "2,200 feet MSL",
+      "correct_answer": "B",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/media/faa-h-8083-13.pdf\">Glider Flying Handbook</a> , page 7-27,&nbsp;</p>\r\n<p>\"Intentional stalls should be performed so the maneuver is completed by 1,500 feet above the ground for recovery and return to normal, wings-level flight. \"</p>",
+      "last_updated": "2013-10-14",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 22,
+    "fields": {
+      "category": "GF",
+      "question_text": "<p>Directional control is maintained after a crosswind touchdown by applying</p>",
+      "option_a": "aileron into the wind",
+      "option_b": "aileron away from the wind",
+      "option_c": "rudder into the wind",
+      "option_d": "whatever is necessary to track the centerline - could be rudder away from the wind to control weather-vaning, could be aileron into the wind to hold wings level, could be aileron away from the wind to deliberately lower the downwind wing to the runway to keep the upwind wing above runway lights if unable to track the centerline",
+      "correct_answer": "D",
+      "explanation": "<p><a href=\"https://www.faa.gov/regulations_policies/handbooks_manuals/aviation/glider_handbook\">Glider Flying Handbook</a> , page 7-36 through 7-38</p>\r\n<p>The GFH references focus on final approach and the flare.&nbsp; AFTER touchdown in a crosswind, which is the question, use whatever controls are necessary.&nbsp; Aileron into the wind may be needed to keep a crosswind from blowing the upwind wing up, while attempting to maintain wings level.&nbsp; Rudder away from the wind may be required to keep the glider from weather-vaning into the wind. If the glider is still weather-vaning, a deliberate but gentle aileron input away from the wind to fly the downwind wing to the runway may help straighten the glider out and keep the upwind wing above runway edge lights if departing the centerline (while applying brakes).</p>",
+      "last_updated": "2025-06-01",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 23,
+    "fields": {
+      "category": "GF",
+      "question_text": "The sailplane&#39;s groundspeed during a downwind landing as compared to a normal upwind landing is normally:",
+      "option_a": "higher",
+      "option_b": "lower",
+      "option_c": "about the same",
+      "option_d": "twice as high",
+      "correct_answer": "A",
+      "explanation": "<a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/media/faa-h-8083-13.pdf\">Glider Flying Handbook</a> , page 7-38. &quot;The tailwind increases the touchdown groundspeed and lengthens the landing roll. The increased distance for landing can be determined by dividing the actual touchdown speed by the normal touchdown speed and squaring the result. &quot;",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 24,
+    "fields": {
+      "category": "ST",
+      "question_text": "When a loss of lift occurs immediately after starting the turn in a thermal, it indicates",
+      "option_a": "a turn in the wrong direction",
+      "option_b": "a late turn",
+      "option_c": "an early turn",
+      "option_d": "a proper turn",
+      "correct_answer": "A",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 25,
+    "fields": {
+      "category": "ST",
+      "question_text": "The pilot makes initial contact with a thermal and turns to the right. Between 90 degrees and 180 degrees of rotation from the initial contact, the variometer drops from 3 knots lift to 0 knots. This decrease in lift indicates:&nbsp;",
+      "option_a": "a turn in the wrong direction",
+      "option_b": "a late turn",
+      "option_c": "an early turn",
+      "option_d": "a proper turn",
+      "correct_answer": "C",
+      "explanation": "<div>GFH, page 10-6. &quot;Soaring pilots&rsquo; opinions differ regarding how long to&nbsp;wait after encountering lift and before rolling into the&nbsp;thermal. Some pilots advocate flying straight until the&nbsp;lift has peaked. Then, they start turning, hopefully back&nbsp;into stronger lift. It is imperative not to wait too long&nbsp;after the first indication that the thermal is decreasing&nbsp;for this maneuver. Other pilots favor rolling into the&nbsp;thermal before lift peaks, thus avoiding the possibility&nbsp;of losing the thermal by waiting too long. <strong>Turning into&nbsp;the lift too quickly will cause the glider to fly back out&nbsp;into sink.</strong> There is no one right way; the choice depends&nbsp;on personal preference and the conditions on a given&nbsp;day. Timing is everything and practice is key.&quot;</div>",
+      "last_updated": "2013-07-24",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 26,
+    "fields": {
+      "category": "ST",
+      "question_text": "When searching for a thermal the recommended speed to maintain is",
+      "option_a": "manuevering speed",
+      "option_b": "Best L/D speed for wind and lift condition",
+      "option_c": "minimum control speed",
+      "option_d": "minimum sink speed",
+      "correct_answer": "B",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 27,
+    "fields": {
+      "category": "ST",
+      "question_text": "<p>The best airspeed to use while thermalling is</p>",
+      "option_a": "<p>manuevering speed</p>",
+      "option_b": "<p>Best L/D speed</p>",
+      "option_c": "<p>minimum control speed</p>",
+      "option_d": "<p>minimum sink speed, considering the angle of bank being used for the turn to stay in the thermal</p>",
+      "correct_answer": "D",
+      "explanation": "<p>The best airspeed to use while thermalling is a compromise between minimizing turn radius and minimizing sink rate.&nbsp; See <a href=\"https://www.faa.gov/regulations_policies/handbooks_manuals/aviation/glider_handbook\">Glider Flying Handbook</a> pages 3-12 and 10-6 through 10-11.&nbsp; Minimum sink speed at 40 degrees of bank (common in a thermal) is faster than minimum sink speed in level flight in calm air.&nbsp; Maneuvering speed would be way too fast.&nbsp; Best L/D speed is normally too fast.&nbsp; Minimum control speed is too slow, even if thermalling straight and level in a cloud street.</p>",
+      "last_updated": "2025-06-01",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 28,
+    "fields": {
+      "category": "ST",
+      "question_text": "The crest of mountain waves may be marked by",
+      "option_a": "cumulus clouds",
+      "option_b": "cirrus clouds",
+      "option_c": "lenticular clouds",
+      "option_d": "rotor clouds",
+      "correct_answer": "C",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 29,
+    "fields": {
+      "category": "ST",
+      "question_text": "<p>when flying near mountain wave, the turbulent area beneath the wave may be marked by</p>",
+      "option_a": "cumulus clouds",
+      "option_b": "cirrus clouds",
+      "option_c": "lenticular clouds",
+      "option_d": "rotor clouds",
+      "correct_answer": "D",
+      "explanation": "<p>Cumulus clouds are cauliflower-shaped. &nbsp;They are caused by lifting from below. &nbsp;They are not usually associated with wave activity.&nbsp;</p>\r\n<p>Cirrus clouds (actually cirro-stratus clouds) are generally indications of a warm frontal passage that is approaching in the next few days.&nbsp;</p>\r\n<p>Lenticular clouds are the smooth, almond shaped clouds that are located in the smooth part of the wave lift. &nbsp;Their presence does not indicate turbulence where the lenticular clouds are.&nbsp;</p>\r\n<p>Rotor clouds are the gnarly clouds that reside under the lenticular clouds. &nbsp;They are the ones that indicate turbulence.&nbsp;</p>",
+      "last_updated": "2016-03-14",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 30,
+    "fields": {
+      "category": "ST",
+      "question_text": "<p>For mountain wave to form, the minimum wind speed across the mountain tops should be:</p>",
+      "option_a": "<p>10 mph</p>",
+      "option_b": "<p>15-20 knots</p>",
+      "option_c": "<p>only when 30 mph or more</p>",
+      "option_d": "<p>only when 40 mph or more</p>",
+      "correct_answer": "B",
+      "explanation": "<blockquote cite=\"https://www.faa.gov/regulations_policies/handbooks_manuals/aviation/glider_handbook\">The weather requirements for wave soaring include sufficient wind and a proper stability profile. Windspeed should be at least 15 to 20 knots at mountaintop level with increasing winds above. The wind direction should be within about 30&deg; perpendicular to the ridge or mountain range. Air stability at the DALR near the mountaintop would not likely produce lee waves even with adequate winds. A well-defined inversion at or near the mountaintop with less stable air above would increase the likelihood of wave production.</blockquote>\r\n<p>Page 9-21 of the Glider Flying Handbook (FAA-H-8083-13B), Last updated: Monday, January 13, 2025</p>\r\n<p><a href=\"https://www.faa.gov/regulations_policies/handbooks_manuals/aviation/glider_handbook\">https://www.faa.gov/regulations_policies/handbooks_manuals/aviation/glider_handbook</a></p>\r\n<p>[updated page number from GFH 2013 version]</p>",
+      "last_updated": "2026-07-09",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 31,
+    "fields": {
+      "category": "FAR",
+      "question_text": "<p>A Student Pilot Certificate (that was&nbsp;issued after 1 April 2016) ...</p>",
+      "option_a": "is valid for 24 calendar months if the student is under 40 years of age, 60 calendar months if the student is over 40 years old",
+      "option_b": "is valid for 36 calendar months",
+      "option_c": "is valid for 60 calendar months",
+      "option_d": "has no expiration date.",
+      "correct_answer": "D",
+      "explanation": "<p>If you've read through the FARs, you'll see the reg:</p>\r\n<p style=\"padding-left: 30px;\"><a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr;sid=c8ec9e5bcd75fbe62b985617f4762433;rgn=div5;view=text;node=14%3A2.0.1.1.2;idno=14;cc=ecfr#14:2.0.1.1.2.1.1.15\">&sect;&nbsp;61.19&nbsp;&nbsp;&nbsp;Duration of pilot and instructor certificates.</a></p>\r\n<p style=\"padding-left: 30px;\">(b) <em>Student pilot certificate.</em></p>\r\n<p style=\"padding-left: 30px;\">(3) For student pilots seeking a glider rating, balloon rating, or a sport pilot certificate, the student pilot certificate does not expire until 60 calendar months after the month of the date issued, regardless of the person's age.</p>\r\n<p>However, after 1 April 2016, the method for handing out student pilot certificates changed. &nbsp;They used to be flimsy paper certificates, and are now credit card sized certificates similar to the private and commercial pilot certificates. So technically speaking, C is correct if the certificate was issued before 1 April 2016. &nbsp;If it was issued after 1 April 2016, it has no expiration date.&nbsp;</p>",
+      "last_updated": "2017-04-09",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 32,
+    "fields": {
+      "category": "AIM",
+      "question_text": "What is the AIM and where can it be found?",
+      "option_a": "The Airport Information Manual is a AOPA guide to airports in the United States",
+      "option_b": "The AIM is not published anymore",
+      "option_c": "The Aeronautical Information Manual is available as part of the FAR/AIM and available online or in print. It provides non-regulatory guidance to pilots.",
+      "option_d": "The Airman's Information Manual is a reference book published by the FAA.",
+      "correct_answer": "C",
+      "explanation": "Since 1988, the &quot;Airman&#39;s information Manual&quot; has been renamed to the Aeronautical Information Manual.&nbsp;",
+      "last_updated": "2013-07-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 34,
+    "fields": {
+      "category": "FAR",
+      "question_text": "<p>No pilot may operate a glider unless it has which of the following required documents onboard:</p>",
+      "option_a": "Airworthiness Certificate, Registration Certificate, Aircraft Logbooks",
+      "option_b": "Airworthiness Certificate, Registration Certificate, OperatingLimits",
+      "option_c": "Registration Certificate, Weight & Balance, Bill of Sale",
+      "option_d": "Airworthiness Certificate, Registration, Operating Limitations, Weight & Balance",
+      "correct_answer": "D",
+      "explanation": "<p>If you got this wrong, you probably should learn the AR[R]OW mnemonic.&nbsp;</p>\r\n<p>A.R.O.W.</p>\r\n<p>Aviation&nbsp;<a class=\"populated\" title=\"mnemonic\" href=\"http://everything2.com/title/mnemonic\">mnemonic</a>&nbsp;to&nbsp;<a class=\"populated\" title=\"remind\" href=\"http://everything2.com/title/remind\">remind</a>&nbsp;you of the&nbsp;<a class=\"populated\" title=\"required documents\" href=\"http://everything2.com/title/required+documents\">required documents</a>&nbsp;to make an aircraft&nbsp;<a class=\"populated\" title=\"airworthy\" href=\"http://everything2.com/title/airworthy\">airworthy</a>. These documents are checked as part of any&nbsp;<a class=\"populated\" title=\"pre-flight inspection\" href=\"http://everything2.com/title/pre-flight+inspection\">pre-flight inspection</a>.<br /><br />Without these documents the airplane can be brand new and in perfect shape but still be&nbsp;<a class=\"populated\" title=\"unairworthy\" href=\"http://everything2.com/title/unairworthy\">unairworthy</a>. The required documents are:<br /><br /><strong><em>A</em></strong>irworthiness Certificate.<br /><strong><em>R</em></strong>egistration.<br /><strong><em>O</em></strong>perating limitations.<br /><strong><em>W</em></strong>eight and Balance<br /><br /><br /><a class=\"populated\" title=\"Airworthiness Certificate\" href=\"http://everything2.com/title/Airworthiness+Certificate\">Airworthiness Certificate</a>:<br />Each aircraft is issued an airtworthiness certificate as it leaves the factory. This certificate certifies that the airplane meets the design requirements and is safe to operate.<br /><br /><a class=\"populated\" title=\"Registration\" href=\"http://everything2.com/title/Registration\">Registration</a>:<br />Just like the registration in your car. It includes things like Owner's name,&nbsp;<a class=\"populated\" title=\"registration number\" href=\"http://everything2.com/title/registration+number\">registration number</a>,&nbsp;<a class=\"populated\" title=\"Owner's address\" href=\"http://everything2.com/title/Owner%2527s+address\">Owner's address</a>, and&nbsp;<a class=\"populated\" title=\"aircraft serial number\" href=\"http://everything2.com/title/aircraft+serial+number\">aircraft serial number</a>.<br /><br /><a class=\"populated\" title=\"Operating limitations\" href=\"http://everything2.com/title/Operating+limitations\">Operating limitations</a>:<br />Most people think this means having the aircraft's&nbsp;<a class=\"populated\" title=\"Pilot Operating Handbook\" href=\"http://everything2.com/title/Pilot+Operating+Handbook\">Pilot Operating Handbook</a>&nbsp;(<a class=\"populated\" title=\"POH\" href=\"http://everything2.com/title/POH\">POH</a>). That is usually true however there is another requirement and that is&nbsp;<a class=\"populated\" title=\"placards\" href=\"http://everything2.com/title/placards\">placards</a>. Some&nbsp;<a class=\"populated\" title=\"placards\" href=\"http://everything2.com/title/placards\">placards</a>&nbsp;are required by&nbsp;<a class=\"populated\" title=\"Airworthiness Directive\" href=\"http://everything2.com/title/Airworthiness+Directive\">Airworthiness Directive</a>&nbsp;(<a class=\"populated\" title=\"type certificate\" href=\"http://everything2.com/title/type+certificate\">AD</a>) or by the aircraft's&nbsp;<a class=\"populated\" title=\"type certificate\" href=\"http://everything2.com/title/type+certificate\">type certificate</a>. These placards are considered part of the&nbsp;<a class=\"populated\" title=\"operating limitations\" href=\"http://everything2.com/title/operating+limitations\">operating limitations</a>.<br /><br /><a class=\"populated\" title=\"Weight and Balance\" href=\"http://everything2.com/title/Weight+and+Balance\">Weight and Balance</a>:<br />A current&nbsp;<a class=\"populated\" title=\"weight and balance\" href=\"http://everything2.com/title/weight+and+balance\">weight and balance</a>&nbsp;sheet is required to be kept in the aircraft. Also, if the aircraft's&nbsp;<a class=\"populated\" title=\"weight and balance\" href=\"http://everything2.com/title/weight+and+balance\">weight and balance</a>&nbsp;has a&nbsp;<a class=\"populated\" title=\"special condition\" href=\"http://everything2.com/title/special+condition\">special condition</a>&nbsp;(such as the aircraft is easily loaded out of aft&nbsp;<a class=\"populated\" title=\"C.G.\" href=\"http://everything2.com/title/C.G.\">C.G.</a>&nbsp;under&nbsp;<a class=\"populated\" title=\"normal loading conditions\" href=\"http://everything2.com/title/normal+loading+conditions\">normal loading conditions</a>) a&nbsp;<a class=\"populated\" title=\"loading chart\" href=\"http://everything2.com/title/loading+chart\">loading chart</a>&nbsp;must be kept with the&nbsp;<a class=\"populated\" title=\"weight and balance\" href=\"http://everything2.com/title/weight+and+balance\">weight and balance</a>.<br /><br />If you&nbsp;<a class=\"populated\" title=\"happen to be\" href=\"http://everything2.com/title/happen+to+be\">happen to be</a>&nbsp;flying internationally today you will need to add another \"R\" document and that is a current&nbsp;<a class=\"populated\" title=\"FCC\" href=\"http://everything2.com/title/FCC\">FCC</a>&nbsp;<a class=\"populated\" title=\"Radion Station License\" href=\"http://everything2.com/title/Radion+Station+License\">Radio Station License</a>.</p>",
+      "last_updated": "2016-03-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 35,
+    "fields": {
+      "category": "FAR",
+      "question_text": "Federal Aviation Regulations require the glider pilot and the tow pilot to agree upon a general course of action that includes:",
+      "option_a": "Takeoff and release signals, tow altitude, emergency procedures",
+      "option_b": "Takeoff and release signals, airspeeds, emergency signals",
+      "option_c": "Proper radio frequencies, airspeeds, tow direction",
+      "option_d": "General direction of tow and tow altitude",
+      "correct_answer": "B",
+      "explanation": "<p><a href=\"http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=&amp;SID=52729e710287983cf343cf679e6d5e32&amp;r=PART&amp;n=14y2.0.1.3.10#14:2.0.1.3.10.4.7.5\">&sect;&nbsp;91.309</a>&nbsp;&nbsp;Towing: Gliders and unpowered ultralight vehicles.</p><p>(a) No person may operate a civil aircraft towing a glider or unpowered ultralight vehicle unless</p><p>...</p><p>(5) The pilots of the towing aircraft and the glider or unpowered ultralight vehicle have agreed upon a general course of action, including takeoff and release signals, airspeeds, and emergency procedures for each pilot.</p>",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 37,
+    "fields": {
+      "category": "WX",
+      "question_text": "<p>Which one of the following thermal indexes predict the best probability of good soaring conditions?</p>",
+      "option_a": "<p>+2 millibars</p>",
+      "option_b": "<p>-2 millibars</p>",
+      "option_c": "<p>+6</p>",
+      "option_d": "<p>-6</p>",
+      "correct_answer": "D",
+      "explanation": "<p>Thermal Index represents the difference between the environmental temperature and the temperature at a particular level determined by following the dry adiabat through the forecast maximum temperature up to that level. Increasing magnitude of a negative value indicates stronger thermal lift. A value of -3 or below generally indicates thermal activity favorable for cross-country soaring. Soaring pilots should consult with the NWS WFO in their soaring area for more information about the soaring forecast.</p>\r\n<p>See page 11-4, <a title=\"Glider Flying Handbook\" href=\"https://www.faa.gov/regulations_policies/handbooks_manuals/aviation/glider_handbook\" target=\"_blank\" rel=\"noopener\">Glider Flying Handbook</a> (FAA-H-8083-13B), Last updated: Monday, January 13, 2025.</p>\r\n<p>[Added explanation, reference, and clerical corrections]</p>",
+      "last_updated": "2026-07-09",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 38,
+    "fields": {
+      "category": "FAR",
+      "question_text": "Who has the final responsibility for the safe operation of a glider?",
+      "option_a": "The duty officer",
+      "option_b": "The aircraft owner",
+      "option_c": "The pilot in command",
+      "option_d": "The aircraft operator",
+      "correct_answer": "C",
+      "explanation": "<p><a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr&amp;sid=aad16734f0f900c2d375294c2181b367&amp;rgn=div8&amp;view=text&amp;node=14:2.0.1.3.10.1.4.2&amp;idno=14\">&sect;91.3</a> Responsibility and authority of the pilot in command.</p><blockquote><p><span class=\"updatebodytest\">(a) The pilot in command of an aircraft is  directly responsible for, and is the final authority as to, the  operation of that aircraft.</span></p></blockquote><ul><li>The duty officer may have information about the aircraft that you don&#39;t know -- check with the duty officer before flying.&nbsp; However, he does not hold the final responsibility of the glider&#39;s operation <br /></li></ul>",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 39,
+    "fields": {
+      "category": "FAR",
+      "question_text": "What documents must be in the pilot&#39;s physical possession during each solo flight?",
+      "option_a": "Logbook, CFI endorsements, pilot certificate",
+      "option_b": "Pilot's certificate, government issued picture ID",
+      "option_c": "Logbook, pilots certificate, medical certificate",
+      "option_d": "None, as long as all required documents are accessible at the airport",
+      "correct_answer": "B",
+      "explanation": "<span class=\"updatebodytest\"><p><a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr&amp;sid=a9056c07df88d231d858c9d5f4f43bcc&amp;rgn=div8&amp;view=text&amp;node=14:2.0.1.1.2.1.1.3&amp;idno=14\">&sect;61.3</a> Requirement for certificates, ratings, and authorizations.</p></span><span class=\"updatebodytest\"><p>  (a) <em>Pilot certificate. </em>No person may serve as a required pilot flight crewmember of a civil aircraft of the United States, unless that person&mdash;</p>  <p>   (1) Has a pilot certificate or special purpose pilot authorization  issued under this part in that person&#39;s physical possession or readily  accessible in the aircraft when exercising the privileges of that pilot  certificate or authorization. However, when the aircraft is operated  within a foreign country, a pilot license issued by that country may be  used; and</p>  <p>  (2) Has a photo identification that is in that  person&#39;s physical possession or readily accessible in the aircraft when  exercising the privileges of that pilot certificate or authorization.  ...</p></span>",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 40,
+    "fields": {
+      "category": "GF",
+      "question_text": "Minimum Sink Speed is defined as:",
+      "option_a": "the best speed for thermalling",
+      "option_b": "the airpseed at which the minimum total drag occurs",
+      "option_c": "the airspeed at which the glider will lose the least amount of altitude for a given period of time",
+      "option_d": "the airspeed for penetrtation into a headwind",
+      "correct_answer": "C",
+      "explanation": "Although the minimum sink speed is usually the best speed for thermalling, it is not defined as such. &nbsp;The min sink speed is the airspeed in which the glider will lose the least amount of altitude over time.&nbsp;",
+      "last_updated": "2013-02-06",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 41,
+    "fields": {
+      "category": "GF",
+      "question_text": "Define Best L/D Speed",
+      "option_a": "The airspeed for thermaling",
+      "option_b": "The airspeed at which the glider will lose the least altitude for a given distance traveled ",
+      "option_c": "The airspeed for penetrtation into a headwind",
+      "option_d": "the airspeed at which the glider will lose the least amount of altitude for a given period of time",
+      "correct_answer": "B",
+      "explanation": "Glider Flying Handbook, page G-1,&nbsp;<br />&quot;Best Glide speed (Best L/D Speed) -- the airspeed that results in the least amount of altitude loss over a given distance.&quot;",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 42,
+    "fields": {
+      "category": "GF",
+      "question_text": "Define Maneuvering Speed",
+      "option_a": "The speed to fly in the pattern while maneuvering to land.",
+      "option_b": "The speed to fly while between thermals, searching for lift",
+      "option_c": "The speed above which full or sharp deflections of the controls should not be made.",
+      "option_d": "The slowest speed at which the glider can safely be maneuvered.",
+      "correct_answer": "C",
+      "explanation": "<p>The regulatory definition is in&nbsp;<a href=\"http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=1&amp;SID=0eb6ca22ab5efa94f23f757d30af7726&amp;h=L&amp;n=14y1.0.1.3.10&amp;r=PART&amp;ty=HTML#14:1.0.1.3.10.3.70.9\">14 CFR 25.335</a> &nbsp;(difficult to parse), but i<span style=\"font-size: 16px\">n short, it&#39;s the speed where the &quot;f</span><span style=\"font-size: 16px\">ull application of pitch, roll, or yaw controls should be confined to speeds below the maneuvering speed;</span><span style=\"font-size: 16px\">&quot;&nbsp;</span></p>",
+      "last_updated": "2013-02-06",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 43,
+    "fields": {
+      "category": "GF",
+      "question_text": "Define maximum structural cruising speed (V<sub>NO</sub>)",
+      "option_a": "The maximum speed at which the glider should be flown in turbulent conditions",
+      "option_b": "The maximum speed at which aerobatic flight maneuveurs may be performed",
+      "option_c": "The speed above which the glider may experience flutter",
+      "option_d": "The speed above which people may get motion sickness",
+      "correct_answer": "A",
+      "explanation": "Instructors -- I am unable to find any document satisfactorily describing this airspeed in the GFH, AIM or FARs.&nbsp;",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 44,
+    "fields": {
+      "category": "GF",
+      "question_text": "Which of the following best describes the never-exceed speed (V<sub>NE</sub>)?",
+      "option_a": "The maximum speed that the glider may be flown in smooth air",
+      "option_b": "The maximum speed that the glider may be flown in rough air",
+      "option_c": "The maximum speed that the glider may be flown with full control deflection",
+      "option_d": "All of the above",
+      "correct_answer": "A",
+      "explanation": "GFH page 4-3<br />NEVER-EXCEED SPEED (the red line). This is&nbsp;the maximum speed at which the glider can be&nbsp;operated in smooth air. This speed should never&nbsp;be exceeded intentionally",
+      "last_updated": "2013-07-24",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 45,
+    "fields": {
+      "category": "GF",
+      "question_text": "Under which case would it <strong>NOT</strong> be  mandatory that a glider pilot immediately release from tow:",
+      "option_a": "The tow plane rocks its wings",
+      "option_b": "The tow plane and glider experience severe turbulence",
+      "option_c": "The tow plane cannot be seen from the glider cockpit",
+      "option_d": "The tow pilot ejects from the tow plane",
+      "correct_answer": "B",
+      "explanation": "<p>If the towplane rocks its wings, that is the signal to immediately release.&nbsp;</p><p>If the towplane can not be seen from the glider cockpit, formation flight can no longer be maintained, and the glider must release. </p><p>If the tow pilot ejects from the tow plane, formation flight can no longer be maintained, and the glider must release. </p><p>Severe turbulence is not a mandatory situation where the glider must release, or there would never be any good wave flights out of Petersburg. &nbsp;</p>",
+      "last_updated": "2012-10-22",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 46,
+    "fields": {
+      "category": "GF",
+      "question_text": "While under tow at a &quot;comfortable&quot; altitude, all of a sudden the tow plane starts a rapid descent to the left.  What should you do?",
+      "option_a": "Turn the glider in the opposite direction, release the rope and remain clear of the tow plane",
+      "option_b": "Follow the tow plane, and keep the rope attached so it is not lost",
+      "option_c": "Return to the airport and land before the tow plane",
+      "option_d": "Release the rope and remain clear of the tow plane",
+      "correct_answer": "D",
+      "explanation": "If the tow pilot does this, there&#39;s not much point in hanging on. &nbsp;It&#39;s most likely the towpilot thought that you released. There probably isn&#39;t going to be enough time to turn the glider into the opposite direction before releasing, so just pull the release and continue the flight from there.&nbsp;",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 47,
+    "fields": {
+      "category": "GFH",
+      "question_text": "What is the ground signal for stop operations immediately?",
+      "option_a": "both arms straight up",
+      "option_b": "both arms straight out and wave both arms over head",
+      "option_c": "motion with your hand across your neck",
+      "option_d": "Jump up and down and yell as loud as possible.",
+      "correct_answer": "B",
+      "explanation": "Glider Flying Handbook, page 7-1, Figure 7-1",
+      "last_updated": "2012-05-02",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 48,
+    "fields": {
+      "category": "GF",
+      "question_text": "Describe how to correct for significant slack in the towline",
+      "option_a": "make a coordinated turn away from the tow plane",
+      "option_b": "decend the glider in tow",
+      "option_c": "extend dive brakes judiciously till the slack is removed",
+      "option_d": "Allow the slack to be taken up by the tow plane",
+      "correct_answer": "C",
+      "explanation": "This question doesn&#39;t offer a right answer (see question #82, which asks for the &#39;immediate&nbsp;reaction to significant slack line&quot;, with an answer choice of &quot;yaw away from the tow plane&quot;).&nbsp; Recommend removing this question from the question bank.&nbsp; ",
+      "last_updated": "2013-04-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 49,
+    "fields": {
+      "category": "FAR",
+      "question_text": "If, as a student pilot, or as a non-glider rated transition pilot, you have not flown for 90 days since your endorsement was given, you:",
+      "option_a": "must pass a check ride given by an SSC flight instructor and receive the proper endorsements.",
+      "option_b": "are legal to fly solo with a verbal OK from your instructor",
+      "option_c": "must pass both a practical and written exam",
+      "option_d": "must have your student pilot certificate re-issued",
+      "correct_answer": "A",
+      "explanation": "<p>&nbsp;<a href=\"http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=1&amp;SID=4a1710cf6b09f9f5d7a32715031db7b6&amp;h=L&amp;n=14y2.0.1.1.2&amp;r=PART&amp;ty=HTML#14:2.0.1.1.2.3.1.4\">&sect;&nbsp;61.87</a>&nbsp;&nbsp;&nbsp;Solo requirements for student pilots.</p><p><span class=\"updatebodytest\">(n) <em>Limitations on student pilots operating an aircraft in solo flight. </em>A student pilot may not operate an aircraft in solo flight unless that student pilot has received:<br /></span><span class=\"updatebodytest\">(2) An endorsement in the student&#39;s logbook  for the specific make and model aircraft to be flown by an authorized  instructor, who gave the training within the 90 days preceding the date  of the flight.</span></p>",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 51,
+    "fields": {
+      "category": "GF",
+      "question_text": "Spin recovery should follow the manufacturer&#39;s recommendations in the POH.&nbsp; In the absence of that information, what is the &quot;nominal&quot; spin recovery technique for a glider?",
+      "option_a": "Ailerons neutral, full opposite rudder to break rotation, forward stick to break stall, neutralize rudder, carefully apply back elevetor to return to normal airspeed",
+      "option_b": "Lower the nose, close speedbrakes/spoilers, full opposite aileron to stop the rotation, when a sufficent flying speed has been reached, gentle backpressure  to a normal glide attitude",
+      "option_c": "Full opposite rudder to stop the rotation, when a sufficent flying speed has been reached, gentle backpressure  to a normal glide attitude",
+      "option_d": "Open speedbrakes, full opposite rudder to stop the rotation,when a sufficent flying speed has been reached, gentle backpressure  to a normal glide attitude",
+      "correct_answer": "A",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/media/faa-h-8083-13.pdf\">Glider Flying Handbook</a> , page 7-32</p><p>&quot;Step 1 Position the ailerons neutral. &nbsp;Step 2 Apply full opposite rudder against the rotation. Step 3 Apply a positive and brisk, straight forward movement of the elevator control past neutral to break the stall. &nbsp;Step 4, after spin rotation stops, neutralize the rudder&quot; The unlisted fifth step is to gently pull the glider out of the dive.</p>",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 52,
+    "fields": {
+      "category": "GFH",
+      "question_text": "Shortly after takeoff the tow pilot rapidly fans the rudder of the towplane.  The glider pilot should:",
+      "option_a": "check spoilers for inadvertent extension",
+      "option_b": "release immediately",
+      "option_c": "position the glider to a lower tow position",
+      "option_d": "Close your canopy - it may be open",
+      "correct_answer": "A",
+      "explanation": "<img style=\"width: 300px; height: 398px\" src=\"http://www.soaringsafety.org/images/rudder-waggle.jpg\" alt=\"undefined\" title=\"undefined\" width=\"300\" height=\"398\" align=\"right\" /><p>This signal is not referenced in the Glider Flying Handbook (2003).</p><p>The signal is used to indicate that &quot;Something is wrong with the glider&quot; &nbsp;In this case, either A or D could be considered correct answers. &nbsp;However, at low altitude &quot;shortly after takeoff&quot; opened spoilers are more critical to the safe continuation of flight than an open canopy. &nbsp;Check the spoilers first! &nbsp;Don&#39;t release unless you are in a good position to release, and don&#39;t confuse the signals of &quot;Release immediately!&quot; (rocking the wings) with &quot;Something is wrong with the glider&quot; (rapid fanning of the rudder).</p>",
+      "last_updated": "2013-02-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 53,
+    "fields": {
+      "category": "AIM",
+      "question_text": "Proper traffic clearing procedures should always be used:",
+      "option_a": "prior to positioning on an active runway",
+      "option_b": "prior to all turns",
+      "option_c": "prior to all abnormal maneuvers",
+      "option_d": "all of the above",
+      "correct_answer": "D",
+      "explanation": "During the practical examination for the private pilot, the examiner will be observing your attention to proper scanning techniques. &nbsp;But most of all, you should be performing proper scanning and clearing of turns because your life depends on it! &nbsp;Clear for traffic before taxiing onto a runway (even if you have made the radio call), prior to all turns in flight, prior to any maneuvers such as stalls, slow flight, or steep dives.&nbsp;",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 55,
+    "fields": {
+      "category": "AIM",
+      "question_text": "When approaching FRR from the west to land, you hear a power plane announce on the Unicom frequency that he is &#39;entering downwind&#39; for the active runway, your first action would be:",
+      "option_a": "Announce by radio that you are in a glider, are landing, and have the right of way",
+      "option_b": "Proceed with caution, visually locate the power plane, and announce on the radio your entry into the pattern when appropriate",
+      "option_c": "Immediately select the alternative runway, complete your pre-landing checklist and proceed to execute a pattern for that runway",
+      "option_d": "Slow to minimum sink speed to extend your time aloft to give the power plane a chance to land",
+      "correct_answer": "B",
+      "explanation": "Many pilots erroneously believe the glider has the right-of-way in this situation; slowing and circling in the pattern increases the liklihood of creating a more dangerous situation; the situation is not sufficiently&nbsp;dire to declare an emergency; glider pilots should always have alternatives when the situation beyond their control changes.",
+      "last_updated": "2011-06-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 56,
+    "fields": {
+      "category": "FAR",
+      "question_text": "As a student pilot, while flying in the vicinity of the Front Royal airport, you must have in your possession while flying solo:",
+      "option_a": "Student pilot certificate and radio license if the glider has a radio",
+      "option_b": "Student pilot certificate and Class III or higher medical certificate",
+      "option_c": "Student pilot certificate and a separate photo ID acceptable to the FAA",
+      "option_d": "Student pilot certificate, logbook, photo ID",
+      "correct_answer": "C",
+      "explanation": "<span class=\"updatebodytest\"><p><a href=\"http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=1&amp;SID=4a1710cf6b09f9f5d7a32715031db7b6&amp;h=L&amp;n=14y2.0.1.1.2&amp;r=PART&amp;ty=HTML#14:2.0.1.1.2.1.1.3\">&sect;61.3</a> Requirement for certificates, ratings, and authorizations.</p></span><blockquote><span class=\"updatebodytest\"><p>  (a) <em>Pilot certificate. </em>No person may serve as a required pilot flight crewmember of a civil aircraft of the United States, unless that person&mdash;</p>  <p>    (1) Has a pilot certificate or special purpose pilot authorization   issued under this part in that person&#39;s physical possession or readily   accessible in the aircraft when exercising the privileges of that pilot   certificate or authorization. However, when the aircraft is operated   within a foreign country, a pilot license issued by that country may be   used; and</p>  <p>  (2) Has a photo identification that is in that   person&#39;s physical possession or readily accessible in the aircraft when   exercising the privileges of that pilot certificate or authorization.   The photo identification must be a:</p>  <p>A medical certificate is not required per 61.23(b)(1)(ii)</p></span></blockquote><p><a href=\"http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=1&amp;SID=4a1710cf6b09f9f5d7a32715031db7b6&amp;h=L&amp;r=SECTION&amp;n=14y2.0.1.1.2.1.1.17\">&sect;&nbsp;61.23</a>&nbsp;&nbsp;&nbsp;Medical certificates: Requirement and duration.</p><blockquote><p>(b) <em>Operations not requiring a medical certificate. </em>A person is not required to hold a medical certificate&mdash;</p>  <p>  (1) When exercising the privileges of a student pilot certificate while seeking&mdash;</p>    <p>  (ii) A pilot certificate with a glider category rating or balloon class rating;&nbsp;</p></blockquote><a href=\"http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=1&amp;SID=4a1710cf6b09f9f5d7a32715031db7b6&amp;h=L&amp;n=14y2.0.1.1.2&amp;r=PART&amp;ty=HTML#14:2.0.1.1.2.1.1.31\">61.51</a> &nbsp;states that a student must have his logbook with him, when performing cross-country flight. Since this is a flight around the airport&#39;s area, it is not considered a cross-country flight. &nbsp; Of course, it&#39;s OK to bring along your logbook; it&#39;s just not required.&nbsp;",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 57,
+    "fields": {
+      "category": "ST",
+      "question_text": "When flying along the ridge in ridge lift, you overtake a slower glider. Safety required that you:",
+      "option_a": "Make radio contact before passing",
+      "option_b": "Pass on the ridge side",
+      "option_c": "Pass on his left",
+      "option_d": "Pass on his right",
+      "correct_answer": "B",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 58,
+    "fields": {
+      "category": "WX",
+      "question_text": "What cloud is a clue to the presence of wave lift?",
+      "option_a": "Cumulus",
+      "option_b": "Lenticular",
+      "option_c": "Stratus",
+      "option_d": "Virga",
+      "correct_answer": "B",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 59,
+    "fields": {
+      "category": "GF",
+      "question_text": "When during the pre-landing checklist, you discover that the spoilers have frozen in the closed position.",
+      "option_a": "Use a slip to control glide path",
+      "option_b": "Extend each leg of the pattern as needed",
+      "option_c": "Select the longest runway available to you",
+      "option_d": "Use some combination of all of the above",
+      "correct_answer": "D",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 60,
+    "fields": {
+      "category": "GFH",
+      "question_text": "What does TLAR stand for and in what context is it usually used?",
+      "option_a": "Top Level Aircraft Requirements, the legal requirement for defining the minimum equipment list for a glider",
+      "option_b": "That Looks About Right, an approximation process for aiming something like a weapon",
+      "option_c": "That Looks About Right, an approximation strategy used to help manage a landing pattern",
+      "option_d": "Transporter-Launcher and Radar, a type of mobile radar used by ATC in the ADIZ",
+      "correct_answer": "C",
+      "explanation": "The term &quot;TLAR&quot; is not referenced in the Glider Flying Handbook, or FAA AIM. &nbsp;It is a loose term to indicate that the current position is approximately correct at any point in the pattern. &nbsp;The term was coined in Tom Knauff&#39;s book &quot;Glider Basics&quot;, page 97.&nbsp;",
+      "last_updated": "2012-05-02",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 61,
+    "fields": {
+      "category": "GF",
+      "question_text": "What are the two cases in which it is essential that the glider immediately release from the tow plane?",
+      "option_a": "Towpilot waggles rudder or towpilot rocks wings",
+      "option_b": "Glider pilot loses sight of towplane or towpilot rocks wings",
+      "option_c": "Towpilot waggles rudder or glider pilot loses sight of towplane",
+      "option_d": "Rate of climb is too slow or radio contact between glider and towplane is lost",
+      "correct_answer": "B",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 62,
+    "fields": {
+      "category": "SSC",
+      "question_text": "<p>According to the SSC Operations Manual, the normal mid-field downwind position is at _____ ft MSL positioned so that the pilot is looking down at the runway at a ___ degree angle.</p>",
+      "option_a": "1500 and 30",
+      "option_b": "1700 and 45",
+      "option_c": "800 and 90",
+      "option_d": "1500 and the lookdown angle is not specified",
+      "correct_answer": "D",
+      "explanation": "<p><strong>3.8 Traffic Pattern</strong></p>\r\n<p>The airport management has established, as standard&nbsp;practice that powered aircraft (including the tow plane)&nbsp;will fly left traffic and gliders will fly right traffic.&nbsp; The normal mid-field downwind position is at 1,500 ft. MSL&nbsp;(800 ft. AGL).&nbsp;&nbsp;The 1 August 2012 revision&nbsp;does not specify lookdown angle.<br /><br />Reference: <a href=\"https://www.skylinesoaring.org/documents/club-documents#h.v5fj9yydmaiq\">OperationsManual.pdf (skylinesoaring.org)</a> Section 3.8 Page 23.</p>",
+      "last_updated": "2024-02-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 63,
+    "fields": {
+      "category": "FAR",
+      "question_text": "<p>A student pilot may log as solo time:</p>",
+      "option_a": "Only the time when he/she is sole occupant of the aircraft",
+      "option_b": "Only the time as instructor is not using the controls",
+      "option_c": "Only the time he/she is flying from the front seat of the aircraft",
+      "option_d": "A student pilot may not log solo time",
+      "correct_answer": "A",
+      "explanation": "<p><a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr&amp;sid=8f5531eae6c327a00ac98ed0c8e006b3&amp;rgn=div8&amp;view=text&amp;node=14:2.0.1.1.2.1.1.31&amp;idno=14\">14 CFR &sect;61.51</a>&nbsp;</p>\r\n<blockquote>\r\n<p>(d) <em>Logging of solo flight time. </em>Except for a student pilot performing the duties of pilot in command of an airship requiring more than one pilot flight crewmember, a pilot may log as solo flight time only that flight time when the pilot is the sole occupant of the aircraft.</p>\r\n</blockquote>",
+      "last_updated": "2021-08-27",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 64,
+    "fields": {
+      "category": "GF",
+      "question_text": "An obstruction (trees) on the approach end of a farmer's field will reduce the usable length of the field by:",
+      "option_a": "10 times the height of the tree",
+      "option_b": "20 times the height of the tree",
+      "option_c": "30 times the height of the tree",
+      "option_d": "40 times the height of the tree",
+      "correct_answer": "A",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 65,
+    "fields": {
+      "category": "GF",
+      "question_text": "What are two features for proper positioning of the glider flying when the tow plane turns?",
+      "option_a": "Glider pilot's view of towplane's wheels are on the horizon and glider nose pointed at tail of towplane",
+      "option_b": "Glider and towplane wings are parallel, nose of glider pointed at towplane's tail",
+      "option_c": "Glider and towplane wings are parallel, nose of glider pointed at outboard wingtip of towplane ",
+      "option_d": "Glider's yaw string is pointed toward the outside of the turn and glider and towplane's wings are parallel.",
+      "correct_answer": "C",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 66,
+    "fields": {
+      "category": "SSC",
+      "question_text": "CFR 91.126 provides that &#39;...When approaching to land at an airport without an operating control tower in a Class G airspace area&#39; ... each pilot of an airplane must make all turns to the left unless the airport displays approved light signals or visual markings indicating that turns must be made to the right..&#39; At FRR, the established procedures require power planes to use standard left traffic on both runways but glider traffic use right traffic. Why?",
+      "option_a": "Because it's easier to \"see and be seen\" by both gliders and airplanes",
+      "option_b": "Because the airport directory's remarks section defines glider, helicopter, and gyroplane traffic as right-hand",
+      "option_c": "Because the airport's management asks us to",
+      "option_d": "Because it's important to maintain separation from powered aircraft in the pattern",
+      "correct_answer": "B",
+      "explanation": "<ul><li>The term &quot;see and be seen&quot; is no longer being used by the FAA for collision avoidance. <br /></li><li>The Airport Facility directory explicitly states that gliders execute right hand traffic for both runway directions; incoming power pilots referring to the airport directory will have this knowledge before showing up to Front Royal. <br /></li><li>Airport management indeed asks that gliders fly a right-hand pattern, but this request carries no weight compared to the airport facility directory listing. <br /></li><li>It is important to maintain separation from power traffic, but there are airports where separation by different pattern shapes is impossible, such as at New Market or Luray, where the patterns are defined as the same for all categories of air traffic. </li></ul><p>Reference: <a href=\"http://www.airnav.com/airport/KFRR\">Airport Directory entry for KFRR</a> : </p>",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 67,
+    "fields": {
+      "category": "GF",
+      "question_text": "On a solo training flight in the local area, what is the first thing you should do safely free of the tow plane?",
+      "option_a": "check for traffic",
+      "option_b": "look for potential sources of lift",
+      "option_c": "locate the airport",
+      "option_d": "trim for best L/D speed",
+      "correct_answer": "C",
+      "explanation": "<p>This question is tricky, and a case could be made for each one of the possible answers. What we really need here is an answer that says &quot;it depends.&quot;</p><p>&quot;Check for traffic&quot; in our opinion, you should have checked for traffic before releasing -- but certainly checking for traffic is important. &nbsp;Trimming for best L/D airspeed should only be done if you are heading to a particular location. &nbsp;If you have released in a thermal, it would not be appropriate to trim for best L/D. &nbsp;Looking for potential lift is important, but finding the airport is far more critical -- If you are not sure where the airport is, look to the towplane and see where he&#39;s going! &nbsp;Getting lost on a solo flight is no fun. &nbsp;</p>",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 68,
+    "fields": {
+      "category": "GF",
+      "question_text": "For downwind landings, which of the following are NOT true? Downwind landings...",
+      "option_a": "...have the illusion of high airspeed",
+      "option_b": "...have significantly reduced effectiveness of the rudder",
+      "option_c": "...require a steeper approach to landing",
+      "option_d": "...have a higher groundspeed at touchdown",
+      "correct_answer": "C",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/media/faa-h-8083-13.pdf\">Glider Flying Handbook</a> , page 7-38</p><p>&quot;On downwind approaches, a shallower approach angle should be used, depending on the obstacles in the approach path.&quot; &nbsp;</p>",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 69,
+    "fields": {
+      "category": "GFH",
+      "question_text": "<p>The main purpose of elevator trim is:</p>",
+      "option_a": "Prevent high-speed flutter of the elevator",
+      "option_b": "Make the elevator more effective",
+      "option_c": "Raise the nose of the glider",
+      "option_d": "Reduce 'pilot workload' by reducing pressure on the stick",
+      "correct_answer": "D",
+      "explanation": "<p><a href=\"http://skylinesoaring.org/docs/Training_GFH-FAA_8083-13a.pdf\">Glider Flying Handbook</a>&nbsp;(2013) page 2-6 \"Trim devices reduce pilot workload by relieving the pressure required on the controls to maintain a desired airspeed.\"</p>",
+      "last_updated": "2013-09-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 70,
+    "fields": {
+      "category": "FAR",
+      "question_text": "The final responsibility for determining whether an aircraft is safe for flight lies with:",
+      "option_a": "The pilot in command",
+      "option_b": "The aircraft owner",
+      "option_c": "A certified inspector",
+      "option_d": "A certified instructor",
+      "correct_answer": "A",
+      "explanation": "<p><a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr&amp;sid=aad16734f0f900c2d375294c2181b367&amp;rgn=div8&amp;view=text&amp;node=14:2.0.1.3.10.1.4.4&amp;idno=14\">&sect;91.7</a> Civil aircraft airworthiness.  </p><p>(b) The pilot in command of a civil  aircraft is responsible for determining whether that aircraft is in  condition for safe flight. The pilot in command shall discontinue the  flight when unairworthy mechanical, electrical, or structural conditions  occur.</p>",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 71,
+    "fields": {
+      "category": "GF",
+      "question_text": "For a &#39;landing out&#39;, is uphill or downhill preferred? Why?",
+      "option_a": "uphill - provides steeper relative glideslope",
+      "option_b": "downhill - provides softer touch-down",
+      "option_c": "uphill- minimizes float and possibility of excessive rollout",
+      "option_d": "downhill - provides more time for fine tuning technique",
+      "correct_answer": "C",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/media/faa-h-8083-13.pdf\">Glider Flying Handbook</a> , page 8-9</p><p>&quot;If level landing areas are not available and the landing must be made on a slope, it is better to land uphill than downhill. Even a slight downhill grade during landing flare allows the glider to float prior to touchdown, which may reuslt in collision with objects on the far end of the selected field&quot;&nbsp;</p>",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 73,
+    "fields": {
+      "category": "GF",
+      "question_text": " Proper &quot;scanning&quot; involves:",
+      "option_a": "Scanning the horizon for anything that moves",
+      "option_b": "Focusing on a series of distant objects to discern moving objects in peripheral vision",
+      "option_c": "Focusing on distant ground objects to get your eyes adjusted",
+      "option_d": "Concentrating on objects in your intended flight path",
+      "correct_answer": "C",
+      "explanation": "<p>See&nbsp;<a href=\"http://www.faa.gov/air_traffic/publications/atpubs/aim/aim0801.html\">AIM 8-1-6</a>. &nbsp;That section in the AIM recommends finding a small portion of the sky, studying it for small objects, and moving on to the next section of sky. &nbsp;The use of peripheral vision is not useful because aircraft on a collision course will not have any relative motion, and peripheral vision only detects objects with relative motion.&nbsp;</p><p>Focusing on distant objects helps guard against &#39;empty field myopia&#39;, referenced in AIM 8-1-6.&nbsp;</p><p>Concentrating on objects in your intended flight path is no good because a mid-air collision is also possible from the side, as well as from the front.&nbsp;</p><p>Also see&nbsp;<a href=\"http://www.faa.gov/regulations_policies/advisory_circulars/index.cfm/go/document.information/documentID/23090\">AC 90-48C</a> , Collision Avoidance. &nbsp;</p>",
+      "last_updated": "2012-12-01",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 74,
+    "fields": {
+      "category": "AIM",
+      "question_text": "What radio frequency should be used for conversation between two gliders?",
+      "option_a": "122.80",
+      "option_b": "123.00",
+      "option_c": "123.30",
+      "option_d": "122.75",
+      "correct_answer": "C",
+      "explanation": "<p><a href=\"http://www.faa.gov/air_traffic/publications/atpubs/aim/Chap4/aim0401.html\">AIM 4-1-11</a>  </p><p id=\"aim0401.html.7\" align=\"CENTER\"><strong><em><a id=\"cn8gx1ccDefa\" name=\"cn8gx1ccDefa\" title=\"cn8gx1ccDefa\"></a><br /></em></strong>  </p> <table border=\"1\" cellspacing=\"0\" cellpadding=\"0\"> <tbody><tr> <td align=\"CENTER\" valign=\"MIDDLE\"> <p align=\"CENTER\"><strong>Use</strong>  </p> </td> <td align=\"CENTER\" valign=\"MIDDLE\"> <p align=\"CENTER\"><strong>Frequency</strong>  </p> </td> </tr>  <tr> <td align=\"LEFT\" valign=\"TOP\"> <p align=\"LEFT\">Air-to-air communication <br /> (private fixed wing aircraft).  </p> </td> <td align=\"CENTER\" valign=\"TOP\"> <p align=\"CENTER\">122.750  </p> </td> </tr>  <tr> <td align=\"LEFT\" valign=\"TOP\"> <p align=\"LEFT\">Air-to-air communications<br /> (general aviation helicopters).  </p> </td> <td align=\"CENTER\" valign=\"TOP\"> <p align=\"CENTER\">123.025  </p> </td> </tr>  <tr> <td align=\"JUSTIFY\" valign=\"TOP\"> <p align=\"JUSTIFY\">Aviation instruction, Glider, Hot Air Balloon <strong>(not to be used for advisory service)</strong>.  </p> </td> <td align=\"CENTER\" valign=\"TOP\"> <p align=\"CENTER\">123.300<br /> 123.500  </p> </td> </tr>   </tbody></table>   ",
+      "last_updated": "2011-04-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 75,
+    "fields": {
+      "category": "GFH",
+      "question_text": "<p>A glider loaded so that the cg is too far aft will:</p>",
+      "option_a": "Be predisposed to fly too fast, and may exceed Vne",
+      "option_b": "Be difficult to control",
+      "option_c": "Have a high sink rate",
+      "option_d": "Be very unlikely to stall or spin",
+      "correct_answer": "B",
+      "explanation": "<p><a href=\"http://skylinesoaring.org/docs/Training_GFH-FAA_8083-13.pdf\">Glider Flying Handbook</a> , page 5-11&nbsp;</p>\r\n<p>\"If the glider is loaded so the CG location is behind the aft limit, handling is compromised. The glider is said to be tail-heavy. Tail heaviness can make pitch control of the glider difficult or even impossible.</p>\r\n<p>When the glider is tail-heavy recovering from a stall may be difficult or impossible. When the stall occurs, the tail-heavy loading tends to make the glider nose continue to pitch upward, increasing angle of attack and complicating stall recovery. In extreme cases,&nbsp;recovery from stall or spin may be difficult or even impossible. \"</p>",
+      "last_updated": "2021-06-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 76,
+    "fields": {
+      "category": "GF",
+      "question_text": "&quot;Speed to fly&quot; means the correct speed to fly:",
+      "option_a": "In the pattern, but not before the final approach speed",
+      "option_b": "To minimize the sink rate of the glider while flying through lift and sink",
+      "option_c": "In turbulence; the maximum allowable speed while still preventing damage to the aircraft",
+      "option_d": "in general; covering the most ground with minimum loss of altitude",
+      "correct_answer": "D",
+      "explanation": "Speed to fly is not the pattern speed, even though the normal pattern speed we fly is very close to the maximum L/D speed. &nbsp;It is also not the speed we use to minimize the sink rate -- that&#39;s the &#39;minimum sink speed&#39;. &nbsp;Speed to fly is not to be confused with V<sub>NO</sub>, the maximum structural crusing speed -- so it has nothing to do with turbulence. &nbsp;Speed to fly is the speed that for a given headwind or tailwind, a given lift or sink, maximizes the glide ratio of the glider with reference to the ground.&nbsp;",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 77,
+    "fields": {
+      "category": "GF",
+      "question_text": "Back pressure on the stick upon entering a turn is required to maintain proper airspeed because:",
+      "option_a": "The lift vector provided by the wing is no longer straight up",
+      "option_b": "the load factor is reduced in a turn",
+      "option_c": "The drag is increased by the use of the rudder",
+      "option_d": "the centrifugal force is acting against the lift vector",
+      "correct_answer": "A",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/media/faa-h-8083-13.pdf\">Glider Flying Handbook</a> , page 3-11</p><p>&quot;To maintain your attitude with the horizon during a turn, you need to increase backpressure on the control stick. &nbsp;The horizontal component of lift creates a force directed inward toward the center of rotation, which is known as centripetal force.&quot; &nbsp;</p>",
+      "last_updated": "2012-11-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 78,
+    "fields": {
+      "category": "GF",
+      "question_text": "What of the following are NOT one of the&nbsp;signs of an impending stall?",
+      "option_a": "low indication on the airspeed indicator",
+      "option_b": "mushy controls, especially rudder",
+      "option_c": "reducing wind noise",
+      "option_d": "mushy controls, especially aileron",
+      "correct_answer": "B",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/media/faa-h-8083-13.pdf\">Glider Flying Handbook</a> , page 7-27,&nbsp;</p><p>Signs of an impending stall include the following:</p><p>High nose attitude.&nbsp;Low airspeed indication, Low airflow noise, Back pressure on sticks, Mushy controls, especially ailerons, Buffet&nbsp;</p>",
+      "last_updated": "2012-11-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 79,
+    "fields": {
+      "category": "GF",
+      "question_text": "Which of these is not an aspect of crosswind takeoffs?",
+      "option_a": "Weathervaning",
+      "option_b": "drifting downwind",
+      "option_c": "tendency for upwind wing to rise",
+      "option_d": "none of the above",
+      "correct_answer": "D",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 80,
+    "fields": {
+      "category": "GF",
+      "question_text": "<p>Immediately upon release from the towplane, the glider pilot should:</p>",
+      "option_a": "Make sure the rope is clear, then initiate a level right turn",
+      "option_b": "Make sure the rope is clear, then initiate a level left turn",
+      "option_c": "Make sure the rope is clear. Then initiate a slightly descending right turn",
+      "option_d": "Reduce airspeed to best speed-to-fly",
+      "correct_answer": "A",
+      "explanation": "<p>Barring an emergency, the tow plane will always turn to the left after the glider releases.&nbsp; By procedure, the glider will always turn right.&nbsp; Exceptions to this rule are for a low altitude rope break.&nbsp;</p>",
+      "last_updated": "2021-06-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 81,
+    "fields": {
+      "category": "GFH",
+      "question_text": "How much should minimum sink speed be increased in a 45 deg banked turn?",
+      "option_a": "Square root of the 1.4 load factor - 1.2 times",
+      "option_b": "It remains the same ",
+      "option_c": "Square root of the 2.0 load factor - 1.4 times",
+      "option_d": "Square root of the 3.0 load factor - 1.6 times",
+      "correct_answer": "A",
+      "explanation": "<p><a href=\"http://skylinesoaring.org/docs/Training_GFH-FAA_8083-13.pdf\">Glider Flying Handbook</a> , page 7-33&nbsp;</p><p>&quot;In a 45&deg; banked turn, load factor is 1.4 Gs. The approximate square root of 1.4 is 1.2. &quot;</p>",
+      "last_updated": "2012-05-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 82,
+    "fields": {
+      "category": "GFH",
+      "question_text": "What is the immediate reaction to significant slack In the towline?",
+      "option_a": "extend the spoilers",
+      "option_b": "yaw toward the tow plane",
+      "option_c": "gently pull up",
+      "option_d": "yaw away from the tow plane",
+      "correct_answer": "D",
+      "explanation": "<a href=\"http://skylinesoaring.org/docs/Training_GFH-FAA_8083-13.pdf\">Glider Flying Handbook</a> , page 7-10, <br />&quot;Slack line recovery procedures should be initiated as soon as the glider pilot becomes aware of the situation. The pilot&#39;s initial action should be to yaw away from the bow in the line&quot;",
+      "last_updated": "2012-05-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 83,
+    "fields": {
+      "category": "GFH",
+      "question_text": "What is the first thing to do if the canopy starts opening in flight?",
+      "option_a": "don't stop \"aviating\"",
+      "option_b": "above all else, reach for the flapping canopy",
+      "option_c": "step on the rudder opposite the canopy hinge",
+      "option_d": "inform Skyline base of what has happened",
+      "correct_answer": "A",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/\">Glider Flying Handbook page 8-11</a> &nbsp;</p><p>If the canopy opens while on aerotow, it is vital to maintain a normal flying attitude to avoid jeopardizing the safety of the glider occupants and the safety of the towplane pilot. Only when the glider pilot is certain that glider control can be maintained should any attention be devoted to trying to close the canopy. If flying a two-seat glider with a companion aboard, concentrate on lying the glider while the other person attempts to close and lock the canopy. If the canopy cannot be closed, the glider may still be controllable. Drag will be higher than normal, so when flying the approach it is best to plan a steeper-than-normal descent path. The best prevention against unexpected opening of the canopy is proper use of the pre-takeoff checklist.</p>",
+      "last_updated": "2011-04-26",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 84,
+    "fields": {
+      "category": "GF",
+      "question_text": "A glider pilot should do which of the following when flying his final approach into a 20 mph headwind and seems to be undershooting:",
+      "option_a": "Raise the nose to slow the aircraft to just above stall speed and decrease the sink rate",
+      "option_b": "Use spoilers",
+      "option_c": "Lower the nose to increase penetration speed",
+      "option_d": "Stretch the glide by flying at minimum sink speed",
+      "correct_answer": "C",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 85,
+    "fields": {
+      "category": "ST",
+      "question_text": "Which way should you circle when joining others in a thermal?",
+      "option_a": "It is at the discretion of the PIC",
+      "option_b": "same direction as others",
+      "option_c": "counterclockwise",
+      "option_d": "clockwise",
+      "correct_answer": "B",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 86,
+    "fields": {
+      "category": "SSC",
+      "question_text": "The Linden VOR is located 4.4 NM SSE of FRR. It is a common approach fix for traffic inbound to lAD, and is also a major Victor Airway intersection.",
+      "option_a": "Avoid this area completely to comply with the FARs",
+      "option_b": "Exercise extreme caution in this area since it is used for instrument approaches even in good weather",
+      "option_c": "This is not a problem because all traffic inbound to IAD is under ATC radar surveillance",
+      "option_d": "This is not a problem because gliders have the right-of-way over powered aircraft",
+      "correct_answer": "B",
+      "explanation": "<ul><li>There are no regulations prohibiting gliders from flying over VORs</li><li>Just because inbound aircraft are under ATC surveillance does not mean that the ATC is aware of your presence, and it does not mean that the ATC will direct inbound traffic away from your glider in this area.&nbsp; (Especially if your aircraft is not transponder-equipped)</li><li>Gliders do not have right-of-way over powered aircraft in all conditions, only when on converging and non-head-on courses (See <a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr&amp;sid=aad16734f0f900c2d375294c2181b367&amp;rgn=div8&amp;view=text&amp;node=14:2.0.1.3.10.2.4.8&amp;idno=14\">&sect;91.113</a>)</li></ul>The best answer for these is &#39;exercise extreme caution&#39;, but it might be even safer to avoid medium to high altitude flights in this area all-together. ",
+      "last_updated": "2013-07-24",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 87,
+    "fields": {
+      "category": "GF",
+      "question_text": "<p>On takeoff on RW 28 on a very cold day with winds of 15kts out of the southwest, the towplane suffers a catastrophic engine failure at an altitude of about 50ft. Without performing the standard signal to you (rocking the wings), the tow pilot releases the towline and dives toward the short grass overrun to RW 28. You are approximately 900ft east of threshold to RW 10. You should:</p>",
+      "option_a": "Clear the release, pull full spoilers, execute a 180 deg tum to the left and land on the pavement",
+      "option_b": "Clear the release, pull full spoilers, and land in the area ahead, avoiding the towplane, wherever he is",
+      "option_c": "Glide to the emergency field on the left, clearing the trees and looking for power lines. ",
+      "option_d": "Execute a 180 deg turn to the left, pull full spoilers, and land downwind on the takeoff runway.",
+      "correct_answer": "B",
+      "explanation": "<p><a href=\"http://www.faa.gov/library/manuals/aircraft/glider_handbook/media/faa-h-8083-13.pdf\">Glider Flying Handbook</a> , page 7-5 (in this situation) the glider has insufficient runway directly ahead and has insufficient altitude to make a safe turn, the best course of action is to land the glider straight ahead. After touchdown, use wheel brake as necessary to slow and stop as conditions permit.&nbsp;</p>\r\n<p>Since the glider still has the rope attached, clearing the release when possible is highly advisable. &nbsp;You don't want the situation to get worse by getting the nose pulled down by an entangled rope while landing. &nbsp;</p>",
+      "last_updated": "2015-07-01",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 88,
+    "fields": {
+      "category": "FAR",
+      "question_text": "A student pilot must have a logbook endorsement made by an authorized flight instructor for the specific make and model of glider to be flown every",
+      "option_a": "30 days",
+      "option_b": "60 days",
+      "option_c": "90 days",
+      "option_d": "none of the above",
+      "correct_answer": "C",
+      "explanation": "<p>&nbsp;<a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr;sid=baca085de2a6596787001610885116bf;rgn=div5;view=text;node=14%3A2.0.1.1.2;idno=14;cc=ecfr#14:2.0.1.1.2.3.1.4\">&sect;&nbsp;61.87</a>&nbsp;&nbsp;&nbsp;Solo requirements for student pilots.</p><p><span class=\"updatebodytest\">(n) <em>Limitations on student pilots operating an aircraft in solo flight. </em>A student pilot may not operate an aircraft in solo flight unless that student pilot has received:<br /></span><span class=\"updatebodytest\">(2)  An endorsement in the student&#39;s logbook  for the specific make and  model aircraft to be flown by an authorized  instructor, who gave the  training within the 90 days preceding the date  of the flight.</span></p>",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 89,
+    "fields": {
+      "category": "FAR",
+      "question_text": "It is the responsibility of the Pilot In Command to be familiar with which of the following prior to each flight",
+      "option_a": "Aircraft weight & balance",
+      "option_b": "Aircraft operating limitations",
+      "option_c": "Existing weather conditions",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "<a style=\"font-family: Times; font-size: medium\" name=\"14:2.0.1.3.10.2.4.2\" href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr;sid=af9390a4d4361fa06e2c4e468e38af99;rgn=div5;view=text;node=14%3A2.0.1.3.10;idno=14;cc=ecfr#14:2.0.1.3.10.2.4.2\" title=\"14:2.0.1.3.10.2.4.2\"><h5>&sect;&nbsp;91.103&nbsp;&nbsp;&nbsp;Preflight action.</h5></a><p style=\"font-family: Times; font-size: medium\">Each pilot in command shall, before beginning a flight, become familiar with all available information concerning that flight. This information must include&mdash;</p><p style=\"font-family: Times; font-size: medium\">(a) For a flight under IFR or a flight not in the vicinity of an airport, weather reports and forecasts, fuel requirements, alternatives available if the planned flight cannot be completed, and any known traffic delays of which the pilot in command has been advised by ATC;</p><p style=\"font-family: Times; font-size: medium\">(b) For any flight, runway lengths at airports of intended use, and the following takeoff and landing distance information:</p><p style=\"font-family: Times; font-size: medium\">(1) For civil aircraft for which an approved Airplane or Rotorcraft Flight Manual containing takeoff and landing distance data is required, the takeoff and landing distance data contained therein; and</p><p style=\"font-family: Times; font-size: medium\">(2) For civil aircraft other than those specified in paragraph (b)(1) of this section, other reliable information appropriate to the aircraft, relating to aircraft performance under expected values of airport elevation and runway slope, aircraft gross weight, and wind and temperature.</p>",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 90,
+    "fields": {
+      "category": "SSC",
+      "question_text": "Signal Knob is approximately 4.3 NM from the center of FRR. Assume your glider has a best L/D of 25:1 and there is no wind. You release from the towplane at 3,500MSL over Signal Knob and turn immediately toward the airport. You arrive over FRR at approximately:",
+      "option_a": "Field elevation",
+      "option_b": "1,750 MSL",
+      "option_c": "2,450 MSL",
+      "option_d": "3,500 MSL",
+      "correct_answer": "C",
+      "explanation": "<p>1 nautical mile is <a href=\"http://www.google.com/search?client=ubuntu&amp;channel=fs&amp;q=1+nautical+mile+in+feet&amp;ie=utf-8&amp;oe=utf-8\">6076 feet</a>  ; (you can also use 6000 feet as a close approximation)</p><p>Use the following equation to determine altitude used per distance: </p><table border=\"0\"><tbody><tr align=\"center\"><td><p>nautical miles *  number of feet in a nautical mile</p><hr /><p>&nbsp;glide ratio</p></td><td align=\"left\">4.3 * 6076<hr /><p align=\"center\">25</p></td><td>= <br /></td><td>26126.8 feet<br /><hr /><div align=\"center\">25<br /></div></td><td>= <br /></td><td>1045 feet <br /></td></tr></tbody></table><p>3500 feet MSL - 1045 feet = 2455. The closest answer is 2450 feet MSL</p>",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 91,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>On the ASK-21, the yellow triangle on the airspeed indicator marks the:</p>",
+      "option_a": "Minimum sink speed",
+      "option_b": "Maximum L/D speed",
+      "option_c": "Minimum approach speed",
+      "option_d": "Speed-to-fly",
+      "correct_answer": "C",
+      "explanation": "<p>The&nbsp;<a href=\"https://www.skylinesoaring.org/documents/flight-manuals#h.1zncxiwsrczd\">ASK-21 flight manual</a> &nbsp;describes the yellow triangle on page 12 as the \"approach speed\". &nbsp;It's simply a coincidence that the Max L/D speed for dual flight is also at that speed.</p>",
+      "last_updated": "2024-02-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 92,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "There are several good reasons to never leave a glider canopy open when unattended.&nbsp; A reason unique to the K-21 canopies is:",
+      "option_a": "The canopies form light concentrating lenses that can start a fire",
+      "option_b": "A canopy might be damaged by unexpected winds",
+      "option_c": "To avoid collecting dirt and trash in the cockpits",
+      "option_d": "Open canopies are more vulnerable to collecting scratches",
+      "correct_answer": "A",
+      "explanation": "<p>Actually, this valuable piece of information IS in the ASK-21 manual. It is in the Derigging section, pages 43a and 43b:</p><p>V.3 PARKING<br />When parking the glider, the canopies have to be<br />closed !<br />When an ASK 21 is parked on an airfield in the sunshine<br />(this must also be observed during the waiting<br />time until take-off when the pilots are already<br />on board ) the canopies must not be left open for<br />some time.<br />Depending on the position of the sun and the<br />intensity of the radiation, the burning-glass<br />effect of the canopies can cause a slo~ fire in the<br />area of the instrument panel or the headrest respectively.<br />Therefore, if you have to store the glider outside,<br />it is absolutely necessary always to close the canopies<br />and to cover them with a white cloth.&nbsp;</p><p>&nbsp;</p>",
+      "last_updated": "2013-09-02",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 120,
+    "fields": {
+      "category": "FAR",
+      "question_text": "A student pilot may log pilot in command time when: ",
+      "option_a": "Only that time when he/she is sole occupant of the aircraft",
+      "option_b": "Only that time when the instructor is not manipulating the controls",
+      "option_c": "Only that time he/she is flying from the front seat of the aircraft",
+      "option_d": "A student pilot may not log pilot in command time",
+      "correct_answer": "A",
+      "explanation": "<p><a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr&amp;sid=8f5531eae6c327a00ac98ed0c8e006b3&amp;rgn=div8&amp;view=text&amp;node=14:2.0.1.1.2.1.1.31&amp;idno=14\">14 CFR &sect;61.51</a>&nbsp;</p><p>For category-add on students:</p><p style=\"text-indent: 2em; font-family: Arial, sans-serif; font-size: 13px\">(e)&nbsp;<span style=\"font-style: italic\">Logging pilot-in-command flight time.</span>&nbsp;</p><p style=\"text-indent: 2em; font-family: Arial, sans-serif; font-size: 13px\">(1) A sport, recreational, private, commercial, or airline transport pilot may log pilot in command flight time for flights-</p><blockquote style=\"margin: 0px 0px 0px 40px; border: none; padding: 0px\"><p><span style=\"font-family: Arial, sans-serif; font-size: 13px; text-indent: 2em\">(ii) When the pilot is the sole occupant in the aircraft;</span>&nbsp;</p></blockquote><p>For students with a student pilot license:&nbsp;</p><p><span style=\"font-family: Arial, sans-serif; font-size: 13px; text-indent: 2em\">(e)(4) A student pilot may log pilot-in-command time only when the student pilot&mdash;</span></p><blockquote style=\"margin: 0px 0px 0px 40px; border: none; padding: 0px\"><p><span style=\"font-family: Arial, sans-serif; font-size: 13px; text-indent: 2em\">(i) Is the sole occupant of the aircraft or is performing the duties of pilot of command of an airship requiring more than one pilot flight crewmember;</span></p><p><span style=\"font-family: Arial, sans-serif; font-size: 13px; text-indent: 2em\">(ii) Has a solo flight endorsement as required under &sect;&nbsp;61.87 of this part; and</span></p><p><span style=\"font-family: Arial, sans-serif; font-size: 13px; text-indent: 2em\">(iii) Is undergoing training for a pilot certificate or rating.</span></p></blockquote>",
+      "last_updated": "2013-02-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 121,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "It is dangerous to stand south of the drainage ditch between the ramp and the taxiway because:",
+      "option_a": "The taxiway is a landing zone for gliders",
+      "option_b": "This area is used by taxiing airplanes",
+      "option_c": "Gliders are very silent on approach",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 122,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "The main hazard in the ramp area is:",
+      "option_a": "Taxiing aircraft",
+      "option_b": "Glider movements",
+      "option_c": "The possibility of getting hit by a propeller",
+      "option_d": "The possibility of fire from aircraft fueling",
+      "correct_answer": "C",
+      "explanation": "Once you&#39;re hit with a propeller, it&#39;s all over. ",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 123,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "When a pilot seated in the cockpit yells &ldquo;Clear prop!&rdquo;",
+      "option_a": "He wants you to clear the ramp for taxi",
+      "option_b": "He is about to start the engine, watch out for the propeller",
+      "option_c": "He is asking you to check that the aircraft is untied",
+      "option_d": "He is announcing that he has completed her pre-start check list",
+      "correct_answer": "B",
+      "explanation": "",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 124,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "<p>At KFRR gliders may land:</p>",
+      "option_a": "Anywhere in an emergency",
+      "option_b": "On the runway if available",
+      "option_c": "On the grass if the runway is not available, or on the taxiway if the grass is not available",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "<p>If there is an issue of pilot and aircraft safety, the glider may be landed anywhere on airport property. However, this does not give license to routinely land on the grass strip adjacent to the published runway, or on the taxiway. &nbsp;Normal&nbsp;landings should&nbsp;take place on the paved runway.&nbsp;</p>",
+      "last_updated": "2014-06-24",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 125,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "<p>Which of the following statements about pushing a glider is NOT correct?</p>",
+      "option_a": "Gliders at Skyline are typically pushed backwards while on paved surfaces",
+      "option_b": "Pushing on the trailing edge of a wing or control surface can cause damage",
+      "option_c": "Pushing backwards in tall grass or across a lip can cause damage to the rudder",
+      "option_d": "Gliders may only be pushed backwards",
+      "correct_answer": "D",
+      "explanation": "<p>At Skyline we typically push gliders backwards on pavement because it is convenient and safe to push from the nose or leading edge of the wing root and the base of the vertical tail.&nbsp; Gliders can be damaged by pushing forward on the trailing edge of the wing or any control surface.&nbsp; Glider rudders can be damaged by pushing backwards in tall grass or across a lip such as the edge of a taxiway.&nbsp; The best direction to push a glider depends on the type of glider and the situation.</p>",
+      "last_updated": "2021-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 126,
+    "fields": {
+      "category": "AIM",
+      "question_text": "<p>As you turn onto the downwind leg to land on Runway 28, you see a non-radio equipped airplane already on his base leg and below you.&nbsp; You should:</p>",
+      "option_a": "Open spoilers and execute an abbreviated pattern, since gliders have the right-of-way over airplanes.",
+      "option_b": "Close spoilers, slow to minimum sink speed, and circle until the airplane has cleared the runway..",
+      "option_c": "Declare an emergency on the CTAF and select the alternate runway on your landing checklist.",
+      "option_d": "Proceed with caution, announce your position on the CTAF, and be prepared to land on an alternate runway if conflict with the airplane is obvious.",
+      "correct_answer": "D",
+      "explanation": "<p>Many pilots erroneously believe the glider has the right-of-way in this situation; slowing and circling in the pattern increases the liklihood of creating a more dangerous situation; the situation is not sufficiently significant to declare an emergency; glider pilots should always have alternatives when the situation beyond their control changes.</p>",
+      "last_updated": "2017-09-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 127,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "Never push a glider by:",
+      "option_a": "The trailing edge of the tail surfaces",
+      "option_b": "The trailing edge surfaces of the wing",
+      "option_c": "The canopy",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "<ul><li>No trailing edges should be pushed, they could damage the surface. <br /></li><li>Pushing on the canopy can cause thousands of dollars of damage </li></ul>",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 128,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "Use extreme caution opening and closing canopies because:<br />",
+      "option_a": "They are fragile",
+      "option_b": "They are expensive",
+      "option_c": "They are not easy to replace",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "the obvious choice is D. ",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 129,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "The ASK-21 rear canopy must remain closed at all times unless someone is entering or exiting the rear cockpit because:",
+      "option_a": "When the canopy is open, it can set the glider on fire",
+      "option_b": "Wind can easily damage the rear canopy",
+      "option_c": "It would damage the glider if someone takes off with it open",
+      "option_d": "The front canopy cannot be latched shut unless the rear canopy is closed",
+      "correct_answer": "A",
+      "explanation": "<p>It only takes a few moments for the front or rear canopies to start a fire due to the lens effect. We often stress that the rear canopy is the one that can start fires, but there have been melted front cockpits on ASK-21s, as well.&nbsp;</p><p>B is only true for very strong winds, &gt; 30 mph</p><p>C is true, but isn&#39;t resolved by a closed rear canopy, it&#39;s only resolved by a <u>locked</u> rear canopy </p><p>D is incorrect because the front canopy can not be latched unless the rear canopy is latched.</p>",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 132,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "<p>When ground-towing&nbsp;gliders:</p>",
+      "option_a": "If towing without a tail dolly, use a second person to push down on the nose or pick up the tail when the glider is turning",
+      "option_b": "Use a second person on the nose or tail to prevent the glider from rolling into the tow vehicle when towing downhill",
+      "option_c": "Ensure the tow rope is longer than the half the total wingspan, so if the glider pivots the wing will not strike the tow vehicle",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "<p>A) We can prevent excessive wear and tear on the glider's tailwheel by picking it up while the glider is turning. It's preferable to pick up the tail at the tail of the aircraft, rather than pushing down on the nose.&nbsp; Pushing down on the nose makes it possible for a sudden acceleration to trap the crew under the glider, or to get hit by the wing of the glider. &nbsp; If picking the tail up, make sure to do so from the inside of the horizontal stabilizer, instead of the tips.&nbsp; In all circumstances, a tail dolly is most preferable for ground operations.</p>\r\n<p>B) When towing downhill, such as towards the approach end of runway 10, it is possible for a glider to accelerate towards the tow vehicle, and you may not be able to slow the glider from the wingtip without turning it</p>\r\n<p>C) If the glider starts to pivot and it is close to the tow vehicle, the wingtip may hit the tow vehicle; holding back one wingtip may make the other wingtip swing forward</p>\r\n<p>D) All of the above are true</p>",
+      "last_updated": "2018-09-09",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 133,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "When entering or exiting a glider, you should",
+      "option_a": "wait for the instructor to get in first",
+      "option_b": "never step directly on the seat cushion",
+      "option_c": "use the seat straps to pull on for leverage",
+      "option_d": "never grab the canopy",
+      "correct_answer": "D",
+      "explanation": "<p>The canopy is the most fragile and delicate part of the cockpit.&nbsp; Replacing it is terribly expensive!&nbsp; Also don&#39;t touch the canopy because the fingerprints reduce visibility.&nbsp; </p><p>&quot;never step directly on the seat cushion&quot; is also true, but not as important as &quot;never grab the canopy&quot;</p>",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 134,
+    "fields": {
+      "category": "GNDOPS",
+      "question_text": "It is important to announce yourself before pushing a glider onto the runway:",
+      "option_a": "to be sure that no glider is about to land",
+      "option_b": "to indicate to the tow plane that you are ready to launch",
+      "option_c": "because doing so assures that you will not interfere with runway traffic",
+      "option_d": "to add a level of safety -- although you must also clear the area visually",
+      "correct_answer": "D",
+      "explanation": "<p>D is correct -- making the radio call only adds to the safety, and still you must look for incoming traffic, even if you made the radio call.&nbsp; </p><p>A is incorrect because an incoming glider may not have a working radio.&nbsp; If you go out to the active runway without clearing first, at least he will be aware of your position and intentions, and be able to act accordingly, but making the radio call alone does not ensure that there are no gliders about to land. </p><p>B is incorrect because there are many circumstances when he is aware you are ready to launch without a radio call.&nbsp;</p><p>C is incorrect because making a call does not mean you are not going to interfere with runway traffic.&nbsp; An incoming plane on final approach will find your call and rolling out onto the runway as an interference with his final approach.&nbsp; </p>",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 135,
+    "fields": {
+      "category": "FAR",
+      "question_text": "FAA regulations require that a tow rope must",
+      "option_a": "be at least 150 feet long",
+      "option_b": "must be at least as strong as 80 percent of the minimum flying weight of the glider",
+      "option_c": "must have the appropriate rings on each end",
+      "option_d": "may not be stronger than 200 percent of the gross weight of the glider",
+      "correct_answer": "D",
+      "explanation": "<p>A is incorrect because the regulations don&#39;t specify any rope length at all.&nbsp;</p><p>B is incorrect because the regulation doesn&#39;t specify the percentage against the minimum flying weight of the glider.&nbsp;</p><p>C is incorrect because the regulations don&#39;t specify what kind of  connections there must be. However, hooking up the tost ring on the  Sprite could be disastrous! </p><p>Reference: <strong><a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr&amp;sid=88b4cd0f81008a7e9c8b053cf07d45a0&amp;rgn=div8&amp;view=text&amp;node=14:2.0.1.3.10.4.7.5&amp;idno=14\">91.309</a> Towing: Gliders and unpowered ultralight vehicles.</strong></p>",
+      "last_updated": "2011-04-25",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 136,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "The <em><strong>maneuvering speed</strong></em> is shown on the airspeed indicator <u>of the ASK-21</u> where",
+      "option_a": "the top of the green arc",
+      "option_b": "the top of the yellow arc",
+      "option_c": "the yellow triangle",
+      "option_d": "it is not shown on the airspeed indicator",
+      "correct_answer": "A",
+      "explanation": "<p>As a general rule, the top of the yellow arc is not maneuvering speed, but the normal operating range (V<sub>NO</sub>). Aircraft certified by the FAA follow this convention. The ASK-21 is a different story. The addage of &quot;do whatever the manual says&quot; applies here. &nbsp;When the ASK-21 was certified in 1980 in West Germany, the convention of V<sub>NO</sub> at the of the green arc didn&#39;t yet apply.&nbsp;</p><p>Gliders certified in Europe since 2001 all share the convention of V<sub>NO</sub> at the top of the green arc.&nbsp;</p><p>See FAA-H-8083 page 4-3, which lists the colors on airspeed indicator markings. Maneuvering Speed is listed under &quot;Other airspeed limitations&quot;.&nbsp;</p>",
+      "last_updated": "2013-02-01",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 156,
+    "fields": {
+      "category": "SSC",
+      "question_text": "SSC uses a designates the official &#39;IP&#39; (Initial Point) as&nbsp;the beginning of the glider landing pattern:<span style=\"white-space: pre\" class=\"Apple-tab-span\">\t</span>",
+      "option_a": "There is no official 'point' designated as IP",
+      "option_b": "You must learn each different instructor's preference of IP, and use that one when flying with that instructor",
+      "option_c": "For 28 approach, the bend in the road, for 10 approach, use the pond",
+      "option_d": "about 700 feet perpendicular to the opposite end of the runway you are landing on. ",
+      "correct_answer": "A",
+      "explanation": "<p>To avoid teaching landmarks as specific &#39;crutches&#39; to landing pattern techniques, SSC&#39;s policy is simply to enter - and announce - a more general &#39;45 degree intercept&#39; to the downwind leg. Similarly, students are not taught to turn from downwind to base leg based on a ground marker.&nbsp;In general, we support the TLAR pattern technique.</p>",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 157,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "If the transponder&#39;s battery fails in flight, you must:&nbsp;",
+      "option_a": "keep the transponder on. The regs require it to be on if equipped. ",
+      "option_b": "turn off the transponder by hitting the circuit breaker switch on the instrument panel",
+      "option_c": "Turn off the transponder at the control head and transponder master power switch, and after the flight recharge the battery",
+      "option_d": "immediately end the flight. ",
+      "correct_answer": "C",
+      "explanation": "<p>91.215(c) states that if equipped with an <strong><em>operable&nbsp;</em></strong>transponder, it must be on. &nbsp;Since the transponder is no longer operable, A probably isn&#39;t the best answer. &nbsp;There are provisions in the same regulation allowing for an aircraft under ATC control to continue working with an inoperative transponder along his route. &nbsp;</p><p><a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr&amp;sid=85faeb607345c51be3d35325fd7e68fb&amp;rgn=div8&amp;view=text&amp;node=14:2.0.1.3.10.3.7.8&amp;idno=14\">91.215&nbsp;ATC transponder and altitude reporting equipment and use.</a></p><p>&nbsp;(c) Transponder-on operation. While in the airspace as specified in paragraph (b) of this section or in all controlled airspace, each person operating an aircraft equipped with an <strong><em>operable</em></strong> ATC transponder maintained in accordance with &sect;91.413 of this part shall operate the transponder, including Mode C equipment if installed, and shall reply on the appropriate code or as assigned by ATC.</p><p>In order to keep the battery from draining to zero, thus causing the battery to be replaced, it&#39;s probably better to just shut off the transponder for the remainder of the flight. &nbsp; Option B isn&#39;t a good choice, given that the transponder should be turned off from the component, instead of the power switch toggle. &nbsp;Option C is a better choice -- turn off the transponder from the device, and recharge the battery after the flight. </p><p>Keep in mind, though that D looks like a pretty good answer, too, because of &sect;91.7&nbsp;</p><p><a href=\"http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr&amp;sid=85faeb607345c51be3d35325fd7e68fb&amp;rgn=div8&amp;view=text&amp;node=14:2.0.1.3.10.1.4.4&amp;idno=14\">&sect;&nbsp;91.7&nbsp;&nbsp;&nbsp;Civil aircraft airworthiness.</a></p><p>(a) No person may operate a civil aircraft unless it is in an airworthy condition.</p><p>(b) The pilot in command of a civil aircraft is responsible for determining whether that aircraft is in condition for safe flight. The pilot in command shall discontinue the flight when unairworthy mechanical, electrical, or structural conditions occur.</p><p>&nbsp;</p><div>Is a malfunctioning transponder reason enough to cause the aircraft to be unairworthy? &nbsp;Not really. &nbsp;The wings keep flying, and the controls keep working, so 91.7 doesn&#39;t really apply.&nbsp;</div>",
+      "last_updated": "2012-11-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 158,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>For the TT21 Mode S Transponder installed in the ASK-21, what is the difference between the \"Alt\" mode and the \"On\" mode?</p>",
+      "option_a": "Each setting carries the same function, but the \"Alt\" mode uses more power.",
+      "option_b": "The \"Alt\" mode has functionalities that were originally designed for airplanes under control of ATC. Use of the\"On\" mode is all that is necessary for our flying club operations.",
+      "option_c": "The \"Alt\" mode will respond will respond to ATC with altitude information, the \"On\" mode will not.",
+      "option_d": "The \"Alt\" mode is a special mode where we activate when we expect to be flying at higher altitudes, or in wave. ",
+      "correct_answer": "C",
+      "explanation": "<p><a href=\"https://www.skylinesoaring.org/documents/flight-manuals#h.8t4e8yx7s4e8\">TT21 Mode S Transponder Manual</a>, page 1 --&nbsp;</p>\r\n<table border=\"1\">\r\n<tbody>\r\n<tr>\r\n<td>&nbsp;OFF</td>\r\n<td>Power is removed from the transponder.&nbsp;</td>\r\n</tr>\r\n<tr>\r\n<td>&nbsp;SBY</td>\r\n<td>&nbsp;The transponder is on, but will not reply to any interrogations</td>\r\n</tr>\r\n<tr>\r\n<td>&nbsp;GND</td>\r\n<td>&nbsp;The transponder will respond to Mode S ground interrogations from surface movement radar.</td>\r\n</tr>\r\n<tr>\r\n<td>&nbsp;ON</td>\r\n<td>&nbsp;The transponder will respond to all interrogations, but altitude reporting is suppressed.&nbsp;</td>\r\n</tr>\r\n<tr>\r\n<td>&nbsp;ALT</td>\r\n<td>&nbsp;The transponder will respond to all interrogations.</td>\r\n</tr>\r\n</tbody>\r\n</table>",
+      "last_updated": "2024-02-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 159,
+    "fields": {
+      "category": "AIM",
+      "question_text": "<p>What is a TFR and how does it apply to you?</p>",
+      "option_a": "Temporary Flight Routing - The ATC can direct air traffic around a certain area",
+      "option_b": "Transient Foul Route - Aircraft flying through, but not stopping at an area must follow new routing instructions",
+      "option_c": "Temporary Flight Restriction - A flight restriction that prohibits flight into an area. ",
+      "option_d": "Transport Flight Route - A flight path reserved for air carriers, transport carriers, and jet liners. ",
+      "correct_answer": "C",
+      "explanation": "<p>The AIM and FAR's both discuss this topic: the former in terms of definition and the latter in terms of requirments. It's a very important type of NOTAM.</p>\r\n<p><a href=\"https://www.faa.gov/air_traffic/publications/atpubs/aim_html/chap3_section_5.html#$paragraph3-5-3\">AIM 3-5-3</a> &nbsp;and&nbsp;FAR&nbsp;General Air Traffic Operating Rules&nbsp;<a href=\"http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=&amp;SID=52729e710287983cf343cf679e6d5e32&amp;r=PART&amp;n=14y2.0.1.3.10#14:2.0.1.3.10.2.4.21\">91.137</a> &nbsp;through &nbsp;91.144 apply.&nbsp;</p>\r\n<p>You must be aware of and comply with all active NOTAMS. One of several sources of their existance is Flight Service Weather Briefers, <a href=\"http://www.1800wxbrief.com\">1800wxbrief.com</a>&nbsp;, and&nbsp;<a href=\"http://tfr.faa.gov/\">http://tfr.faa.gov/</a></p>",
+      "last_updated": "2024-02-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 160,
+    "fields": {
+      "category": "AMF",
+      "question_text": "<p>What is the&nbsp;maximum pressure altitude allowed without supplemental oxygen while&nbsp;operating a club glider?&nbsp;</p>",
+      "option_a": "10,000 feet",
+      "option_b": "12,000 feet",
+      "option_c": "12,500 feet",
+      "option_d": "14,000 feet",
+      "correct_answer": "C",
+      "explanation": "<p>See&nbsp;<a href=\"https://www.skylinesoaring.org/documents/club-documents#h.v5fj9yydmaiq\">SSC Ops Manual</a> &nbsp;para. 3.11&nbsp;&nbsp; 'Members may not fly Club aircraft above 12,500ft MSL without use of an approved oxygen system, and must have a logbook entry documenting training on the oxygen system to be used, signed by a Skyline Soaring instructor.'</p>\r\n<p>FAR&nbsp;<a href=\"http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=&amp;SID=52729e710287983cf343cf679e6d5e32&amp;r=PART&amp;n=14y2.0.1.3.10#14:2.0.1.3.10.3.7.6\">91.211</a> &nbsp;- which is less stringent than the Club rule - also applies.&nbsp;</p>",
+      "last_updated": "2024-02-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 167,
+    "fields": {
+      "category": "AMF",
+      "question_text": "A pilot goes out with his friends on Friday night and consumes a significant number of beers at a bar, finishing the last drink at midnight. He gets a taxi ride home. At 0800 the next morning, he wakes up with a slight hangover, and recovers after consuming a few aspirin. He notices that it&#39;s going to be a great soaring day and goes to the airport for a morning glider flight starting at 1000.&nbsp;",
+      "option_a": "The pilot may fly so long as his blood alcohol content is less than 0.04% BAC by volume.",
+      "option_b": "The pilot should not fly for 12-24 hours after the overconsumption. ",
+      "option_c": "If the pilot was drinking hard liquor instead of beer, he would be grounded, but beer is OK. ",
+      "option_d": "The pilot had more than 8 hours from drinking until take-off, so it's OK for him to fly. ",
+      "correct_answer": "B",
+      "explanation": "<p>The pilot probably shouldn&#39;t fly for 12-24 hours after the binge drinking. Just because the regulations state that 8 hours is the minimum time permitted between the consumption of alcoholic beverages to piloting an aircraft doesn&#39;t mean it&#39;s a good idea. &nbsp;The spectacular soaring weather MUST NOT be a determination for how fit to fly the pilot is. AIM 8-1-1 states the following:&nbsp;</p><blockquote style=\"margin: 0px 0px 0px 40px; border: none; padding: 0px\"><p><font size=\"2\">&nbsp;<font face=\"Arial\">2.&ensp;</font><span style=\"text-align: justify\">A consistently high alcohol related fatal aircraft accident rate serves to emphasize that alcohol and flying are a potentially lethal combination. The CFRs prohibit pilots from performing crewmember duties within 8 hours after drinking any alcoholic beverage or while under the influence of alcohol. However, due to the slow destruction of alcohol, a pilot may still be under influence 8 hours after drinking a moderate amount of alcohol. <strong>Therefore, an excellent rule is to allow at least 12 to 24 hours between &ldquo;bottle and throttle,&rdquo; </strong>depending on the amount of alcoholic beverage consumed.</span></font></p></blockquote>",
+      "last_updated": "2013-02-01",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 168,
+    "fields": {
+      "category": "AMF",
+      "question_text": "<p>Situation: Billy-Bob is getting heavier in his later years. His BMI is 35, but still manages to stay under the maximum weight limit of the gliders at the field. &nbsp;His wife complains of his constant very loud snoring all through the night. &nbsp;How could this affect his hobby of aviation?</p>",
+      "option_a": "His flying career will be over, once he exceeds the maximum allowable weight for our gliders",
+      "option_b": "He will have a hard time finding an instructor to fly with him, while staying under max-gross weight",
+      "option_c": "He could have sleep-obstructive apnea, causing him to have chronic fatigue",
+      "option_d": "His weight alone poses a higher possibility of other chronic ailments such as high blood pressure and heart failure",
+      "correct_answer": "C",
+      "explanation": "<p>While all of these possible answers are true, the most alarming part of this example is the very loud snoring. &nbsp;Recently, the AIM has been updated to reflect the dangers associated with chronic fatigue caused by a sleeping disorder called sleep apnea.&nbsp;<a href=\"https://www.faa.gov/air_traffic/publications/atpubs/aim_html/chap8_section_1.html\">AIM 8-1-e-(4)</a>&nbsp;writes about this, and&nbsp;recommends seeing a sleep study specialist to determine if the pilot has this condition.</p>",
+      "last_updated": "2024-02-23",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 170,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>The Club Laptop kiosk user is designed to</p>",
+      "option_a": "<p>Have full admin privileges</p>",
+      "option_b": "<p>Prevent logsheet creation</p>",
+      "option_c": "<p>Allow logsheet management but restrict admin overrides</p>",
+      "option_d": "<p>Require logout at the end of each day</p>",
+      "correct_answer": "C",
+      "explanation": "<p>The kiosk user can create/update logsheets but cannot override administrative functions</p>\r\n<ul>\r\n<li>A is wrong: It explicitly does not have admin override powers.</li>\r\n<li>B is wrong: Creating logsheets is one of its main functions.</li>\r\n<li>D is wrong: It does not require logout.</li>\r\n</ul>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 171,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>If Internet connectivity drops during the day (after initialization), the duty officer should:</p>",
+      "option_a": "<p>Stop logging flights immediately</p>",
+      "option_b": "<p>Continue logging flights and allow IndexedDB to queue changes</p>",
+      "option_c": "<p>Restart the browser</p>",
+      "option_d": "<p>Switch to paper logs permanently</p>",
+      "correct_answer": "B",
+      "explanation": "<p>Offline mode queues actions locally using IndexedDB and syncs when connectivity returns&nbsp;</p>\r\n<ul>\r\n<li>A is incorrect: Logging continues offline.</li>\r\n<li>C is incorrect: Closing the browser risks losing queued data.</li>\r\n<li>D is incorrect: Paper is not required unless system failure persists.</li>\r\n</ul>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 172,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>If the yellow offline banner appears and you have entered important data, you should:</p>",
+      "option_a": "<p>Close the browser to reset the connection</p>",
+      "option_b": "<p>Log out and log back in</p>",
+      "option_c": "<p>Leave the app open until connectivity is restored</p>",
+      "option_d": "<p>Re-enter the data on your phone</p>",
+      "correct_answer": "C",
+      "explanation": "<p>Closing the app while offline can cause IndexedDB data loss</p>\r\n<ul>\r\n<li>A and B risk losing unsynced data</li>\r\n<li>D risks duplicate/conflicting entries</li>\r\n</ul>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 173,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>When an instructor is selected for a two-seat glider flight, the passenger fields</p>",
+      "option_a": "<p>Are required</p>",
+      "option_b": "<p>Automatically populate</p>",
+      "option_c": "<p>Ghost out</p>",
+      "option_d": "<p>Become optional but editable</p>",
+      "correct_answer": "C",
+      "explanation": "<p>Passenger fields ghost out when an instructor is onboard</p>\r\n<ul>\r\n<li>A is false: They are disabled.</li>\r\n<li>B is false: They blank out.</li>\r\n<li>D is false: They are not editable.</li>\r\n</ul>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 176,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>A flight with a launch time but no landing time is considered</p>",
+      "option_a": "<p>Pending</p>",
+      "option_b": "<p>Flying</p>",
+      "option_c": "<p>Incomplete</p>",
+      "option_d": "<p>Finalized</p>",
+      "correct_answer": "B",
+      "explanation": "<p>Flights with launch time but no landing time are marked \"Flying\"</p>\r\n<ul>\r\n<li data-start=\"3838\" data-end=\"3859\">A is before launch.</li>\r\n<li data-start=\"3862\" data-end=\"3889\">C is not a system status.</li>\r\n<li data-start=\"3892\" data-end=\"3939\">D applies to logsheets, not individual flights.</li>\r\n</ul>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 177,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Cloning a flight copies all of the following EXCEPT</p>",
+      "option_a": "<p>Pilot</p>",
+      "option_b": "<p>Instructor</p>",
+      "option_c": "<p>Passenger information</p>",
+      "option_d": "<p>Release altitude</p>",
+      "correct_answer": "C",
+      "explanation": "<p>Passenger information is not copied when cloning.</p>\r\n<p><a href=\"https://www.skylinesoaring.org/cms/restricted-documents/duty-officer-instructions/logsheet-instructions/#OverseeingOperations\">[Reference:</a>]</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 183,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>How does one qualify as an Assistant Duty Officer?</p>",
+      "option_a": "Be appointed by the Chief Duty Officer",
+      "option_b": "Be a member of the Club for at least 90 days, have a private pilot certificate, and be appointed by the Chief Duty Officer.",
+      "option_c": "Have a private pilot license, complete the Soaring Safety Foundation's online Wing Runner Course, be a member of the Club for at least six months and be appointed by the Chief Duty Officer",
+      "option_d": "Complete the Soaring Safety Foundation's online Wing Runner Course, be instructed on-the-job by experienced ADOs and/or DOs, and be appointed by the Chief Duty Officer",
+      "correct_answer": "D",
+      "explanation": "<p>The requirements for becoming an Assistant Duty Officer are summarized in Operations Manual Section 1.6.10. It's pretty straightforward - show up at the field, be coached by one of the experienced and qualified members on how to help out (e.g., moving aircraft in and out of the hangar and to and from the flightline; launching a glider, generally helping out as needed). You'll also need to be checked out in how to drive the ATV and the Gator. Once you have been approved as an ADO, an icon will be placed on your online \"Instruction Record\" page that marks you as qualified for this position.</p>\r\n<p>A new member should qualify as an Assistant Duty Officer well within the first 90 days of his membership (although that is flexible, for example, if a member joins late in the season and doesn't have time to get on-the-job training in the first 90 days). And while a Private Pilot certificate is required to be a Duty Officer, it's not for the ADO.</p>\r\n<p>&nbsp;</p>",
+      "last_updated": "2015-01-31",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 184,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>How does one qualify as a Duty Officer?</p>",
+      "option_a": "Be a Full (not Probationary) member, hold at least a Private Pilot certificate, meet all the qualifications of the Assistant Duty Officer, and be approved by the Chief Duty Officer.",
+      "option_b": "Serve as an Assistant Duty Officer for one year and be appointed by the Chief Duty Officer.",
+      "option_c": "Complete the Soaring Safety Foundation's online Wing Runner course, and pass a test on how to use the Club's computer to manage operations. ",
+      "option_d": "All of the above.",
+      "correct_answer": "A",
+      "explanation": "<p>The requirements for becoming a Duty Officer are summarized in Operations Manual Section 1.6.9, q.v. Having said THAT, it's also true that it takes considerable on-the-job training to master all the many duties of the Duty Officer (and managing the Club's logsheet program is one of the more challenging ones). Maybe someday we will have a real test for operating the Club's logsheet program (well, there's some questions on THIS program that deal with that!) because it's one of the more challenging things a Duty Officer has to learn.<strong> &nbsp;</strong>Once approved by the Chief Duty Officer, an icon will be placed on you online \"Instruction Record\" page that marks you as qualified for this position.</p>\r\n<p>You DO have to have a private pilot certificate, but also must be a Full member (meaning you've been a Probationary member for at least a year).</p>",
+      "last_updated": "2015-03-13",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 185,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>What are the Duty Officer/Assistant Duty Officer hours of duty?</p>",
+      "option_a": "9:00 AM - 6:00 PM",
+      "option_b": "9:00 AM - Until operations are over and all equipment secured",
+      "option_c": "8:00 AM - Sunset (varies with season)",
+      "option_d": "One hour after sunrise - one hour before sunset (varies with season)",
+      "correct_answer": "B",
+      "explanation": "<p>The Operations Manual Section 2.1.1 (q.v.) says arrival at 9:AM until 'everything's done'; however, you should be both aware of variations and flexible because under certain circumstances (e.g., outstanding soaring forecast day, a special operations day) it may be needed to get to the field earlier and/or leave later. Also be aware that the DO (and other crew) should remain 'on duty' until all aircraft are at least accounted for, including members in their private ships who may be on cross-country tasks.</p>\r\n<p>While early starts are nice in the summertime when facing long, hot days, it's a bit much to ask all the time - and it's also not unusual to be putting things away at sunset!</p>",
+      "last_updated": "2015-01-31",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 186,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>What <em>GENERAL</em> activities occupy the Duty Officer all day?</p>",
+      "option_a": "Serves as \"Daily Safety Officer\", coordinates activities of all other members, manages Club logsheet program for operations, negotiates with FBO, collects money.",
+      "option_b": "Sets up all equipment for operations, manages ADO activities, establishes launch priorities, notify Potomac Tracon of operational limits for the day.",
+      "option_c": "Leads daily Safety Briefing before first flights, coordinates use of trainers for instruction with Duty Instructor(s), negotiates runway use with the Fixed Base Operator",
+      "option_d": "All of the above.",
+      "correct_answer": "D",
+      "explanation": "<p>That's a lot of things to be in charge of, right? You can find these activities spelled out in a little more detail in the Club's Operations Manual Section 2.2 <em>inter alia</em>, and there's a lot there (go back and re-read it!)</p>",
+      "last_updated": "2015-01-31",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 187,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>What should the Duty Officer generally do <em>before arriving</em> and <em>after leaving</em> the field?</p>",
+      "option_a": "<p><strong>BEFORE ARRIVING</strong>: Contact Duty Instructor, Assistant Duty Officer, and Duty Towpilot to confirm their participation.</p>\r\n<p><strong>AFTER DEPARTING</strong>: Finalize the logsheet, including maintenance reports, safety reports, tow plane tach times, and other operational issues.&nbsp;</p>",
+      "option_b": "<p><strong>BEFORE ARRIVING:</strong>&nbsp;Contact Potomac TRACON and advise them of limits for operations that day.&nbsp;</p>\r\n<p><strong>AFTER DEPARTING</strong>: upload logsheets to the Club's server.</p>",
+      "option_c": "<p><strong>BEFORE ARRIVING</strong>: Check weather forecast to confirm that you will conduct or cancel operations that day.&nbsp;</p>\r\n<p><strong>AFTER DEPARTING</strong>: Collect payments from the members who flew.&nbsp;</p>",
+      "option_d": "<p><strong>BEFORE</strong>: Contact Duty Instructor, Assistant Duty Officer, and Duty Towpilot to confirm their participation.</p>\r\n<p><strong>AFTER</strong>: Finalize the logsheet, including an operation and safety report.&nbsp;</p>",
+      "correct_answer": "A",
+      "explanation": "<p>These things can and should be done before leaving home for the field and after returning home that evening. They're intended to start the coordination process with the key people you'll be working with that day (ADO, DI, DT), set in motion any repairs that might need to be made to equipment, and let the members know what they missed!</p>\r\n<p>You cannot determine before you leave home what conditions prevail at the field, so you cannot tell Potomac TRACON what to expect! And you SHOULD upload the logsheet BEFORE you leave the field.</p>\r\n<p>With the possible exception of area-wide hurricanes or snow/ice of such severity that members cannot safely leave home, <strong><em>NEVER</em></strong> cancel operations due to weather without actually BEING on the field! The micrometeorology in the valley is very difficult to forecast, and is rarely comparable to what you see east of the mountains.</p>\r\n<p>The new logsheet software is continually updated while the laptop is online.&nbsp; There's no obligation to finalize the logsheet while you're at the airfield. You can do that at home, where you're more comfortable writing up the after-operations reports.&nbsp; You should do the maintenance reports at the field, though.&nbsp;</p>",
+      "last_updated": "2026-02-20",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 188,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Who is responsible for getting equipment set up before operations begin and what equipment is involved?</p>",
+      "option_a": "The members on the Roster are responsibile for getting the gliders they want to fly out of the hangar and moved to the ramp, the Assistant Duty Officer is responsible for getting tow vehicles out of the hangars and moving the trailer to the correct end of the runway, and the Duty Officer is responsible for setting up the Club computer",
+      "option_b": "The Duty Officer directs and coordinates with all members present to move all equipment known to be needed for the day from the hangars to the flight line.",
+      "option_c": "The Duty Officer and Assistant Duty Officer are responsible for moving all equipment from the hangars to the flight line",
+      "option_d": "The Duty Instructor is responsible for moving the trainers from the hangar to the flight line, the Duty Towpilot is responsible for readying the towplane for flight, and the Assistant Duty Officer is responsible for moving the tow vehicles and trailer to the flight line",
+      "correct_answer": "B",
+      "explanation": "<p>The Duty Officer can't \"do it alone\"!&nbsp;</p>\r\n<p>The precise sequence of equipment movement will vary a bit from day to day, but in general, the DO and ADO should coordinate the actions of all members as they arrive to move gliders, tow vehicles, and the trailer from the hangar to the correct flight line.&nbsp; On any day of operations, both the Club trainers should be moved from the hangar to the flight line; if it's known at the time that members plan to fly the Sprite, it should also be moved to the flight line; if not, it may remain in the hangar until a member indicates intent to fly it, in which case the DO will assign one more members to retrieve it.</p>\r\n<p>Members who fly the Cirrus are responsible for assembling it.</p>\r\n<p>The Duty Towpilot(s) will take responsibility for moving the towplane(s) from the hangar to the flight line, although in some cases, other members will help move them, under the supervision of the towpilot.</p>\r\n<p>Members who are private owners are responsible for assembling their own gliders (with volunteer help from other members), and the ADO and DO should coordinate the movement of private gliders with Club tow vehicles on the airport.&nbsp;</p>\r\n<p>Note: Some private owners may push their own gliders from the hangar or use their on vehicles; if the latter, they must coordinate with the DO before driving their vehicles on airport taxiways and ramp and promptly remove the vehicles when the towing is complete.</p>",
+      "last_updated": "2015-02-06",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 189,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>What actions should the DO take before commencing flight operations?</p>",
+      "option_a": "Contact Potomac Tracon, conduct Safety Briefing, set up club computer for operations, get approval for correct operations runway from fixed base operator, identify wingrunners, assure towropes and gliders are inspected, confirm Duty Instructor, Duty Towpilot(s), and Assistant DO are present, confirm VHF radios are functional",
+      "option_b": "Contact Potomac Tracon, conduct Safety Briefing, set up club computer for operations, identify correct operations runway, identify wingrunners, assure towropes and gliders are inspected, confirm Duty Instructor, Duty Towpilot(s), and Assistant DO are present, hang up flag (if operation from runway 28), confirm all radios are avaialble and functional",
+      "option_c": "Contact Potomac Tracon, insure that water/beverages are available, conduct Safety Briefing with all members present, set up club computer for operations, identify correct operations runway, identify wingrunners, confirm towropes and gliders are inspected, confirm Duty Instructor, Duty Towpilot(s), and Assistant DO are present, hang up flag (if operation from runway 28), confirm all radios are avaialble and functional",
+      "option_d": "Contact Potomac Tracon, conduct Safety Briefing, set up club computer for operations, identify correct operations runway, identify wingrunners, assure towropes and gliders are inspected, confirm Duty Instructor, Duty Towpilot(s), and Assistant DO are present, hang up flag (if operation from runway 28), confirm al personal radios are avaialble and functional",
+      "correct_answer": "C",
+      "explanation": "<div class=\"page\" title=\"Page 2\">\r\n<div class=\"layoutArea\">\r\n<div class=\"column\"><span style=\"font-size: 10.000000pt; font-family: 'TimesNewRomanPSMT';\">That's a lot of stuff, right?&nbsp; You can find more detailed information in the Operations Manual, Section 2.2.1 and the Duty Officer Instructions and Checklist (q.v.). </span></div>\r\n<div class=\"column\">&nbsp;</div>\r\n<div class=\"column\"><span style=\"font-size: 10.000000pt; font-family: 'TimesNewRomanPSMT';\">At the beginning of each operating day, the Duty Officer shall notify the Potomac TRACON Supervisor by telephone of the planned start/finish times for glider operations, maximum altitudes expected, and the approximate area of most glider traffic with reference to appropriate local NAVAIDS. (There is some suggested 'patter' you can use on the Club's logsheet program.)<br /></span>\r\n<p><span style=\"font-size: 10.000000pt; font-family: 'TimesNewRomanPSMT';\">The Duty Officer shall conduct a daily coordination briefing with all members of the duty crew and all available Club members. The Duty Officer will brief the critical information individually to members who arrive after the initial briefing. The Duty Officer will determine the active runway for Skyline operations by coordinating with the airfield manager and the duty tow pilot and duty instructor, will continue to verify that the proper runway is in use, and make appropriate changes in the glider operations as needed. When the glider pattern is changed, he/she should notify all glider pilots of the change, including those who are airborne, via radio. . . . The decision to launch gliders from the currently active end and recover on the other end, versus just ground- towing gliders to the other end for the next launch, is a judgment call left to the Duty Officer after consultation with the airfield manager and the duty tow pilot and duty instructor. </span></p>\r\n<p><span style=\"font-size: 10.000000pt; font-family: 'TimesNewRomanPSMT';\">In addition to notifying pilots of changes in the glider pattern, the Duty Officer shall ensure that gliders announce taking the active runway on the radio. Detailed radio operation procedures are included in the Skyline Duty Officer Instructions and Checklist. </span></p>\r\n<p><span style=\"font-size: 10.000000pt; font-family: 'TimesNewRomanPSMT';\">Understand that these are the minimum actions to be taken; you will inevitably discover the need for variations due to unique circumstances presented by the day, and your role as coordinator/assignment of the actions of all members present should help you decide exactly how to organize the day for safe and efficient operation. </span></p>\r\n<p>&nbsp;</p>\r\n<p>&nbsp;</p>\r\n</div>\r\n</div>\r\n</div>",
+      "last_updated": "2015-02-07",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 190,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>What is included in the morning Safety Briefing?</p>",
+      "option_a": "Introduce fixed base operator (Reggie or Magan), whose responsibility it is to conduct safety briefings at KFRR.  Consult with them to determine what safety-related actions the Club is responsible for.",
+      "option_b": "Identify duty crew (including augmenting staff like towpilots and/or instructors), weather (including health-related issues such as heat, wind, and cold), operational status of all vehicles, determine who may be flying cross-country, review of signals and emergency procedures, and reminder to pay up before leaving",
+      "option_c": "Assign the Duty Instructor (alternate: Duty Towpilot) to inform all present of concerns unique to the day that pilots should be aware of",
+      "option_d": "All of the above.",
+      "correct_answer": "B",
+      "explanation": "<p>This is all covered in Operations Manual Section 2.2.1:</p>\r\n<div class=\"page\" title=\"Page 2\">\r\n<div class=\"layoutArea\">\r\n<div class=\"column\">\r\n<p><span style=\"font-size: 11.000000pt; font-family: 'Cambria';\">2.2.1 Coordination &amp; Communication </span></p>\r\n<p><span style=\"font-size: 10.000000pt; font-family: 'TimesNewRomanPSMT';\">Before initiating operations, the Duty Officer shall conduct a daily coordination briefing with all members of the duty crew and all available Club members. The Duty Officer will brief the critical information individually to members who arrive after the initial briefing. Minimum required briefing items include the following: </span></p>\r\n<p><span style=\"font-size: 10.000000pt; font-family: 'TimesNewRomanPSMT';\">&bull; Identification of the assigned duty crew, and volunteer augmenting towpilots / instructors &bull; Weather, NOTAMS, and facility status for KFRR and logical alternates<br /> &bull; Physiological considerations<br /> &bull; Status of gliders, towplanes, and tow vehicles</span></p>\r\n<p><span style=\"font-size: 10.000000pt; font-family: 'TimesNewRomanPSMT';\">&bull; Contact information exchange for any glider pilots flying outside safe no-lift gliding distance, and retrieve considerations &bull; Initial flying line-up<br /> &bull; Review of launch procedures and signals, and critical tow signals<br /> &bull; Emergency actions and Emergency Response Plan </span></p>\r\n<p><span style=\"font-size: 10.000000pt; font-family: 'TimesNewRomanPSMT';\">&bull; Responsibility to confirm with Duty Officer the accuracy of logged flight data, and to settle payments </span></p>\r\n</div>\r\n</div>\r\n</div>",
+      "last_updated": "2015-02-07",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 191,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Ian Fleming has been a member of the club for several years. One April Saturday he shows up to take an instructional flight. When his turn comes, the DO goes to pull Ian&rsquo;s name down from the drop-down list, but it is not there. What should the DO do?</p>",
+      "option_a": "Go to the \u201cMembers\u201d tab on the field computer and click on the \u201cFull\u201d tab. Unclick all the boxes for initiation fees, SSC dues, and SSA membership, type in Ian\u2019s name in the box then hit \u201cAdd Full Member\u201d. Ian is now ready to take his flight.",
+      "option_b": "Instruct Ian that there is an issue with his current status with the club and to contact the Membership Officer, Treasurer, Safety Officer, or a member of the Board. Ian is free to fly and the DO can log his flight as a guest to the instructor with Ian as the alternate payer.",
+      "option_c": "Instruct Ian that there is an issue with his current status with the club and to contact the Membership Officer, Treasurer, Safety Officer, or a member of the Board. Ian is not free to fly unless the conflict is resolved.",
+      "option_d": "The DO may substitute Ian\u2019s name with his (the DO), allowing Ian to fly, and putting Ian as the alternate payer.",
+      "correct_answer": "C",
+      "explanation": "<p>Ian has been placed on the No-Fly list for non-payment of dues and fees, has not satisfied his requirement to attend the Safety Meeting, or because a actions taken by the Board of Directors.</p>",
+      "last_updated": "2015-03-11",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 192,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>A release altitude of &ldquo;0&rdquo; (zero) feet:</p>",
+      "option_a": "<p>Fails validation</p>",
+      "option_b": "<p>Is valid</p>",
+      "option_c": "<p>Automatically sets 300 feet</p>",
+      "option_d": "<p>Is treated as missing</p>",
+      "correct_answer": "B",
+      "explanation": "<p>Validation requires release altitude to be present, but the number of 0 is still valid.&nbsp; There's a possibility that the glider and tow plane got launched, and the rope broke, or the launch was otherwise aborted. The glider either lands straight ahead, or continues to roll on the runway.&nbsp; In either case, a 0 (zero) is a valid entry on the logsheet program.&nbsp;</p>\r\n<p>Compare that with a launch that has an unlisted release altitude, listed as \"-----\" on the logsheet program.&nbsp; A missing release altitude is grounds for the logsheet to fail validation when you're finalizing the logsheet.&nbsp;</p>\r\n<p>In this case, 0 (zero) and missing \"-----\" are separate concepts, and treated differently from the logsheet program's perspective.&nbsp;</p>\r\n<p>In the case of billing for Skyline Soaring Club, there is a hookup fee of 25 dollars.&nbsp; If the duty officer believes that the conditions of the aborted launch don't merit the hookup fee of 25 dollars, the duty officer can always select \"Free Tow\" for this flight.&nbsp;</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 193,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Visiting pilots are added to the system by:</p>",
+      "option_a": "<p>Manually typing their name into the flight modal</p>",
+      "option_b": "<p>Admin-only database entry</p>",
+      "option_c": "<p>The \"Register Visiting Pilot\" QR Code feature</p>",
+      "option_d": "<p>Selecting \"UNKNOWN Private\"</p>",
+      "correct_answer": "C",
+      "explanation": "<p>The QR-based Visiting Pilot feature registers them.&nbsp; It's really important to get your information from the pilot at the day of operations.&nbsp; The best way to do this is to have the visiting pilot enter their own information.&nbsp; Duty Officers are&nbsp;<em>notoriously bad</em> at entering the user's name correctly.&nbsp; An incorrectly-entered name can haunt a user for years-to-come!</p>\r\n<p>If you got this wrong, please re-read the section in the logsheet-instructions document: See the \"Visiting Pilot\" section under \"<a href=\"https://www.skylinesoaring.org/cms/restricted-documents/duty-officer-instructions/logsheet-instructions/#FinancePage\">Finances</a>\"<br><br></p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 194,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Which statement(s) are true regarding how the Glider Flying Handbooks required wing runners to signal a glider launch?</p>",
+      "option_a": "Rotate your right arm in a circular motion",
+      "option_b": "Rotate your left arm in a circular motion",
+      "option_c": "Watch for glider pilot to wag rudder before rotating arm",
+      "option_d": "A or B plus C",
+      "correct_answer": "D",
+      "explanation": "<p>This is kind of a no brainer. It doesn&rsquo;t matter which arm you rotate or in which direction. All the matters is that the tow pilot can easily see and acknowledge the signal and that there's clear coordination between the glider pilot and the wingrunner.</p>",
+      "last_updated": "2015-03-13",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 196,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Chris, who is not a member of the club, wants to buy a polyester Skyline Soaring Club shirt for his girlfriend. How does the DO complete this transaction?</p>",
+      "option_a": "Go to the \"Finances\" tab in the field computer and select \"Charges\". Select Chris' name from the drop-down box. Type in the $16.00 for the charge. Then select \"Clothing Sale\" from the Item box. In the comment box",
+      "option_b": "Go to the \"Finances\" tab in the field computer and select \"Charges\". Since Chris is not a member, leave the name drop-down box empty but go to the Alternative Payer box and type in his name. Type in the $16.00 for the charge and select \"Clothing Sale\" from the Item box. In the comment box, enter a statement indicating Chris purchased a polyester shirt and paid with a check. ",
+      "option_c": "Politely explain to Chris that merchandise can be sold to only club members.",
+      "option_d": "Go to the \"Finances\" tab in the field computer and select \"Charges\". Since Chris is not a member, leave the name drop-down box empty temporarily. Type in the $16.00 for the charge and select \"Clothing Sale\" from the Item box. In the comment box, enter a statement indicating Chris purchased a polyester shirt and paid with a check. Now go to the \u201cMembers\u201d tab and select \u201cPayer\u201d. Type is Chris\u2019 name and hit Add Payer. Now go back to the \u201cFinances\u201d tab, then \"Charges\" and select the aforementioned input. Find Chris' name that has now been entered in the drop-box.",
+      "correct_answer": "C",
+      "explanation": "<p><em>As a not-for-profit club, we are not allowed to sell merchandise to those who are not club members.&nbsp;</em> However, it's not unheard of for a member, perhaps overhearing the conversation or reacting to the needs of one of theri guests, to volunteer to purchase the item and then give it to the non-member . . . leaving no trace of a sale to a non-member on club records.</p>",
+      "last_updated": "2017-04-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 197,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>In the course of the day Orville Wright is able to satisfy Bob that he can successfully and safely fly the Grob 103 solo. Orville completes a 35-minute glider flight and a safe landing. What can the Duty Office now do?</p>",
+      "option_a": "Put a nice write-up in the daily operations report calling out Orville as successfully completing his first solo flight.",
+      "option_b": "In the field computer, go to the \"Shutdown\" tab and select \"Award\". Select Orville's name from the drop-down box, select \"A Badge\" from the award drop-down box, when make a comment regarding what glider was used and any other pertinent information.",
+      "option_c": "Coordinate with the ground crew to make sure photographs are take of Orville, Bob and the tow pilot.",
+      "option_d": "Both A. and B, with C optional",
+      "correct_answer": "D",
+      "explanation": "<p>Sometimes the instructor and/or oher crew may want to 'dunk' the new solo with a bucket of water or 'trim their tail' by cutting off the back of their shirt and writing congratulatory comments on it.&nbsp; While these are traditions, not every new solo may appreciate them! Students who are nearing their first solo&nbsp;should be made aware of the tradition before they show up at the airport with the nicest shirt they own.&nbsp;</p>",
+      "last_updated": "2017-04-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 198,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>The Visiting Pilot URL:</p>",
+      "option_a": "<p>Requires login</p>",
+      "option_b": "<p>Never expires</p>",
+      "option_c": "<p>Expires after 24 hours</p>",
+      "option_d": "<p>Works in offline mode</p>",
+      "correct_answer": "C",
+      "explanation": "<p>The URL disappears 24 hours after creation.&nbsp;</p>\r\n<p>[ <a href=\"https://www.skylinesoaring.org/cms/restricted-documents/duty-officer-instructions/logsheet-instructions/#FinancePage\">Reference</a> See \"Visiting Pilot\"]</p>\r\n<p>The visiting pilot mode does not work in offline mode.&nbsp;</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 199,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Before creating a new logsheet for the day, what is required?</p>",
+      "option_a": "<p>At least one flight must already be queued</p>",
+      "option_b": "<p>The Club Laptop must be connected to the Internet</p>",
+      "option_c": "<p>The MiFi must be turned on</p>",
+      "option_d": "<p>All pilots must have signed in</p>",
+      "correct_answer": "B",
+      "explanation": "<p data-start=\"1021\" data-end=\"1209\">The documentation states that starting a new logsheet requires Internet access (Offline mode does not allow starting a logsheet)</p>\r\n<p data-start=\"1021\" data-end=\"1209\"><a href=\"https://www.skylinesoaring.org/cms/restricted-documents/duty-officer-instructions/logsheet-instructions/\">https://www.skylinesoaring.org/cms/restricted-documents/duty-officer-instructions/logsheet-instructions/</a></p>\r\n<ul data-start=\"1211\" data-end=\"1416\">\r\n<li data-start=\"1211\" data-end=\"1275\">\r\n<p data-start=\"1213\" data-end=\"1275\">A is incorrect: You cannot queue flights without a logsheet.</p>\r\n</li>\r\n<li data-start=\"1276\" data-end=\"1349\">\r\n<p data-start=\"1278\" data-end=\"1349\">C is incorrect: Any Internet connection works; MiFi is not mandatory.</p>\r\n</li>\r\n<li data-start=\"1350\" data-end=\"1416\">\r\n<p data-start=\"1352\" data-end=\"1416\">D is incorrect: Pilot sign-in is unrelated to logsheet creation.</p>\r\n</li>\r\n</ul>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 200,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Scenario: Fidel has arrived at the club with a brand new glider.&nbsp; It's so new that nobody has had time to enter the details about that glider into the system.&nbsp; You look for the glider in the pull-down menu, but can't find it. How do you log the flight with Fidel in the logsheet program?</p>",
+      "option_a": "<p>Refuse to log the flight</p>",
+      "option_b": "<p>Select \"UNKNOWN Private\" as the glider.&nbsp; It should be at the bottom of the list of available gliders.&nbsp;</p>",
+      "option_c": "<p>Tell Fidel to use another member&rsquo;s glider</p>",
+      "option_d": "<p>Create the glider yourself in admin</p>",
+      "correct_answer": "B",
+      "explanation": "<p>D could also be a correct answer only if the duty officer is Ertan Tete (who happens to be a website admin).&nbsp; Otherwise, just mark it as 'UNKNOWN Private\" and let the webmasters update the information later.&nbsp; Be sure to get the N number of the new private glider, so all of the details can be entered correctly into the system.&nbsp;</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 201,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>What responsibilities does the Duty Officer not have?</p>",
+      "option_a": "Maintaining the flight log, make sure the flight line is moving efficiently, and crowd control",
+      "option_b": "Welcoming and answering soaring related questions from visitors and assist with completing membership forms.",
+      "option_c": "Provide the primary radio interface between the ground and flight operations.",
+      "option_d": "Monitor weather conditions and modify ongoing flight activities accordingly.",
+      "correct_answer": "B",
+      "explanation": "<p>The DO is responsible for safe and efficient glider operations. Anything that distracts from that responsibility is not accountable to the DO and should be handled by the ADO or more preferably another club member. The DO is not responsible for visitors, other than making sure they safety is maintained.</p>",
+      "last_updated": "2015-03-22",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 202,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Full-Member Franco has brought a brand-new motorglider to the field. &nbsp;He has launched his self-launch motorglider, flew around for several hours, and landed back at Front Royal. How do you log this flight?&nbsp;</p>",
+      "option_a": "<p>Mark the towplane as \"SSC Pawnee\", List him as the pilot of the glider, and the glider of the towplane. Add a note at the end of the ops report to have the treasurer and webmaster make any necessary corrections.</p>",
+      "option_b": "<p>Select \"Self-Launch\" sailplane in the drop down field for gliders, fill in the pilot's name as the tow pilot as well as the glider pilot.</p>",
+      "option_c": "<p>Select \"UNKNOWN Private\" for the glider. Select \"Self-Launch\" as the tow plane.&nbsp;</p>",
+      "option_d": "<p>Since he is not using any club resources, it is not necessary to log this flight at all.</p>",
+      "correct_answer": "C",
+      "explanation": "<p>Now that we have a few motor gliders in the club that are capable of self-launching, we would like to keep usage stats on them, even if they are not using club resources when flying. &nbsp;We have created a special tow pilot and glider that are presented in the drop down menus that allow you to select self-launch as the tow plane. &nbsp;A tow charge won't be applied to self-launch gliders.&nbsp;</p>\r\n<p>&nbsp;</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 203,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>On what promises to be a really good soaring day, several private owners show up, all intending to attempt FAI badge cross-country flights.&nbsp; George Gliderguy announces that he is attempting a 500K diamond distance. He uses this badge attempt to get early into the queue. After launch, he returns only 20 minutes after takeoff. George asks for a priority relight. Where does George go into the launch queue?</p>",
+      "option_a": "George gets the next tow, since he is attempting an FAI badge flight (reference Ops Manual 2.4)",
+      "option_b": "George gets the first tow after all the other pilots who are attempting a badge flight have had one launch, but pre-empts other members waiting for a tow in Club ships..",
+      "option_c": "George gets the first tow according to his arrival time at the airport, as recorded in the launch queue established at the start of the day.",
+      "option_d": "George gets a tow whenever there is an occasion when the towplane is not otherwise engaged in towing.",
+      "correct_answer": "C",
+      "explanation": "<p>Well, TECHNICALLY, C is the correct answer. Ops Manual Section 2.4 gives George a SINGLE priority for tow, so if he screws it up then he has to fall back on the 'normal' sequencing rules.&nbsp; However, if there is a towplane sitting idle and there are no other members who have a priority for a launch (e.g., planning for a badge or record flight), then D could well be chosen.&nbsp; While the Duty Officer has final authority on the tow priority, he is also free to exercise discretionary good judgement.</p>",
+      "last_updated": "2017-04-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 204,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>A student and instructor are doing several repeated rope breaks in the same ASK-21. After landing from the first 3-minute flight, what is the most efficient and correct way to log the next one?</p>",
+      "option_a": "<p>Add a new flight manually and re-enter everything</p>",
+      "option_b": "<p>Edit the existing flight and overwrite times</p>",
+      "option_c": "<p>Clone the flight and enter new times</p>",
+      "option_d": "<p>Leave it unlogged until end of day</p>",
+      "correct_answer": "C",
+      "explanation": "<p>Cloning copies pilot, instructor, glider, and release altitude while leaving times blank.</p>\r\n<ul>\r\n<li>A wastes time.</li>\r\n<li>B destroys the historical record of the first flight.</li>\r\n<li>D creates operational risk and increases error probability.</li>\r\n</ul>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 205,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>What actions should the DO take at the hangar to setup the Skyline Base Station radio at the beginning of the operating day?</p>",
+      "option_a": "Disconnect the base station charger from the 110 volt AC outlet, place the charger in the trailer for transport to the operating position, and assemble antenna poles.",
+      "option_b": "Disconnect the charger from the radio, turn off the charger, and leave it in the hangar and assemble the antenna poles.",
+      "option_c": "Disconnect the base station charger from the 110 volt AC outlet, place the charger in the trailer, and transport the base station and antennas to the operating position.",
+      "option_d": "Disconnect the charger from the radio, turn off the charger, and leave it in the hangar, and transport the base station and antennas to the operating position.",
+      "correct_answer": "D",
+      "explanation": "<p>The charger should be disconnected from the radio, turned off and left in the hangar. The red and black cable coming from the back of the radio is not connected to anything during the operating day. The radios are powered by a battery inside the radio case. The antenna poles should be assembled at the operating position, not at the hanger.</p>",
+      "last_updated": "2015-05-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 206,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>What actions should the DO take at the operating position (runway 10 or runway 28) to setup the Skyline Base Station radio at the beginning of the operating day?</p>",
+      "option_a": "Remove the bungee cords holding the antenna and mast sections.  Remove the antenna and fold the black antenna elements away from the white center element so they form a 45 degree angle.  Assemble the two antenna poles and place them in the white PVC pipes attached to the trailer.  Make sure the antenna cables are free and have no sharp bends.  Turn on the chrome power switch located on the jack panel and verify that the green light is on and the fan is running.  Set the frequency of one of the radios to 123.3 and the other to 123.0.  Plug the mike into the mike jack for the radio set to 123.0.  Verify the volume setting of each radio by pressing the \u201ctest\u201d button and listening to the noise",
+      "option_b": "Remove the bungee cords holding the antenna and mast sections.  Remove the antenna and fold the black antenna elements away from the white center element so they form a 45 degree angle.  Assemble the two antenna poles and place them in the white PVC pipes attached to the trailer.  Make sure the antenna cables are free and have no sharp bends.  Turn on the chrome power switch located on the jack panel and verify that the green light is on and the fan is running.  Set the frequency of one of the radios to 123.3 and the other to 123.0.  Plug the mike into the mike jack for the radio set to 123.3.  Verify the volume setting of each radio by pressing the \u201ctest\u201d button and listening to the noise.  ",
+      "option_c": "Remove the bungee cords holding the antenna and mast sections.  Remove the antenna and fold the black antenna elements away from the white center element so they form a 90 degree angle.  Assemble the two antenna poles and place them in the white PVC pipes attached to the trailer.  Make sure the antenna cables are free and have no sharp bends.  Turn on the chrome power switch located on the jack panel and verify that the green light is on and the fan is running.  Set the frequency of one of the radios to 123.3 and the other to 123.0.  Plug the mike into the mike jack for the radio set to 123.3.  Verify the volume setting of each radio by pressing the \u201ctest\u201d button and listening to the noise.  ",
+      "option_d": "Remove the bungee cords holding the antenna and mast sections.  Remove the antenna and fold the black antenna elements away from the white center element so they form a 90 degree angle.  Assemble the two antenna poles and place them in the white PVC pipes attached to the trailer.  Make sure the antenna cables are free and have no sharp bends.  Turn on the chrome power switch located on the jack panel and verify that the green light is on and the fan is running.  Set the frequency of one of the radios to 123.3 and the other to 123.0.  Plug the mike into the mike jack for the radio set to 123.0.  Verify the volume setting of each radio by pressing the \u201ctest\u201d button and listening to the noise.  ",
+      "correct_answer": "C",
+      "explanation": "<p>The three black antenna elements should be set at a 90 degree angle to the white center element. Setting them at another angle degrades the performance of the antenna. The mic should be plugged into the jack for the radio set to 123.3 MHz which is the frequency assigned by the FCC to the Skyline base station.</p>",
+      "last_updated": "2015-05-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 207,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p><strong></strong>The DO wishes to set Radio 1 to 123.3 MHz. How is this done?</p>",
+      "option_a": "Tune the standby frequency (red display) of Radio 1 to 123.0 MHz and the active frequency (yellow display) of Radio 1 to 123.3 MHz",
+      "option_b": "Tune the standby frequency of Radio 1 to 123.3 MHz and the active frequency of Radio 1 to 123.0 MHz.",
+      "option_c": "Tune the standby frequency of Radio 1 to 123.3 MHz and press the flip/flop button labelled with a double arrow.",
+      "option_d": "Tune the active frequency of Radio 1 to 123.3 MHz and press the flip/flop button labelled with a double arrow.",
+      "correct_answer": "C",
+      "explanation": "<p>The radio frequency can only be changed by setting the standby (red display) frequency to the desired value and then loading that frequency as the active frequency (yellow display) by pressing the flip/flop button labelled with a double arrow. The active frequency cannot be set directly.</p>",
+      "last_updated": "2015-05-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 208,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>The DO wishes to contact a glider which is aloft and ask whether any lift has been found. May the DO use the base station to do this?</p>",
+      "option_a": "The DO may use the base station radio turned to 123.3 MHz to contact the glider and inquire about lift",
+      "option_b": "The DO may use the base station radio turned to 123.0 MHz to contact the glider and inquire about lift.",
+      "option_c": "The DO should ask the FBO to use the UNICOM radio tuned to 123.0 MHz to contact the glider and inquire about lift.",
+      "option_d": "Neither the base station radio nor the UNICOM radio may be used to make an inquiry about lift.",
+      "correct_answer": "A",
+      "explanation": "<p>The base station radio is licensed by the FCC to use the frequency 123.3 MHz for the coordination of soaring activities between gliders, tow aircraft and ground stations. This would include using the radio to discuss lift conditions. The base station is not licensed to use the UNICOM frequency 123.0 MHz and should not transmit on the UNICOM frequency except in an emergency. The FBO should not be asked to use the UNICOM frequency to make inquiries about lift conditions. The UNICOM frequency is reserved for communication related to airport operations, requests for ground transportation, food and lodging, communications with ground vehicles, relaying certain limited information to ATC and communications related to safety of life and property. The base station radio may be used to receive (monitor) any aviation frequency.</p>",
+      "last_updated": "2015-05-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 209,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p><strong></strong>The Soaring operation has ended for the day and trailer has been placed in the hangar. What action should the DO take with regard to the base station radio?</p>",
+      "option_a": "The radio power switch should be turned off (green light will go out).  The charger should be connected to the red and black wire coming from the back of the cabinet.  The charger should be turned on and placed on the top of the radio cabinet.",
+      "option_b": "The radio power switch should be turned off (green light will go out).  The charger should be connected to the red and black wire coming from the back of the cabinet.  The charger should be placed in the trailer or on the floor where it cannot fall.",
+      "option_c": "The radio power switch should be turned off (green light will go out).  The charger should be connected to the red and black wire coming from the back of the cabinet.  The charger should be placed in the trailer or on the floor where it cannot fall. There should be space around the charger to allow for ventilation because the charger runs warm in the normal course of operation.",
+      "option_d": "The charger should not be connected when the radios are not in use.  The charger is used to charge the radios when they are in operation.  ",
+      "correct_answer": "C",
+      "explanation": "<p>The charger should not be placed on top of the radio cabinet because of the danger that it could fall and be damaged. The charger runs warm during operation and for this reason there should be space for ventilation around it. The radios are powered by batteries and so the charger is disconnected and left in the hanger during the operating day. The charger is connected to the radios when the trailer is returned to the hanger at the end of the day.</p>",
+      "last_updated": "2015-05-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 226,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>If you lift the truck bed of the Gator (by pressing the release on the front driver's side corner of the truck bed), you will get this view.&nbsp; The yellow cap in this picure is for . . . .</p>\r\n<p><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/Gator-yellow-cap.jpg\" alt=\"Gator Truck Bed\" width=\"480\" height=\"640\"></p>",
+      "option_a": "<p>Filling the gas tank</p>",
+      "option_b": "<p>Filling the transmission fluid</p>",
+      "option_c": "<p>Filling the engine oil reservoir</p>",
+      "option_d": "<p>None of the above</p>",
+      "correct_answer": "C",
+      "explanation": "<p>The engine oil level should be checked every morning when getting the equpment out of the hangar.&nbsp; This cap also contains the oil dipstick.</p>",
+      "last_updated": "2026-01-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 227,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>The larger orange knob in this picture of the Gator is . . .</p>\r\n<p><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/Gator_Controls.jpg\" alt=\"controls in the gator\" width=\"640\" height=\"640\"></p>",
+      "option_a": "<p>Gear selection lever</p>",
+      "option_b": "<p>Parking brake lever</p>",
+      "option_c": "<p>Four-wheel lockout lever</p>",
+      "option_d": "<p>Truck bed release lever</p>",
+      "correct_answer": "A",
+      "explanation": "<p>It has three positions - that way, the other way, and neutral.&nbsp; The smaller knob locks the differential if the Gator gets stuck and a wheel is spinning (do not operate in the locked position normally!). You can also see the fuel tank guage, the round white dial just below the parking brake hanlde.</p>",
+      "last_updated": "2026-01-28",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 228,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>Wieght and balance calculations should be performed prior to every flight. What is the maximum weight specified in the ASK-21&nbsp;Flight Manual?</p>",
+      "option_a": "792 lbs",
+      "option_b": "902 lbs",
+      "option_c": "1140 lbs",
+      "option_d": "1320 lbs",
+      "correct_answer": "D",
+      "explanation": "<p>ASK-21 Flight Manual (9 Mar 83), Section II.6</p>\r\n<p>Empty Weight approx 792 lbs</p>\r\n<p>Max weight of all non-lift producing memebers 902 lbs</p>\r\n<p>Max all weight 1320 lbs</p>",
+      "last_updated": "2015-08-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 229,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>Weight and balance calculations should be perfomed prior to every flight. What is the maximum payload (yes...maximum means the parachute weight counts) for the front seat in the ASK-21?</p>",
+      "option_a": "154 lbs",
+      "option_b": "200 lbs",
+      "option_c": "242 lbs",
+      "option_d": "286 lbs",
+      "correct_answer": "C",
+      "explanation": "<p>ASK-21 Flight Manual (9 Mar 83), page 13, section II.8.</p>\r\n<p>Minimum payload is 154 lbs...max is 242 lbs...</p>",
+      "last_updated": "2015-08-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 230,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>Flight performace is adversealy affected by precepitation. What does the ASK-21 Flight Manual recommend for final approach if it is raining?&nbsp;&nbsp;</p>",
+      "option_a": "The Flight Manual is silent on this matter",
+      "option_b": "Slip the glider for better inflight visibility ",
+      "option_c": "Add 5 knots to your approach speed as a safety margin",
+      "option_d": "Reduce your approach speed by 5 knots as a safety margin",
+      "correct_answer": "C",
+      "explanation": "<p>ASK-21 Flight Manual (9 Mar 83), page 23, Section III.3.</p>\r\n<p>As a safety margin add 5 knots to the approach speed</p>",
+      "last_updated": "2015-08-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 231,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>It is permissible to launch without a wing runner. If you are departing from an area of high grass or rough ground, what is your immediate action procedure in the event of ground looping?</p>",
+      "option_a": "Release the tow rope",
+      "option_b": "Raise the wing ",
+      "option_c": "Lift off sooner to get airborne",
+      "option_d": "Always use a wing runner in these conditions",
+      "correct_answer": "A",
+      "explanation": "<p>ASK-21 Flight Manual (9 Mar 83), page 25, Section III.5</p>\r\n<p>Release the tow rope immediately</p>",
+      "last_updated": "2015-08-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 232,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>You have landed out and are preparing to fly home the following morning. The gliderport you are departing from is unfamiliar with the ASK-21. In your preflight briefing with the tow pilot, after you have visually&nbsp;inspected the&nbsp;tow rope, s/he asks you if there is a maximum speed for your ship on tow. What say you?</p>",
+      "option_a": "Yes...but it exceeds your tow plane's capabilities",
+      "option_b": "No..I'm a great pilot on tow so just fly and I can handle whatever you can give me",
+      "option_c": "Yes...thank you for asking! 97 kts for the launch this morning, please",
+      "option_d": "Yes...thank you for asking! 75 kts for the launch this morning, please",
+      "correct_answer": "C",
+      "explanation": "<p>ASK-21 Flight Manual (9 Mar 83), page 32, IV.4</p>\r\n<p>Max tow speed is 97 kts...112 mph</p>\r\n<p>Most favorable tow speed during climb is 50-75 kts...56-87 mph</p>\r\n<p>Lift off occurs at approx 40 kts or 47 mph</p>",
+      "last_updated": "2015-08-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 233,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>Wilbur Wright used the term \"stall\" for the first time in 1904 when describing&nbsp;a climbing turn he witnessed&nbsp;Orville perform&nbsp;(the two agreed early on not to&nbsp;fly together so if something happened the other would carry on the work. But I digress). Does the use of airbrakes in the pattern&nbsp;increase or decrease the stall speed of the ASK-21?</p>",
+      "option_a": "Decreases your stall speed by about 1.6 kts because you are slowing down",
+      "option_b": "Increases your stall speed by about 1.6 kts  ",
+      "option_c": "Neither...stalls don't occur at the lower speeds we fly in the pattern",
+      "option_d": "The ASK-21 has spoilers so it doesn't matter",
+      "correct_answer": "B",
+      "explanation": "<p>ASK-21 Flight Manual (9 Mar 83), page 34, IV.8</p>\r\n<p>The airbrakes increase the stalling speed by about 1.5 kts or 3 km/h.</p>",
+      "last_updated": "2021-05-09",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 234,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>What are the prohibited aerobatic manuevers in the ASK-21?</p>",
+      "option_a": "All abrupt aerobatic maneuvers",
+      "option_b": "Loop forward (outside loop)",
+      "option_c": "Tail sliding",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "<p>ASK-21 Flight Manual (9 Mar 83), page 36</p>\r\n<p>All of the above.</p>",
+      "last_updated": "2021-06-28",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 235,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>Is it permissible to fly the ASK-21 solo from the back seat?</p>",
+      "option_a": "Sure...just make sure you have ballast in the front seat",
+      "option_b": "Never",
+      "option_c": "Only if the SSC DO authorizes the flight",
+      "option_d": "Always",
+      "correct_answer": "B",
+      "explanation": "<p>ASK-21 Flight Manual (9 Mar 83), page 49</p>\r\n<p>Never fly the glider from the rear seat only.</p>",
+      "last_updated": "2015-08-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 236,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>The ASK-21 Flight Manual authorizes&nbsp;aerobatic manuevers. Another authoritative&nbsp;source document&nbsp;are&nbsp;the Federal Aviation Regulations (FARs). FAR 91.307 provides the guidance pilots&nbsp;need on performing aerobatics. Is that correct?</p>",
+      "option_a": "True",
+      "option_b": "False",
+      "option_c": "N/A",
+      "option_d": "N/A",
+      "correct_answer": "B",
+      "explanation": "<p>False.</p>\r\n<p>FAR Sec 91.307, Parachutes and Parachuting. This FAR describes intentional manuevers that exceed certain parameters, but the intent of this FAR is just about parachutes NOT about aerobatics.</p>\r\n<p>Go to FAR Sec 91.303, Aerobatic Flight, to find definitive guidnace for pilots flying acro.</p>",
+      "last_updated": "2016-04-24",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 237,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>The ASK-21 is known world-wide as the best sailplane available for initial flight training through solo to certification and is for fun soaring. It has a fair glide ratio (34-to-1) and a low minimum sink rate that allows the \"K-21\" to climb in weak thermals. But you can't fly it if you break the canopy. Which are important&nbsp;\"Canopy Rules\" for handling the K-21?</p>",
+      "option_a": "Closed and locked at all times",
+      "option_b": "Close rear canopy first and always close them ground towing",
+      "option_c": "Never lift a canopy by the plexiglass or the open vent window",
+      "option_d": "All of the above ",
+      "correct_answer": "D",
+      "explanation": "<p>All of the above...plus:</p>\r\n<p>Do not scratch the canopies with rings, watches, belt buckles, cellphones...</p>\r\n<p>When sitting in the glider keep one hand up holding the canopy.</p>\r\n<p>Rear canopy closes first...both latches completly forwards and \"clicked\"</p>\r\n<p>Canopy hinges are easily damaged in the wind.</p>",
+      "last_updated": "2015-08-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 238,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>Ground handling is an important&nbsp;aspect of our sport. The wingspan of the ASK-21 is 17 meters/56 feet. This leaves little room with the hangar openings. What are important ground handling techniques to ensure our operation runs smoothly and safely?</p>",
+      "option_a": "Helpers give a \"thumbs up\" at each wingtip (better than a verbal)",
+      "option_b": "Push gently down on the nose to lift the tailwheel--DO NOT SKID the tailwheel sideways",
+      "option_c": "Never leave the glider with the removable tail wheel dolly attached ",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "<p>Moving the ASK-21 means we usually push it backwatds by the nose or wing root</p>\r\n<p>Both canopies fully closed</p>\r\n<p>Don't try to turn the glider by the wingtip without having a helper push the nose down</p>\r\n<p>To push the glider forward, leave the canopies closed and push from behind the wing, palms flat on top of the wing, near the spar</p>",
+      "last_updated": "2015-08-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 239,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>Ground handling is an important&nbsp;aspect of our sport. After you have completed your Before Takeoff Checklist and are marshalled into&nbsp;position on the active runway, it is easy to become distracted. Tow plane, wing runners, radios, tow rope last minute inspection, and making sure the glider is pointed in the right direction. As the PIC, you have the task to retain Situational Awareness on all of this activity and to be directive, as needed, to ensure safe operations. Why is ensuring pre-takeoff runway alignment so important in the ASK-21?</p>",
+      "option_a": "Because the prevailing winds will shift",
+      "option_b": "Because with low speeds without rudder and elevator authority, the K-21 will roll wherever it is pointed",
+      "option_c": "Because the prop wash from the tow plane will affect lift off speed",
+      "option_d": "Because you are solo the rear canopy may come unlatched",
+      "correct_answer": "B",
+      "explanation": "<p>At the start of the takeoff roll the glider will go in the direction it is pointed.</p>\r\n<p>The same affect occurs during rollout so landing alignment&nbsp;is equally important. Aim the glider at the center of the landing zone. Try to hold the nose up at touchdown, but it will quickly slow and dip over onto the nosewheel. With only a demonstrated crosswind of 8 kts, the ASK-21 will \"weathervane\" into the wind (even when on the nosewheel) as the rudder is small.&nbsp;</p>\r\n<p>Don't relax on rollout. Use the wheelbrake (full aft airbrake) as much as required. Continuious hard braking may overheat the brake pads, reducing effectiveness.</p>",
+      "last_updated": "2015-08-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 241,
+    "fields": {
+      "category": "ASK21",
+      "question_text": "<p>The ASK-21 is advertised as being reluctant to spin with two people, but you are light and flying solo.&nbsp; In your thermal today, you try to turn the K-21 with excess rudder to \"tighten things up a bit\" in gusty conditions, and suddenly the skidding turn becomes an unexpected drop of the inside wing, with extreme yaw into the turn.&nbsp; You neutalize the stick and apply full rudder opposite the direction of rotation, and before you can really understand what just happened you find the nose pointed steeply down and airspeed increasing rapidly, still with a lot of bank.&nbsp; What do you do now?</p>",
+      "option_a": "Continue to hold anti-spin controls - Opposite rudder, neutral aileron, pause, stick slowly forward to neutral",
+      "option_b": "Recover from the spiral dive - Relax back pressure, roll wings level, then stick smoothly aft until nose is above the horizon, rudders as necessary to keep yaw string close to center",
+      "option_c": "Increase back pressure on the stick until nose is above the horizon",
+      "option_d": "Deploy the parachute",
+      "correct_answer": "B",
+      "explanation": "<p>See ASK-21 POH page 22 section III.2, \"Recovery from Spin\"</p>\r\n<p>See ASK-21 POH page 33 section IV.6, \"Slow Speed Flight, Wing Dropping and Spins\"</p>\r\n<p>See GFH chapter 8 page 8-15, \"Spiral Dives\"</p>\r\n<p>In this scenario, the aircraft has already stopped spinning and airspeed is increasing, so:</p>\r\n<p>a) not appropriate to continue to hold anti-spin controls</p>\r\n<p>b) a spiral dive, or nose-low unusual attitude, needs to be addressed quickly to ge the nose above the horizon without exceeding max allowable speed or g-loading</p>\r\n<p>c) increasing back pressure before levelling the wings may only tighten the spiral, allow airspeed to increase, and eventually exceed allowable g-loading</p>\r\n<p>d) there is no parachute</p>",
+      "last_updated": "2018-09-01",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 242,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Getting gliders in and out of the hangars is an important responsibility for the Duty Officer to supervise.&nbsp; The wingspan of the trainers is about&nbsp;17 meters (56 feet), which is wider than the hangar doors.&nbsp; To get the K-21 properly into the hangar, you should:</p>\r\n<ol style=\"list-style-type: upper-roman;\">\r\n<li>Start by placing the fuselage dolly over the small red painted rectangular symbol on the ramp just outside the hangar - (Figure 1)</li>\r\n<li>Put the tail dolly on AND the fuselage dolly under the glider while outside the hangar (Figure 2)</li>\r\n<li>Have at least two helpers (three is better)</li>\r\n<li>Maneuver into hangar with gliders's right wing first, under the towplane's wing (Figure 3)</li>\r\n<li>Make sure fuselage dolly is on marked square like this: (Figure 4)&nbsp;</li>\r\n</ol>\r\n<table style=\"margin-left: auto; margin-right: auto;\" border=\"1\">\r\n<tbody>\r\n<tr>\r\n<td><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/Grob%20Spotting%20Square.jpg\" alt=\"Grob Spotting Square\" width=\"400\" height=\"533\"></td>\r\n<td><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/Positioning%20K-21JPG.jpg\" alt=\"\" width=\"400\" height=\"267\"></td>\r\n</tr>\r\n<tr>\r\n<td style=\"text-align: center;\">Figure 1</td>\r\n<td style=\"text-align: center;\">Figure 2</td>\r\n</tr>\r\n<tr>\r\n<td style=\"text-align: center;\"><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/Moving%20K-21%20Into%20Hangar.jpg\" alt=\"\" width=\"400\" height=\"267\"></td>\r\n<td><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/Sprite%20in%20Hangar.jpg\" alt=\"\" width=\"400\" height=\"300\"></td>\r\n</tr>\r\n<tr>\r\n<td style=\"text-align: center;\">Figure 3</td>\r\n<td style=\"text-align: center;\">Figure 4</td>\r\n</tr>\r\n</tbody>\r\n</table>",
+      "option_a": "<p>All of these</p>",
+      "option_b": "<p>II, III, IV</p>",
+      "option_c": "<p>II, III, IV, V</p>",
+      "option_d": "<p>I, II, III, IV</p>",
+      "correct_answer": "B",
+      "explanation": "<p>Number one is a trick question!&nbsp; That's actually the mark from which you start putting the GROB into the hangar, by putting the main gear on that rectangle!</p>\r\n<p>Also number five!&nbsp; That's actually the SPRITE on ITS dolly!&nbsp; Here's what the K-21 dolly position should look like when properly in the hangar:&nbsp;</p>\r\n<p><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/K-21%20Dolly.jpg\" alt=\"\" width=\"400\" height=\"300\"></p>",
+      "last_updated": "2026-01-28",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 244,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Getting gliders in and out of the hangars is an important responsibility for the Duty Officer to supervise.&nbsp; The wingspan of the trainers is about 17 meters (56 feet), which is wider than the hangar doors.&nbsp; To get the Grob 103 in the hangar properly, you should:</p>\r\n<ol style=\"list-style-type: upper-roman;\">\r\n<li>Start by placing the fuselage dolly over the small red painted rectangular symbol on the ramp just outside the hangar - (Figure 1)</li>\r\n<li>The tail dolly can be on or off; if off, maneuvering it in the hangar requires the nose to be pushed down. (Figure 2)</li>\r\n<li>Have at least two helpers (three is better), one on glider's right wing (Figure 3), one on the nose, and one on glider's left wingtip.&nbsp; Ideally, another one guards the horizontal tail.</li>\r\n<li>Maneuver into hangar by pushing nose so that main gear tracks the dotted red line, aim to put main gear on this mark in hangar:&nbsp;(Figure 4)</li>\r\n<li>Be careful to not hit horizontal tail on sidewall of hangar</li>\r\n</ol>\r\n<p>&nbsp;</p>\r\n<table style=\"margin-left: auto; margin-right: auto;\" border=\"1\">\r\n<tbody>\r\n<tr>\r\n<td><img style=\"display: block; margin-left: auto; margin-right: auto;\" src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/Grob%20Spotting%20Square_EZpxaoj.jpg\" alt=\"\" width=\"200\" height=\"267\"></td>\r\n<td><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/Positioning%20Grob.jpg\" alt=\"\" width=\"400\" height=\"265\"></td>\r\n</tr>\r\n<tr>\r\n<td style=\"text-align: center;\">Figure 1</td>\r\n<td style=\"text-align: center;\">Figure 2</td>\r\n</tr>\r\n<tr>\r\n<td><img style=\"display: block; margin-left: auto; margin-right: auto;\" src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/Grob%20Wing%20Guard.jpg\" alt=\"\" width=\"400\" height=\"267\"></td>\r\n<td><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/Where%20Grob%20Goes_7RZQJjy.jpg\" alt=\"\" width=\"400\" height=\"300\"></td>\r\n</tr>\r\n<tr>\r\n<td style=\"text-align: center;\">Figure 3</td>\r\n<td style=\"text-align: center;\">Figure 4</td>\r\n</tr>\r\n</tbody>\r\n</table>",
+      "option_a": "<p>All of these</p>",
+      "option_b": "<p>I, III, IV, V</p>",
+      "option_c": "<p>II, III, IV, V</p>",
+      "option_d": "<p>I, III, V</p>",
+      "correct_answer": "A",
+      "explanation": "<p>No tricks here . . . this is pretty straightforward.&nbsp; Notice that the guy holding the glider's right wing is actually using his body to insure that the leading edge of the wing cannot be damaged by striking the hangar door frame!</p>\r\n<p>And it's important to make sure the main wheel follows the dotted line precisely - - otherwise, the right wing tip might not clear the back of the hangar, and/or the horizontal tail may strike the side wall.</p>\r\n<p>Oh, and always keep the glider's right wing down, because the left wing has to clear the Sprite!</p>",
+      "last_updated": "2026-01-28",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 245,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>The best order for putting aircraft back in the hangar is:</p>",
+      "option_a": "Grob, K-21, Sprite",
+      "option_b": "Grob, Sprite, K-21",
+      "option_c": "Sprite, K-21, Grob",
+      "option_d": "K-21, Grob, Sprite",
+      "correct_answer": "C",
+      "explanation": "<p>Actually, the only rather <em>critical</em> sequencing is that the Sprite needs to go in before the Grob - the K-21 can pretty well fit into any sequencing!</p>\r\n<p>Now, getting them out is pretty obvious - - gotta get the Grob out before the Sprite!</p>",
+      "last_updated": "2015-08-30",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 246,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>Canopies on gliders should always be closed when the machine is unattended - gusts of wind are obvious hazards for any glider.&nbsp; One of our gliders, the K-21, is particularly vulnerable to a unique hazard, which is:</p>",
+      "option_a": "The locking pins can be inadvertently left extended, causing damage when the canopy is closed",
+      "option_b": "Open rear canopy exposes the instrument panel to damaging sunlight",
+      "option_c": "Closed canopies allow the buckles on the harness to get too hot",
+      "option_d": "Open canopies have caused fires in the cockpit",
+      "correct_answer": "D",
+      "explanation": "<p>The rear-seat&nbsp;canopy forms a convex lens whose focal point is right on the rear seat's pilot headrest!&nbsp; (It can work in reverse, with the front&nbsp;canopy burning the instrument panel in the front seat.)&nbsp;Recently, the headrest was replaced with a non-flammable cloth, but this shouldn't keep you from getting in the habit of closing the canopy any time you walk away from the glider. The burning headrest event does not&nbsp;have to be strong sunlight, as this can happen on an overcast day. Answer B is incorrect because the front seat canopy is possible to get too hot when it's left open. Answer C is annoying, but not something that can cause permanent damage. Very hot belt buckles are one reason why we have silver aluminized canopy covers for both the Grob and the K-21. These can be used to block the sunlight in the cockpit when the glider is going to be sitting on the ramp for any significant waiting period on a sunny day.</p>",
+      "last_updated": "2017-04-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 250,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>Billy-Bob just did his first solo in a high performance glider, the Discus CS. While attempting to stop, the glider pitched over and scraped the nose on the ground, causing a big ugly scrape, removing the outer layer of gelcoat.&nbsp; What are some of the contributing factors that could have caused this?&nbsp;</p>\r\n<ol style=\"list-style-type: upper-roman;\">\r\n<li>Billy-Bob's pilot weight was too high, and he didn't have the appropriate tail ballast</li>\r\n<li>Billy-Bob didn't apply aft-stick during roll-out</li>\r\n<li>Billy-Bob landed too fast</li>\r\n<li>Billy-Bob landed too slow</li>\r\n<li>Billy-Bob forced the landing onto the pavement</li>\r\n<li>Billy-Bob applied the brakes too abruptly</li>\r\n</ol>",
+      "option_a": "I, II and III",
+      "option_b": "I, II and IV",
+      "option_c": "II, IV and V",
+      "option_d": "I, II, III, VI",
+      "correct_answer": "D",
+      "explanation": "<p>Billy-Bob&nbsp;probably has gotten in the habit of landing main-wheel only, and not holding back-stick on the roll-out. This is a terrible habit, and should be roundly discouraged when flying the Discus or other tailwheel gliders.&nbsp; In order to minimize the chances of nosing-over, hold back-stick during roll-out, land at as low a speed as possible, and gently apply the wheel brakes.&nbsp; Contributing factors are very heavy pilot weight and forward CG.&nbsp;</p>\r\n<p>Remember, on roll-out that stick should be full-aft! This is not the SGS 1-36, and there is no nose skid!&nbsp;</p>",
+      "last_updated": "2017-10-24",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 251,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>During take-off, Billy-Bob suddenly kited the Discus CS several feet above the tow plane, once&nbsp;the glider attained flying speed. What are some of the contributing factors that might have caused this?&nbsp;</p>\r\n<ol style=\"list-style-type: upper-roman;\">\r\n<li>Very low pilot weight</li>\r\n<li>Very high pilot weight</li>\r\n<li>Billy-Bob did not get the tail wheel off of the ground during the acceleration phase of the take-off</li>\r\n<li>Billy-Bob was distracted by the Oudie complaining about a PowerFLARM proximity warning and looked away</li>\r\n<li>Low tire pressure</li>\r\n</ol>",
+      "option_a": "I, III, and IV",
+      "option_b": "III, and IV",
+      "option_c": "II, III, and V",
+      "option_d": "IV and V",
+      "correct_answer": "B",
+      "explanation": "<ol style=\"list-style-type: upper-roman;\">\r\n<li><strong>Very low pilot weight</strong><ol>\r\n<li>Low pilot weight could cause the glider to tend to be less nose heavy, and for a given elevator configuration, could cause the glider to get higher faster. Probably not enough to be a significant factor, though.&nbsp;</li>\r\n</ol></li>\r\n<li><strong>Very high pilot weight</strong><ol>\r\n<li>For a given elevator configuration, the pilot would need more back stick to get the nose off of the ground. Probably not a contributing factor.</li>\r\n</ol></li>\r\n<li><strong>Billy-Bob did not get the tail wheel off of the ground during the acceleration phase of the take-off</strong><ol>\r\n<li>This is the biggest gotcha when transitioning to the Discus CS, or other tailwheel-equipped gliders, after training in the ASK-21 and Grob 103. If you do your take-off roll with the tail on the ground for the whole time, you will be unpleasantly surprised. Once the tow plane and glider have accelerated to the appropriate speed, the glider will very suddenly develop lift, and will balloon into the air.&nbsp; The novice pilot might not notice this until he's several feet off of the ground, and then has to take immediate action, having to dive down into position. Best solution is to plan to get that tail wheel off the ground as soon as practical during your take-off roll. If you have a cross-wind, try to keep the tail on the ground for better directional stability.&nbsp;</li>\r\n</ol></li>\r\n<li><strong>Billy-Bob was distracted by the Oudie complaining about a PowerFLARM proximity warning and looked away</strong><ol>\r\n<li>This is fairly common. Sometimes a plane with a transponder can be located nearby, to cause the PowerFLARM to beep when it's not welcome. Be sure to ignore any extraneous inputs while on that take off roll. It doesn't matter if your seat is on fire, you have a tick on your leg, or your PowerFLARM is beeping, keep that eye on the towplane!&nbsp;</li>\r\n</ol></li>\r\n<li><strong>Low tire pressure</strong><ol>\r\n<li>I can't believe you selected this.&nbsp;</li>\r\n</ol></li>\r\n</ol>",
+      "last_updated": "2017-10-24",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 252,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>During Assembly, Billy-Bob has inserted the left wing and left it on the wing stand. Jimmy-George is holding the right wingtip. Jimmy-George inserts the right wing. The left wing pops out when&nbsp;Jimmy-George pushes in on the wingtip. What is the most obvious rookie mistake to cause this problem?</p>",
+      "option_a": "Billy-Bob forgot to put the spar-pin half-way in, during assembly",
+      "option_b": "Billy-Bob put the spar-pin in all the way, during assembly",
+      "option_c": "Billy-Bob just needs to go to the left wing and push, that's just the way this glider is. The spar pin goes in only after the wings are fully positioned. ",
+      "option_d": "Billy-Bob has the spoilers unlocked, and needs to lock them",
+      "correct_answer": "A",
+      "explanation": "<p>The Schempp-Hirth gliders Ventus, Discus, Duo Discus, Nimbus and Arcus all have only spar pin. You always assemble the left wing first.&nbsp; After inserting the left wing, make sure to put the spar pin in only half-way. This keeps the left wing from popping out when Jimmy-George pushes in on the wingtip. The left wing won't pop out because the back panel is shaped in away to prevent the left wing plus spar pin from moving outboard when the wing spar interlocks engage.&nbsp;</p>\r\n<p>B is wrong because if you put the spar pin in all the way, you won't get the wing more than halfway in. The insertion of the right wing will bang on the fully-inserted spar pin, and you won't make any progress.&nbsp;</p>\r\n<p>C&nbsp;is the answer that many people think is right. If you have this problem at a contest, the experienced pilots will laugh at you for being such a rookie. Don't be a rookie.&nbsp;</p>\r\n<p>D could be right if the spoilers were locked. When the spoiler handle is in the lock position, it makes it very difficult to insert the wings. Make sure the spoilers are unlocked and that the water dump valve is closed when attempting to assemble the wings.&nbsp;</p>",
+      "last_updated": "2017-10-24",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 253,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>Risks associated with flying the Discus CS in freezing temperatures include:</p>",
+      "option_a": "Possibility that controls may freeze and bind, especially the airbrakes.",
+      "option_b": "Possibility that water in ballast tanks could freeze, causing damage and making the glider no longer airworthy.",
+      "option_c": "Possibility that dump valves could freeze, making it impossible to get rid of ballast.",
+      "option_d": "All of the above.",
+      "correct_answer": "D",
+      "explanation": "<p>A. POH section 4.9 discusses flight at freezing temps and suggests use of Vaseline on the mating surface of airbrakes.</p>\r\n<p>B. POH sections 2.7 and 4.7 discuss flight with water ballast, and states ballast must be dumped&nbsp;before going below 36 deg F. Table on page 22c lists standard lapse rate altitudes and surface temps where freezing is likely.</p>\r\n<p>C. Dump valves could freeze first, though not specifically addressed in the POH.</p>",
+      "last_updated": "2018-01-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 254,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>To lower the landing gear in the Discus CS:</p>",
+      "option_a": "Unlock the black handle at the right edge of the seat pan, push forward and engage in the front recess.",
+      "option_b": "Unlock the black handle at the right edge of the seat pan, pull back and engage in the rear recess.",
+      "option_c": "Push the blue handle on the left side of the cockpit forward and past the over-center lock.",
+      "option_d": "Push the sliding red knob on the right canopy rail full forward and lock into place.",
+      "correct_answer": "A",
+      "explanation": "<p>A. POH section 1.2 (6) page 7 describes procedures for lowering gear, but contains a typo corrected by hand. This position is the reverse of the procedure for the Cirrus, by the way.</p>\r\n<p>B. This raises the gear.</p>\r\n<p>C. This locks the airbrakes closed.</p>\r\n<p>D. This unlocks the canopy at the hinge side so it can be jettisoned.</p>\r\n<p>&nbsp;</p>",
+      "last_updated": "2018-01-27",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 255,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>To adjust the elevator trim on the Discus CS:</p>",
+      "option_a": "Loosen the green knob on the left at the seat mold to reposition the elevator trim tab, then tighten in place.",
+      "option_b": "Move the green knob on the left at the seat mold line inwards to release, move to adjust spring tension, release to lock.",
+      "option_c": "Move the black ball-shaped knob on the right cockpit wall forward or aft to the desired position.",
+      "option_d": "Move the blue lever on the left hand side of cockpit forward or aft to the desired position.",
+      "correct_answer": "B",
+      "explanation": "<p>A. There is no trim tab on the elevator.</p>\r\n<p>B. POH section 1.2 (12) page 8 describes the procedure adjusting spring-loaded elevator trim.</p>\r\n<p>C. The black ball on the right cockpit wall is for opening and closing water ballast dump valves.</p>\r\n<p>D. The blue lever is for airbrakes.</p>",
+      "last_updated": "2018-01-27",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 256,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>The maximum permitted speed in the Discus CS is:</p>",
+      "option_a": "151 knots at sea level, less above 10,000 ft MSL.",
+      "option_b": "135 knots at all altitudes.",
+      "option_c": "135 knots at sea level, less above 14,000 ft MSL.",
+      "option_d": "119 knots at all altitudes.",
+      "correct_answer": "C",
+      "explanation": "<p>A. 151 knots is Vne for the ASK-21. You must have gotten confused with that.&nbsp;</p>\r\n<p>B.&nbsp;POH section 2.4 page 19 lists speed limits by altitude.&nbsp; Plotting these shows the break from 135 knots is at 14,000 ft MSL.</p>\r\n<p>C. POH section 2.4 page 19 lists speed limits by altitude.&nbsp; Plotting these shows the break from 135 knots is at 14,000 ft MSL.</p>\r\n<p>D. 119 knots is the Vne for the Cirrus.&nbsp;You must have gotten confused with that.&nbsp;</p>",
+      "last_updated": "2018-01-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 257,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>The yellow triangle on the airspeed indicator of the Discus CS shows:</p>",
+      "option_a": "54 knots, best L/D speed without ballast.",
+      "option_b": "51 knots, beginning of the green arc (normal operating range).",
+      "option_c": "55 knots, recommended approach speed without ballast.",
+      "option_d": "62 knots, recommended approach speed at maximum allowable gross weight.",
+      "correct_answer": "D",
+      "explanation": "<p>A. 54 knots is close to best L/D without ballast, but that is not where the yellow triangle is and is not what the yellow triangle means.</p>\r\n<p>B. 51 knots is 1.1&nbsp;multiplied by the clean stall speed. It is also the beginning of the green arc, but that is not where they yellow triangle is.</p>\r\n<p>C. 55 knots is a recommended pattern speed in the Skyline Soaring ops manual, but is not related to the yellow triangle.</p>\r\n<p>D. POH page 18 has a table that shows the meaning of airspeed indicator markings, 62 knots is for approach speed at max weight.</p>",
+      "last_updated": "2018-01-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 258,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>Maximum permitted speed in rough air, and maneuvering speed in the Discus CS are:</p>",
+      "option_a": "81 knots for rough air, 97 knots for maneuvering.",
+      "option_b": "97 knots for rough air, 108 knots for maneuvering.",
+      "option_c": "108 knots indicated airspeed for both.",
+      "option_d": "108 knots true airspeed for both.",
+      "correct_answer": "C",
+      "explanation": "<p>A. 81 knots is max winch speed, 97 knots max aero tow.</p>\r\n<p>B. 97 knots is max aero tow speed.</p>\r\n<p>C.&nbsp;POH section 2.4 page 19 has a table for airspeed limits, 108 knots indicated for both.&nbsp;</p>\r\n<p>D. Not true airspeed.</p>",
+      "last_updated": "2018-01-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 259,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>In the Discus CS, manueuvering load limits must not exceed:</p>",
+      "option_a": "Positive 3.5 G's with the airbrakes open.",
+      "option_b": "Positive 5.3 G's or negative 2.65 G's at maneuvering speed.",
+      "option_c": "Positive 4.0 G's or negative 1.5 G's at Vne.",
+      "option_d": "All of the above.",
+      "correct_answer": "D",
+      "explanation": "<p>POH seciton 2.5 page 20 lists the maneuvering load factor limits, all these apply.</p>",
+      "last_updated": "2018-01-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 260,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>With a 16-lb paracute, the maximum allowable pilot weight in the Discus CS is:</p>",
+      "option_a": "242 pounds (110 kg).",
+      "option_b": "226 pounds.",
+      "option_c": "226 pounds, unless tail ballast is carried.",
+      "option_d": "154 pounds (70 kg).",
+      "correct_answer": "B",
+      "explanation": "<p>The maximum cockpit weight, including parachute, is 242 lbs (110 kg), per POH section 2.7 page 21.</p>\r\n<p>A. Does not include the weight of the parachute.</p>\r\n<p>B. Is the max allowable pilot weight after subtracting the mandatory parachute.</p>\r\n<p>C. Tail ballast changes CG, but does not allow higher cockpit weight.</p>\r\n<p>D. 154 (70 kg) pounds is the minimum cockpit weight, including parachute (138 pounds plus parachute).</p>",
+      "last_updated": "2018-01-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 261,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>The CG location in Discus CS 9Y without water ballast, for a 170-pound pilot plus 16-pound parachute (186 pounds combined), is:</p>",
+      "option_a": "Within limits, at 20% of allowable aft CG range.",
+      "option_b": "Within limits, at 50% of allowable aft CG range.",
+      "option_c": "Within limits, at 80% of allowable aft CG range.",
+      "option_d": "Outside allowable limits.",
+      "correct_answer": "C",
+      "explanation": "<p>See cockpit card CG loading chart:</p>\r\n<p>A. 20% of allowable aft CG range is for maximum pilot weight of 226 pounds plus parachute.</p>\r\n<p>B. 50% of allowable aft CG range is for pilot weight of 186 pounds plus parachute.</p>\r\n<p>C. 90% of allowable aft CG range is for minimum pilot weight of 138 pounds plus parachute.</p>\r\n<p>D. Without water ballast, design cockpit load of 154-242 pounds (70-110 kg) including parachute remains within allowable CG range.</p>",
+      "last_updated": "2025-01-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 262,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>The Discus CS procedure for spin recovery is:</p>",
+      "option_a": "Apply full opposite rudder, stick full forward, when rotation stops recover from dive.",
+      "option_b": "Apply full opposite rudder against direction of spin, ease control stick forward until rotation stops, centralize rudder and pull out smoothly from dive.",
+      "option_c": "Apply full rudder against direction of spin, stick full aft momentarily then stick forward until rotation stops.",
+      "option_d": "Neutralize all controls until spin stops, then recover from dive.",
+      "correct_answer": "B",
+      "explanation": "<p>POH section 3.1 page 28 contains the approved language for spin recovery.</p>\r\n<p>A. Full forward stick is not necessary and may result in disorienting loss of control.</p>\r\n<p>B. This is the exact language from the POH for spin recovery.</p>\r\n<p>C. Stick full aft may delay recovery.</p>\r\n<p>D. Full rudder against direction of rotation may be necessary to recover from spin.</p>",
+      "last_updated": "2018-01-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 263,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>To bail out of the Discus CS:</p>",
+      "option_a": "Unlock canopy with normal left-side lever forward, release right hinge side with red knob forward, throw off canopy, release harness, exit cockpit, pull parachute ripcord when clear.",
+      "option_b": "Release harness, unlock canopy with normal left-side canopy forward, release right hinge side with red knob forward, throw off canopy, exit cockpit, pull ripcord.",
+      "option_c": "Release harness, release right hinge side of canopy with red knob forward, unlock canopy from left side, throw off canopy, exit cockpit, pull ripcord.",
+      "option_d": "Unlock canopy with normal left-side lever forward, release right hinge side with red knob forward, throw off canopy, release harness, exit cockpit, allow static line tether to deploy parachute.",
+      "correct_answer": "A",
+      "explanation": "<p>POH section 3.2 page 29 contains procedures for emergency exit.</p>\r\n<p>A. This is the procedure for emergency exit, plus releasing the harness after the canopy has been jettisoned, then pulling the parachute ripcord when clear of the aircraft.</p>\r\n<p>B. It is not recommended to release the harness before jettisoning the canopy since you need to be secured in order to operate the release mechanisms.</p>\r\n<p>C. Same as B plus the normal side should be opened before releasing the hinges.</p>\r\n<p>D. Although there is a static line tether connection available on the glider, it is rarely used, may not have been attached, or may not have worked -- always pull the parachute ripcord when clear of the aircraft.</p>",
+      "last_updated": "2018-01-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 264,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>The maximum allowable speed on aerotow in the Discus CS is:</p>",
+      "option_a": "62 knots",
+      "option_b": "81 knots",
+      "option_c": "97 knots",
+      "option_d": "108 knots",
+      "correct_answer": "C",
+      "explanation": "<p>POH section 4.3 page 35 provides aerotow limits and procedures.</p>\r\n<p>A. 62 knots is the recommended approach speed at max allowable weight.</p>\r\n<p>B. 81 knots is the winch launch limit.</p>\r\n<p>C. 97 knots is the aerotow limit.</p>\r\n<p>D. 108 knots is the maneuvering speed and rough air limit.</p>",
+      "last_updated": "2018-01-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 265,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>Reasons the Discus CS requires a separate checkout at Skyline Soaring for flying with water ballast include the following:</p>\r\n<p>I. Tire pressure required for the main landing gear wheel increases at total weight above 794 pounds.<br />II. Handling characteristics and speeds to fly change when full ballast is carried, increasing weight by approximately 400 pounds.<br />III. If ballast tanks are not completely emptied and dried after flight, they can freeze on the ground making the glider no longer airworthy.<br />IV. SSC cockpit cards are based on flying without ballast, and do not cover flight restrictions or weight and balance with ballast.<br />V. Flight with water ballast requires careful monitoring of inflight temps to avoid freezing of water in ballast tanks.<br />VI. Takeoff and landing procedures are different with water ballast.<br />VII. Internal baffling in the wings can hold water assymetrically, making takeoff difficult if not balanced.<br />VIII. Water can transfer from one wing to the other making takeoff difficult if not balanced.<br />IX. Recovery from a spin may be difficult with water ballast, especially if not symmetrical.<br />X. Filling wing tanks with water under pressure from a hose can damage the wings.</p>",
+      "option_a": "All of the above except I, VI, and IX.",
+      "option_b": "All of the above except VIII and X.",
+      "option_c": "All of the above except VIII.",
+      "option_d": "All of the above.",
+      "correct_answer": "C",
+      "explanation": "<p>All of the above restrictions except items IV and VIII are described in the POH.&nbsp;&nbsp;</p>\r\n<p>IV - The SSC cockpit cards, in the interest of keeping things simple, do not address flight with ballast, so this is still True.</p>\r\n<p>VIII - The wing ballast tanks are not interconnected, though water can move to low side within each tank if one wing is allowed to stay low when partially filled, and will not redistrute immediately due to internal baffles when wings are levelled just before takeoff.&nbsp; False.</p>",
+      "last_updated": "2018-01-18",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 266,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>The maximum proven crosswind component for takeoff and landing in the Discus CS is:</p>",
+      "option_a": "Not specified.",
+      "option_b": "11 knots.",
+      "option_c": "11 mph.",
+      "option_d": "15 knots.",
+      "correct_answer": "B",
+      "explanation": "<p>POH section 2.12 page 27 specifies that the maximum crosswind component proven for takeoff and landing is 20 km/h (11 knots).</p>",
+      "last_updated": "2018-01-18",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 267,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>During preflight of the Discus CS, check the following:</p>",
+      "option_a": "Check that the main spar pin is fully home and secured. ",
+      "option_b": "Three sets of static ports are clear (nose, under wing, and on boom near the tail).",
+      "option_c": "No unusual play when shaking the trailing edge of ailerons, rudder and elevator.",
+      "option_d": "All of the above.",
+      "correct_answer": "D",
+      "explanation": "<p>A. Location and installation of the pin is covered in the POH, page 53.&nbsp;</p>\r\n<p>B. Location of static ports is described in separate items under daily inspection, POH item 4b page 33 and item 9 page 34.</p>\r\n<p>C.&nbsp;POH daily inspection item 2c page 32 and item 6b page 33.</p>\r\n<p>D. All of the above are in the POH.</p>",
+      "last_updated": "2019-06-09",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 268,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>For a normal takeoff in the Discus CS without water ballast:</p>",
+      "option_a": "Set trim to one third travel from full forward, stick neutral with intermediate to forward CG position, when elevator is effective raise the tail to level attitude.",
+      "option_b": "Set trim to one third travel from full forward, stick slightly forward if CG position is slightly aft, when elevator is effective raise tail to level attitude.",
+      "option_c": "Set trim to neutral, keep stick aft and tail on the ground until liftoff.",
+      "option_d": "A and B above.",
+      "correct_answer": "D",
+      "explanation": "<p>POH section 4.3.1 page 35 describes airotow takeoff procedures.</p>\r\n<p>A. Correct for intermediate to forward CG location.</p>\r\n<p>B. Correct for aft CG position.</p>\r\n<p>C. Not part of the recommendation, and would result in premature liftoff with a strong initial climbing vector.</p>\r\n<p>D. Both A and B are covered in the POH recommendation.</p>",
+      "last_updated": "2018-01-18",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 269,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>In high-speed flight in the Discus CS:</p>",
+      "option_a": "Full deflection of controls may only be used up to Va (108 knots), only one third deflection at Vne.",
+      "option_b": "Full deflection of controls may be used at any speed.",
+      "option_c": "Airbrakes should never be used above Va (108 knots).",
+      "option_d": "Dive angle should not exceed 60 degrees.",
+      "correct_answer": "A",
+      "explanation": "<p>POH section 4.6 page 43 describes high speed flight considerations:</p>\r\n<p>A. Is correct, full deflection of controls is permitted up to Va/Vno, one third at Vne.</p>\r\n<p>B. Is not correct, full deflection should not be used at Vne, especially the elevator.</p>\r\n<p>C. Airbrakes may be used up to Vne, with caution.</p>\r\n<p>D. Dive angle should not exceed 45 degrees without water ballast, and 30 degrees with ballast.</p>",
+      "last_updated": "2018-01-18",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 270,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>For normal landings in the Discus CS:</p>",
+      "option_a": "Touchdown should be at minimum speed, with airbrakes extended, approximately 38 knots.",
+      "option_b": "At minimum speed with proper flare just above the runway, touchdown is tail first.",
+      "option_c": "Flaring high can result in a stall and dropped-in landing with damage to the tail wheel and boom.",
+      "option_d": "All of the above.",
+      "correct_answer": "D",
+      "explanation": "<p>POH section 4.11 page 52 describes approach and landing.</p>\r\n<p>A. Is correct per POH</p>\r\n<p>B. Is correct per POH</p>\r\n<p>C. Is always correct for any glider.</p>\r\n<p>D. All of the above are true.</p>",
+      "last_updated": "2018-01-18",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 271,
+    "fields": {
+      "category": "Discus",
+      "question_text": "<p>If it is necessary to add ballast to reach minimum allowable seat weight of 154 pounds (70 kg) including parachute:</p>",
+      "option_a": "Lead or a sand/shot cushion must be securely held in place by attaching it to the lap belt brackets.",
+      "option_b": "A shot bag may be placed under the seat cushion, but does not need to be attached to the lap belt brackets.",
+      "option_c": "Wing ballast may be added to ensure the CG is within limits.",
+      "option_d": "Tail ballast may be added to ensure the CG is within limits.",
+      "correct_answer": "A",
+      "explanation": "<p>A.&nbsp;POH section 2.7 page 21 requires ballast to be attached to the lap belt brackets, or bolted into the fuselage nose cone.</p>\r\n<p>B.&nbsp;Simply putting weight under the seat cushion does not meet the POH requirement.</p>\r\n<p>C.&nbsp;Wing ballast does not affect the POH minimum seat weight restriction.</p>\r\n<p>D. Tail ballast does not affect the POH minimum seat weight restriction.</p>",
+      "last_updated": "2018-01-18",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 272,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>Flying at or below Manuevering Speed (Va) always protects from an over-G condition for which conditions:</p>",
+      "option_a": "Elevator and half aileron",
+      "option_b": "Elevator only with spoilers closed",
+      "option_c": "Elevator and half rudder",
+      "option_d": "Elevator only, with spoilers closed or open",
+      "correct_answer": "B",
+      "explanation": "<p>An aircraft's G-limit is reduced when ailerons are deflected due to extra forces they apply to the wings. Typically the G-limit with full aileron deflection is about 2/3 of the level-flight G-limit. Because Manueuvering Speed is defined as stall speed times the square of the G-limit, aileron deflection reduces Maneuvering Speed.&nbsp;</p>\r\n<p>Further, and separately, rudder deflection during high G-loading can create twisting forces on the tail boom that exceed the design limit. The combination of a high roll rate with rudder deflection severely reduces the G-limits on&nbsp;gliders.</p>\r\n<p>Further, and separately, spoiler deployment blanks out part of the fattest wing area, which transfers loads farther out on the wing, increasing bending moments.&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 273,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>Which of these aerobatic maneuvers are NOT approved for SSC ASK-21 gliders:</p>",
+      "option_a": "Cuban Eight, Cloverleaf, and Barrel Roll",
+      "option_b": "Tail Slide, Outside Loop, and Snap Roll",
+      "option_c": "Split-S and Immelmann",
+      "option_d": "Chandelle and Lazy Eight",
+      "correct_answer": "B",
+      "explanation": "<p><strong>Section 2.3. Prohibited Maneuvers</strong> in the <em>SSC Advanced Flying Guide</em> lists all prohibited maneuvers in option B.&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 274,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>Parachutes must be worn while performing aerobatics maneuvers and each parachute must have received a certified repack within the past:</p>",
+      "option_a": "90 days",
+      "option_b": "Calendar year",
+      "option_c": "180 days",
+      "option_d": "Two years",
+      "correct_answer": "C",
+      "explanation": "<p>14 CFR 91.307 &ndash; PARACHUTES. Must be repacked within the previous 180 days. Each occupant must wear parachute if the flight will exceed a bank angle of 60 degrees relative to horizon or exceed a pitch attitude above or below 30 degrees relative to the horizon.</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 275,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>At the maximum permissible speed of the ASK-21 (151 knots), what is the maximum permissible deflection of any flight control:</p>",
+      "option_a": "Normal limits",
+      "option_b": "2/3 of full deflection",
+      "option_c": "1/2 of full deflection",
+      "option_d": "1/3 of full deflection",
+      "correct_answer": "D",
+      "explanation": "<p>Page 9 of the ASK-21 POH states that at max permissible airspeed, only 1/3 of possible control deflections are permitted.&nbsp;</p>",
+      "last_updated": "2022-11-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 276,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>What are the G-limits of the ASK-21 glider:</p>",
+      "option_a": "+6.5 G to -4.0 G up to maneuvering speed ",
+      "option_b": "+5.3 G to -3.0 G above maneuvering speed",
+      "option_c": "+3.5 G to -0.0 G with spoilers open",
+      "option_d": "All three. ",
+      "correct_answer": "D",
+      "explanation": "<p>See page 9 of the ASK-21 POH.&nbsp;</p>\r\n<p>These limits are for symmetrical maneuvers.&nbsp;</p>",
+      "last_updated": "2022-11-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 277,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>Which statement is true for the Slow Roll in an ASK-21:</p>",
+      "option_a": "It is super easy, just hold full aileron until you're right side up again. ",
+      "option_b": "It is a low-stress maneuver that isn't even real aerobatics. ",
+      "option_c": "It is very challenging and should be learned as two separate half-roll maneuvers.",
+      "option_d": "The ASK-21 glider just loves to roll inverted.",
+      "correct_answer": "C",
+      "explanation": "<p><strong>Section 3.5. Slow Roll</strong> in the <em>SSC Advanced Flying Guide</em> says:</p>\r\n<p>A full 360-degree Slow Roll is a challenging maneuver in the ASK-21. Being comfortable with this maneuver&mdash;and knowing how to do it right&mdash;can save you someday if you experience a severe, unexpected inflight upset. While the Slow Roll is used in some manner in all advanced aerobatic maneuvers, it&rsquo;s an excellent technique for recovering from severe inflight upsets.</p>\r\n<p>It is highly recommended that you initially practice the Slow Roll as <strong>two separate maneuvers</strong>:</p>\r\n<ol>\r\n<li><strong>First Half: </strong>Roll inverted and hold for a few seconds as you note where the horizon is during inverted flight. You will need this sight picture during the more advanced maneuvers. This also trains your muscle memory to apply forward stick pressure as you pass through inverted to prevent an inverted high-speed situation.</li>\r\n<li><strong>Second Half: </strong>After a brief pause, continue in the same direction to roll out of inverted.</li>\r\n</ol>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 278,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>The following additional equipment is required in the ASK-21 glider when performing aerobatics:</p>",
+      "option_a": "Parachutes, G-meter in front seat, and barf bags",
+      "option_b": "Parachutes and G-meters in both cockpits.",
+      "option_c": "Parachutes, 5-point should harness, and rudder pedal foot loops",
+      "option_d": "Parachutes and 5-point should harness for loops only ",
+      "correct_answer": "C",
+      "explanation": "<p>See page 8 in the ASK-21 POH, II.3 MINIMUM EQUIPMENT</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 279,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>If you accidentally exceed the maximum permissible airspeed of 151 knots:</p>",
+      "option_a": "Don't worry about it if you exceeded it briefly and by no more than 10 knots.",
+      "option_b": "Perform a structural damage/controllability check",
+      "option_c": "Ground the aircraft until it can be inspected by a certified mechanic",
+      "option_d": "Both B & C",
+      "correct_answer": "D",
+      "explanation": "<p><strong>Section 2.4. Inflight Procedures</strong> of the <em>SSC Advanced Flying Guide</em> says:</p>\r\n<p>Any time an overspeed or over-G occurs, notify the DO, perform a structural damage/controllability check, and return immediately to land.</p>\r\n<p>Ground the aircraft until it can be inspected by a certified mechanic.</p>",
+      "last_updated": "2022-11-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 280,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>If you over-G the ASK-21 while performing aerobatics:</p>",
+      "option_a": "Perform a structural damage/controllability check",
+      "option_b": "Return to land immediately",
+      "option_c": "Notify the DO and ground the aircraft ",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "<p><strong>Section 2.4. Inflight Procedures</strong> of the <em>SSC Advanced Flying Guide</em> says:</p>\r\n<p>Any time an overspeed or over-G occurs, notify the DO, perform a structural damage/controllability check, and return immediately to land.</p>\r\n<p>Ground the aircraft until it can be inspected by a certified mechanic.</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 281,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>When flying aerobatics, you can experience low or even negative G-loads, which could cause your arms and feet to float. Under these conditions, you should:</p>",
+      "option_a": "Never remove your hands or feet from the flight controls while flying aerobatics. ",
+      "option_b": "Just float along and enjoy the weird sensation. ",
+      "option_c": "See if you can take a drink while upside down. ",
+      "option_d": "Be sure to snap a picture while inverted. It will impress your friends. ",
+      "correct_answer": "A",
+      "explanation": "<p>Page 36 of the ASK-21 POH includes the following:</p>\r\n<p>ATTENTION: Never&nbsp;release stick and rudder pedals when flying aerobatics.&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 282,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>The recommend entry speed and pull for a Loop in the ASK-21 is:</p>",
+      "option_a": "108 knots, 3-4 Gs",
+      "option_b": "79 knots, 3 Gs",
+      "option_c": "92 knots, 2-3 Gs",
+      "option_d": "Whatever works best for you. ",
+      "correct_answer": "C",
+      "explanation": "<p>See page 38 of the ASK-21 POH for a list of all entry conditions.&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 283,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>When performing a Slow Roll, the following entry airspeed and pull are used:</p>",
+      "option_a": "89 knots, but no pull for a slow roll, just roll. ",
+      "option_b": "89 knots, with a 2 G pull to level flight before rolling.",
+      "option_c": "89 knots, with a 2 G pull to 10-20\u00b0 nose up before rolling.",
+      "option_d": "You can perfom one at any airspeed.",
+      "correct_answer": "C",
+      "explanation": "<p>See page 38 of the ASK-21 POH for a list of the entry speed and section <strong>3.5. Slow Roll</strong> in the <em>SSC Advanced Flying Guide</em> for conditions.&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 284,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>When performing a Loop, which statement(s) are true about the airspeed you should have as you go over the top:</p>",
+      "option_a": "If speed exceeds 70 knots, abort the Loop and perform unusual attitude recovery. ",
+      "option_b": "Speed over the top should be exactly half of your entry speed. ",
+      "option_c": "Ideally you should be at 40-50 knots.",
+      "option_d": "Both A & C",
+      "correct_answer": "D",
+      "explanation": "<p>See <strong>Section 3.6. Loop</strong> in the <em>SSC Advanced Flying Guide</em>.&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 285,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>The Lazy Eight is not really an aerobatic maneuver, so you don't need to wear a parachute.&nbsp;</p>",
+      "option_a": "True, if bank doesn't exceed 60 and pitch doesn't exceed 30",
+      "option_b": "False, because the ideal target pitch attitude is 45 degrees nose up. ",
+      "option_c": "False, becaue it's just too easy. ",
+      "option_d": "Both A & B",
+      "correct_answer": "D",
+      "explanation": "<p>See <strong>Section 4.8. Lazy Eight</strong> in the <em>SSC Advanced Flying Guide.&nbsp;</em></p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 286,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>How many sorties are recommended for you first day of flying glider aerobatics:</p>",
+      "option_a": "No limit because glider aerobatics aren't real aerobatics.",
+      "option_b": "No more than two sorties your first day, even if you've flown aerobatics before. ",
+      "option_c": "Glider aerobatics are disorienting, but only a wuss would impose limits. ",
+      "option_d": "No more than four sorties your first day, unless you're really tough. ",
+      "correct_answer": "B",
+      "explanation": "<p>Glider aerobatics are disorienting even for experience aerobatics and military pilots.</p>\r\n<p>Read <strong>Chapter 5</strong> in the <em>SSC Advanced Flying Guide.</em></p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 287,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>How many aerobatics flights will I need before I can take up my friends and show them how cool I am?</p>",
+      "option_a": "Most people can qualify for solo aerobatics within 10 aerobatics flights.",
+      "option_b": "There are different qualification standards for the various maneuvers. ",
+      "option_c": "The SSC does not permit aerobatics to be flown wihout an aerobatics instructor. ",
+      "option_d": "Only a few will be certified to fly aerobatics with friends and family. ",
+      "correct_answer": "C",
+      "explanation": "<p>See <strong>Section 1.3. Sailplane Aerobatics</strong> in the <em>SSC Advanced Flying Guide.&nbsp;</em></p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 288,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>What are the weather limits for flying aerobatics sorties at the Skyline Soaring Club?</p>",
+      "option_a": "Standard VFR weather minimums apply. ",
+      "option_b": "Visibility 5 statute miles with a ceiling of no lower than 5,000 feet. ",
+      "option_c": "Visibility 3 statute miles with a ceiling of no lower than 5,000 feet. ",
+      "option_d": "Visibility 10 statute miles with a ceiling of no lower than 5,000 feet. ",
+      "correct_answer": "B",
+      "explanation": "<p>See <strong>Section 2.1. Preflight Procedures</strong> in the <em>SSC Advanced Flying Guide.&nbsp;</em></p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 289,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>The following statement is true about the pitot extension tube for the ASK-21.&nbsp;</p>",
+      "option_a": "Without one, there are different limiting speeds for aerobatics. ",
+      "option_b": "Trick question, there is no such thing. ",
+      "option_c": "It's nice to have, but doesn't affect any critical airspeed limitations. ",
+      "option_d": "Flight without the extension is expressely prohibited by the POH. ",
+      "correct_answer": "A",
+      "explanation": "<p>See the Skyline Soaring Club Aerobatics Checklist.&nbsp;</p>\r\n<p>See pages 36 and 37 in the ASK-21 POH.&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 290,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>On average, how much altitude will the ASK-21 lose during over-the-top maneuvers such as a Loop, or each leaf of a Cloverleaf, or each half of a Cuban 8:</p>",
+      "option_a": "Because we pull up first, all over-the-top maneuvers leave us higher than we began. ",
+      "option_b": "Each time over the top costs us about 300 feet of altitude loss. ",
+      "option_c": "Each time over the top costs us about 100 feet of altitude loss. ",
+      "option_d": "Each time over the top costs us about 200 feet of altitude loss. ",
+      "correct_answer": "B",
+      "explanation": "<p>See the <strong>SSC Aerobatics Cockpit Card</strong> and read the <strong>NOTE</strong> at the end of each aerobatic maneuver for altitude changes on all maneuvers.&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 291,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>The flying of aerobatics sorties by pilots of the Skyline Soaring Club requires the following:</p>",
+      "option_a": "An aerobatics instructor must be with you on all sorties.",
+      "option_b": "Approval by the DO and maintaining radio contact on 123.0. ",
+      "option_c": "The DO must open the SSC pre-approved aerobatics box. ",
+      "option_d": "All of the above. ",
+      "correct_answer": "D",
+      "explanation": "<p>See <strong>Section 2.1. Preflight Procedures</strong> in the <em>SSC Advanced Flying Guide.</em></p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 292,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>The emergency bailout procedures for the ASK-21 are found in the POH in the following section and pages.</p>\r\n<p>Further, that section says that if circumstances allow, the front pilot should allow the rear pilot to bail out _________ (first? or second?).&nbsp;</p>",
+      "option_a": "Section IV,9 on pages 35-36. First.",
+      "option_b": "Section IV.9 on pages 35-36, Second.",
+      "option_c": "Section VI.4 on pages 51-52, Second. ",
+      "option_d": "Section III.2 on pages 22-23, First.",
+      "correct_answer": "D",
+      "explanation": "<p>Do you really need this one explained now that you found it in Section III.2 on pages 22-23!&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 293,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>The <em>SSC Advanced Flying Guide</em> contains many sections of text that are highlisted in red, bolded, and set off from the normal text.</p>\r\n<p>Each of these red and bolded paragraphs are a WARNING that represent o<font>perating procedures or practices:&nbsp;</font></p>",
+      "option_a": " . . which if not strictly observed could result in serious damage to the aircraft.",
+      "option_b": " . . that is essential to emphasize. ",
+      "option_c": " . . that could result in personal injury or loss of life or loss of the aircraft if not carefully followed. ",
+      "option_d": "None of the above! Surely, there is nothing at all hazardous about flying aerobatics. ",
+      "correct_answer": "C",
+      "explanation": "<p>While flying aerobatics is quite safe when done correctly and with respect for all that's happening, it certainly is hazardous when done without careful planning, study, and attention to detail.&nbsp;</p>\r\n<p>See <strong>Section 1.2. Overview of This Program</strong> in the <em>SSC Advanced Flying Guide.&nbsp;</em></p>\r\n<p>&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 294,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>The maneuvers illustrated in the <em>SSC Advanced Flying Guide</em> must be flown only inside the club's approved aerobatics box.</p>\r\n<p>This box comes with a set of waivers granted to us by the FAA, which were necessary to obtain and to adhere to because:&nbsp;</p>",
+      "option_a": "We don't want to scare our airport neighbors. ",
+      "option_b": "Aerobatics cannot be performed with 4nm of a Victor airway and one lies directly over us.",
+      "option_c": "It gives us a nice safe space that no one else is allowed to fly through. ",
+      "option_d": "It has good viewing points for crowds on the ground. ",
+      "correct_answer": "B",
+      "explanation": "<p>Read all of <strong>Attachment 1</strong> of the <strong>SSC Advanced Flying Guide</strong> and the <strong>Aerobatics Checklist</strong> for detailed depictions of the aerobatic box, the use of which is required by Federal Air Regulations for all of our club's aerobatic flying.&nbsp;</p>\r\n<p>Our field and flying area lies within 4nm of the centerlines of two Victor airways. We cannot perform aerobatics without a waiver from the FAA, which we have secured.</p>\r\n<p>The top of our box gives us 500 feet of normal VFR separation from IFR traffic using those airways.&nbsp;</p>\r\n<p>A special mention about fake answer C: Our aerobatics box provides exactly ZERO protection from other aircraft flying through it any time. We do expect that club members will avoid the box when it is in use, but the box is not depicted on any aeronautical chart, and no pilots outside of the SSC will know of its activation. There will be NOTAM and no TFR.&nbsp;</p>\r\n<p><strong>Constant traffic vigiliance and clearing turns before every maneuver are absolutely MUSTS!&nbsp;</strong></p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 295,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>Gloders are not required to have transponders or ADS-B devices. The SSC has voluntarily elected to provide both of those devices in all of the club's aircraft. Legally, however, if either of those devices are inoperative, the aircraft could still be flown normally. Is this true for SSC gliders while performing aerobatics?</p>",
+      "option_a": "No, Our aerobatics box waiver requires any glider using it to have a transponder set to 1202. ",
+      "option_b": "Yes. Even doing aerobatics, we're still a glider with the same exemption. ",
+      "option_c": "No. Our aerobatics box waiver required any glider using it to have a working ADS-B Out. ",
+      "option_d": "Both A & C. ",
+      "correct_answer": "D",
+      "explanation": "<p>Read all of&nbsp;<strong>Attachment 1<em>&nbsp;</em></strong>in the&nbsp;<em>SSC Advanced Flying Guide</em> for details on the restrictions to which we agreed in exchange for getting the waivers we need for the club's aerobatics box.&nbsp;</p>\r\n<p>The current SSC aerobatics box is expanded considerably compared to our previous box, which will greatly improve our ability to perform the aerobatic maneuvers properly. The restrictions to which we agreed will help other aircraft see and avoid our gliders while aerobatics are being performed, which helped us get approval for the larger box and the higher altitude.&nbsp;</p>",
+      "last_updated": "2019-09-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 296,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>When assembling the PW-5, which wing should you insert first?</p>",
+      "option_a": "The left wing.  All gliders have adopted this as standard.",
+      "option_b": "The right wing, because the manual said so.",
+      "option_c": "Either wing.  The glider is symmetrical.",
+      "option_d": "Panic and call Keith.",
+      "correct_answer": "B",
+      "explanation": "<p>The Sailplane Maintenance Manual p. 3-8 (pdf p. 49), &para; C.3. instructs: \"rig the right-hand wing first....\"</p>\r\n<p>You may then insert the main bolts halfway to help hold the right wing in place while inserting the left wing.</p>",
+      "last_updated": "2021-12-18",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 297,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>What is the maximum allowed gross weight of the PW-5?</p>",
+      "option_a": "300 lbs.",
+      "option_b": "110 kg.",
+      "option_c": "110 daN.",
+      "option_d": "661.4 lbs.",
+      "correct_answer": "D",
+      "explanation": "<p>The POH lists 300 kg (661.4 lbs) as the maximum weight of the aircraft. POH p. 2.4 (pdf p. 13), &para; 2.4.</p>\r\n<p>&nbsp;</p>",
+      "last_updated": "2022-01-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 298,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>During your preflight, you open the inspection plate to check the connections to control systems. After you close the inspection plate, should it be taped in place?</p>",
+      "option_a": "No, wing tape is expensive and should not be wasted on non-control surfaces.",
+      "option_b": "No, we paid good money for the latch on the inspection plate, and should maximize that investment.",
+      "option_c": "No, the wing tape is usually kept in the hangar and it is a pain to go get it.",
+      "option_d": "Yes, the inspection plate must always be taped so we don't lose it.",
+      "correct_answer": "D",
+      "explanation": "<p>The inspection plate latch is insufficient to hold the inspection plate in place at flying speed, so the inspection plate must be taped in place.</p>",
+      "last_updated": "2021-12-18",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 299,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>What is the Never Exceed speed (Vne) of the PW-5?</p>",
+      "option_a": "65 kts.",
+      "option_b": "81 kts.",
+      "option_c": "115 kts.",
+      "option_d": "121 kts.",
+      "correct_answer": "D",
+      "explanation": "<p>A. 65 kts is incorrect because that is the maximum winch launch (Vw) speed.</p>\r\n<p>B. 81 kts is incorrect because that is the maneuvering (Va) speed and maximum aerotow (Vt) speed.&nbsp;</p>\r\n<p>C. 115 kts was the original limit per POH page 2.2 , but has been superseded by technical notes from the manufacturer and EASA</p>\r\n<p>D. 121 kts is now correct after the manufacturer and EASA type certification notices.</p>",
+      "last_updated": "2022-01-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 300,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>Someone gave you a hint to search online for the phrase \"Smyk PW-5 Service Bulletin BS-17-08-19 dated February 21, 2008\" and after finding it, you learned that the maximum operating altitude of the SSC's PW-5 is:</p>",
+      "option_a": "16,404' MSL",
+      "option_b": "16,404' AGL",
+      "option_c": "18,000' MSL",
+      "option_d": "36,089' MSL",
+      "correct_answer": "D",
+      "explanation": "<p>A. 16,404' MSL is incorrect because the original 5,000 m limitation in the POH was increased by a subsequent service bulletin.</p>\r\n<p>B. 16,404' AGL is incorrect because it is a distractor based upon the obsolete 5,000 m limitation in the POH.</p>\r\n<p>C. 18,000' MSL is incorrect because although it is the floor of Class A airspace, operations in Class A airspace are permitted under certain circumstances.</p>\r\n<p>D. 36,089' MSL is correct because the maximum altitude was increased to 11,000 m by Service Bulletin BS-17-08-09 dated February 21, 2008.</p>",
+      "last_updated": "2024-06-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 301,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>Assuming the gross weight of the glider does not provide for a more restrictive limitation, what is the maximum weight of the pilot, parachute or seat cushions, and baggage?</p>",
+      "option_a": "213 lbs",
+      "option_b": "242 lbs",
+      "option_c": "247.5 lbs",
+      "option_d": "There is no separate cockpit load limit; the gross weight controls.",
+      "correct_answer": "B",
+      "explanation": "<p>A. 213 lbs is incorrect because that is the Sprite's maximum pilot weight.</p>\r\n<p>B. 242 lbs is correct. The design maximum cockpit load is listed as 110 kg (242 lbs) in the POH at p. 2.7 (pdf p. 16), &para; 2.12.&nbsp; However, the max allowable gross weight may restrict this further.</p>\r\n<p>C. 247.5 lbs is incorrect because the maximum cockpit load is 110 kg and not 110 daN.</p>\r\n<p>D. is incorrect because there is a separate cockpit load limit published.</p>",
+      "last_updated": "2022-01-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 302,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>The maximum strength of rope or weak-link is ____ according to the PW5 POH, and ____ according to the FAA.</p>",
+      "option_a": "<p>700 lbs, 600 kg, because the POH specifies 700 and the regulation specifies 2x gross weight.</p>",
+      "option_b": "<p>1574 lbs, 1323 lbs, because the POH specifies 700 daN, and the regulation specifies 2x gross weight</p>",
+      "option_c": "<p>1374 lbs, 1374 lbs, because the POH supersedes the regulation in this case.</p>",
+      "option_d": "<p>1238 lbs, 1238 lbs, because the limiting factor is the towplane's tost release.</p>",
+      "correct_answer": "B",
+      "explanation": "<p>The POH specifies 700 daN (1574 lbs) at p. 2.6 (pdf p. 15), &para; 2.10.</p>\r\n<p>14 CFR &sect; 91.309(a)(3) requires a breaking strength no more than twice the gross weight of the aircraft (2 * 300 kg = 600 kg = 1323 lbs).</p>\r\n<p>A. is incorrect because the POH specifies 700 daN, not 700 lbs.</p>\r\n<p>B. is correct.</p>\r\n<p>C. is incorrect because you are required to comply with both the regulation and the operating limitations in the POH.</p>\r\n<p>D. is incorrect because 1238 lbs is the actual rated rope strength of SSC's polypropylene ropes, and not the limit of the towplane's tost hook.</p>\r\n<p>[Clarified in the call of the question this is for the PW5]</p>\r\n<p>&nbsp;</p>\r\n<p>&nbsp;</p>",
+      "last_updated": "2026-07-09",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 303,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>In the PW-5, the green arc on the airspeed indicator is from 38 KIAS to 81 KIAS.&nbsp; 38 KIAS is 1.1 times the stall speed for a heavy aircraft.&nbsp; 81 KIAS is:</p>",
+      "option_a": "The maximum rough air speed",
+      "option_b": "The maneuvering speed",
+      "option_c": "Maximum aerotowing speed",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "<p>Pages 2.2 lists the airspeed limitations and page 2.3 list the airspeed indicator markings.&nbsp; In this case, Vra (Vno) and Va and Vt are all the same, at 81 KIAS.</p>",
+      "last_updated": "2021-12-21",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 304,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>When landing the PW-5, touchdown attitude should be:</p>",
+      "option_a": "Tail wheel first",
+      "option_b": "Tail wheel and main gear simultaneously",
+      "option_c": "Main gear only (slightly tail low)",
+      "option_d": "Main gear and nose wheel simultaneously",
+      "correct_answer": "C",
+      "explanation": "<p>POH page 4.10 specifies that on landing the touchdown should be only on the main wheel, avoiding tail skid impact.&nbsp; This is different from the Discus (tail wheel first) or ASK-21 (tail and main roughly at the same time).&nbsp; Touching down nose first is never a good idea.&nbsp; Touching down tail first may cause severe tail boom vibration and damage.&nbsp; Landing with full spoilers may increase the chance of touching down tail first.</p>",
+      "last_updated": "2022-01-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 305,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>The PW-5 is capable of spinning.&nbsp; The procedure for recovering from a spin in the PW-5 is:</p>",
+      "option_a": "Full opposite rudder, ease stick forward until rotation stops, centralize rudder and recover from dive.",
+      "option_b": "Full opposite rudder, pause, ease stick forward until rotation stop, centralize rudder and recover from dive.",
+      "option_c": "Ailerons neutral, full opposite rudder, ease stick forward until rotation stops, centralize rudder and recover from dive.",
+      "option_d": "Full opposite rudder, stick full forward until rotation stops, centralize rudder and recover from dive.",
+      "correct_answer": "C",
+      "explanation": "<p>POH page 3.2 specifies the steps for spin recovery. (A) are the steps for recovery in the Discus, (B) are the steps for recovery in the ASK-21, (C) are the steps explicitly listed for the PW-5.&nbsp; (D) is probably not a good idea in any glider.&nbsp; Subtle differences between A, B, C.&nbsp; In practice, ailerons should always be neutral during recovery for most gliders.</p>",
+      "last_updated": "2021-12-21",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 306,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>In the PW-5, the POH-recommended aerotow speed while climbing is:</p>",
+      "option_a": "60 KIAS",
+      "option_b": "65-70 KIAS",
+      "option_c": "50-75 KIAS",
+      "option_d": "60 MPH",
+      "correct_answer": "A",
+      "explanation": "<p>POH page 4.9 specifies the recommended aerotow speed of 60 KIAS in a climb (A).&nbsp; Option (B) may be commonly used by towplanes, but not specified in the POH.&nbsp; (C) is the recommended range from the ASK-21 POH, and (D) is wrong because the PW-5 airspeeds are specified in KIAS.&nbsp;</p>",
+      "last_updated": "2024-06-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 307,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>In the PW-5, before takeoff adjust the trim setting to:</p>",
+      "option_a": "Neutral",
+      "option_b": "Position 1-2 for light pilots, and up to 5-6 for heavy pilots",
+      "option_c": "Full forward",
+      "option_d": "Full aft",
+      "correct_answer": "B",
+      "explanation": "<p>POH page 4.9 specifies setting 1-2 for light pilots and up to 5-6 for heavy pilots.</p>",
+      "last_updated": "2021-12-21",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 308,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>In the PW-5, aerotow in the low tow position (including boxing the wake) is not recommended because:</p>",
+      "option_a": "The glider is unstable in low tow position",
+      "option_b": "The cable rubs the front of the fuselage",
+      "option_c": "Sufficient elevator authority is not available",
+      "option_d": "Boxing the wake is never permitted solo",
+      "correct_answer": "B",
+      "explanation": "<p>POH page 4.9 recommends against flying under the towing airplane downwash because the cable rubs the fuselage.</p>",
+      "last_updated": "2021-12-21",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 309,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>In the PW5, there are canopy locking hand grips on both sides.&nbsp; Which of the following is FALSE?</p>",
+      "option_a": "Pull back on the canopy grips just until you meet resistance",
+      "option_b": "Pull back on the canopy grips until the sliding rod by your shoulders no longer shows bare metal",
+      "option_c": "If the canopy does not align properly, you may need to pull the aft sides of the canopy rail inward by grasping the locking rod, or ask for help from somebody outside",
+      "option_d": "If the canopy rail goes wide to the outside, it is possible for the handle to be aft but not locked",
+      "correct_answer": "A",
+      "explanation": "<p>The canopy rarely seats completely without help to push or pull the lower aft corners inward.</p>",
+      "last_updated": "2022-01-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 310,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>The red T-handle at the top of the instrument panel is:</p>",
+      "option_a": " The tow cable release knob",
+      "option_b": "The rudder pedal adjust knob",
+      "option_c": "The canopy jettison knob",
+      "option_d": "The cabin air vent adjust knob",
+      "correct_answer": "C",
+      "explanation": "<p>POH page 7.2 describes the location of the emergency canopy release.&nbsp; Without a parachute, there are few cases where you would ever want to touch this.</p>",
+      "last_updated": "2022-01-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 311,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>In the PW5, the wheel brake is activated by:</p>",
+      "option_a": "Pulling full aft on the spoiler handle",
+      "option_b": "Squeezing the brake handle on the lower part of the control stick",
+      "option_c": "Squeezing the brake handle on the front of the spoiler handle",
+      "option_d": "Pulling up on the brake lever just behind the trim adjuster",
+      "correct_answer": "C",
+      "explanation": "<p>POH page 7.2 identifies the brake lever.&nbsp; A is how the ASK-21 works, B is how the Discus works, D is a Blanik feature.&nbsp; Do NOT land with the brake lever on the spoiler handle already squeezed.</p>",
+      "last_updated": "2022-01-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 312,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>Refer to the cockpit cards with cockpit loading chart based on the 2 Jan 2022 weight and balance.&nbsp; You weigh 230 pounds as dressed for your flight, and intend to position the seat back full aft.&nbsp; Are you legal to fly N505CC?</p>",
+      "option_a": "Yes, because the allowable cockpit load is 110 kg or 242 pounds.",
+      "option_b": "Yes, because the CG position would be 52% of allowable aft range.",
+      "option_c": "No, because the max allowable gross weight of the glider limits pilot weight to 223.5 pounds.",
+      "option_d": "Yes, because it is permissible to exceed max allowable gross weight if not flown for aerobatics.",
+      "correct_answer": "C",
+      "explanation": "<p>C is correct, because the most recent empty weight of 437 pounds limits the cockpit load to 223.5 pounds.</p>\r\n<p>A is not correct, because the design cockpit load is still subject to the MAGW limit.</p>\r\n<p>B is not correct, because the allowable CG position is still subject to the MAGW limit.</p>\r\n<p>D is not correct, because there is no concession here for exceeding the MAGL limit.</p>",
+      "last_updated": "2022-02-14",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 313,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>Refer to the cockpit cards with cockpit loading chart based on the 2 Jan 2022 weight and balance.&nbsp; You weigh 145 pounds as dressed for your flight, and intend to position the seat back full forward.&nbsp; Are you legal to fly this PW5?</p>",
+      "option_a": "No, because the minimum pilot weight for all gliders is 70 kg or 154 pounds.",
+      "option_b": "No, because the CG limit would be too far aft.",
+      "option_c": "Yes, the weight is within the allowable range and the CG would be at 90% of allowable aft range.",
+      "option_d": "Yes, but only if you sit on a 25 pound shot bag.",
+      "correct_answer": "C",
+      "explanation": "<p>C is correct, the weight is within cockpit limits (121 to 242 pounds) and the CG is within limits but right at the club-recommended 90% aft range.</p>\r\n<p>A is not correct, for this glider the design cockpit minimum was 55 kg or 121 pounds, with the restriction that if below 60 kg or 132 pounds the seat must be full forward.</p>\r\n<p>B is not correct, the CG is right at the club recommended aft limit at 90%.</p>\r\n<p>D is not correct, a shot bag is not required, but if you did, 25 pounds would move the CG forward to about 74%, which might be more comfortable to handle.</p>",
+      "last_updated": "2022-01-29",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 314,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>Section 4.5.7 of the POH says that \"looping\" aerobatics are approved in the PW-5. Are you excited about flying some loops?</p>",
+      "option_a": "Yes, but only with a parachute",
+      "option_b": "Yes, if I can squeeze a CFIG in with me ",
+      "option_c": "No, due to SSC ops manual prohibitions",
+      "option_d": "No, because I'm scared of loops, but I'll certainly try some if I get brave enough",
+      "correct_answer": "C",
+      "explanation": "<p>Section <strong>3.10 Aerobatics</strong> in the SSC Ops manual prohibits aerobatics except when flying dual and even then with all other requirements satisfied.&nbsp;</p>",
+      "last_updated": "2022-02-14",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 315,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>The PW-5 seems to like \"mean pilots,\" but has a special note that applies to some \"light pilots.\"&nbsp;</p>",
+      "option_a": "Even though the PW-5 has no limits on \"mean pilots,\" they should get an attitude adjustment. ",
+      "option_b": "The statement is wrong, there are no special notes about \"light pilots\"",
+      "option_c": "A very bright \"light pilot\" is allowed to fly at night",
+      "option_d": "A \"light pilot\" who weighs less than 60kg must set the back-rest at the front limit position",
+      "correct_answer": "D",
+      "explanation": "<p>The PW-5 POH has a CAUTION in Section 6.2 that states: PILOTS OF THE BODY+PARACHUTE WEIGHT BELOW 60KG MUST HAVE THE BACK-REST LOCATED IN LIMIT FRONT POSITION.</p>",
+      "last_updated": "2022-02-14",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 316,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>What does the PW-5 POH say about side slips?</p>",
+      "option_a": "Any airspeed and bank angle are allowable.",
+      "option_b": "Minimum airspeed is 49 knots and max bank angle of 20 degrees to maintain heading",
+      "option_c": "Minimum airspeed is 49 knots, any bank angle, and the airspeed indication will always be valid",
+      "option_d": "Maximum airspeed is 49 knots, but the airspeed indication will not be valid",
+      "correct_answer": "B",
+      "explanation": "<p>Section <strong>4.5.3 FLIGHT</strong> says that side slips should be performed at an airspeed of 49 knots or higher and that heading can be maintained at up to 20 degrees of bank. It also says that the airspeed indicator will be invalid.&nbsp;</p>",
+      "last_updated": "2022-02-14",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 317,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>The yellow arc on the airspeed indicator is from 81 to 115 knots with a redline at 115 because:</p>",
+      "option_a": "Those markings show the correct limits. ",
+      "option_b": "Those markings are incorrect because the max limit (Vne) has been increased to 121 knots",
+      "option_c": "The yellow arc shows the range for performing aerobatics",
+      "option_d": "The yellow arc and red line can't be wrong! ",
+      "correct_answer": "B",
+      "explanation": "<p>121 kts is the correct Vne after the manufacturer and EASA type certification notices, but the airspeed indicator markings have not been changed.&nbsp;</p>",
+      "last_updated": "2022-02-14",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 318,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>In the SSC Advanced Flying Guide, a CAUTION signifies:</p>",
+      "option_a": "Operating procedures or practices which, if not strictly observed, could result in damage to the aircraft. ",
+      "option_b": "Operating procedures or practices that could result in personal injury or loss of life, or loss of the aircraft if not carefully followed.",
+      "option_c": "Operating procedures or practices which might make you barf. ",
+      "option_d": "Operating procedures or practices which are very scary to perform. ",
+      "correct_answer": "A",
+      "explanation": "<p>See Chapter 1 in the&nbsp;<em>SSC Advanced Flying Guide</em></p>",
+      "last_updated": "2022-11-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 319,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>The build-up principle to learning aerobatics means:</p>",
+      "option_a": "Building excitement for your friends to come to the airport to watch. ",
+      "option_b": "To start out slowly and work on new techniques to build up to performing complete aerobatic maneuvers.",
+      "option_c": "To build up your courage before each aerobatics flight. ",
+      "option_d": "To never fly aerobatics when there are cloud build-ups in the area. ",
+      "correct_answer": "B",
+      "explanation": "<p>See Chapter 5 in the&nbsp;<em>SSC Advanced Flying Guide</em></p>",
+      "last_updated": "2022-11-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 320,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>Which is these is true about G-LOC:</p>",
+      "option_a": "It\u2019s a device on the control stick that can lock out the possibility of exceeding the aircraft\u2019s G limits. ",
+      "option_b": "It\u2019s a loss of consciousness occurring from high g-forces draining blood away from the brain, causing cerebral hypoxia.",
+      "option_c": "You can minimize it by performing the AGSM.",
+      "option_d": "Both B and C are correct. ",
+      "correct_answer": "D",
+      "explanation": "<p>See Chapter 5 in the&nbsp;<em>SSC Advanced Flying Guide</em></p>",
+      "last_updated": "2022-11-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 321,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>Club aerobatics are restricted to the designated Aerobatics Practice Area (APA):</p>",
+      "option_a": "To ensure separation from all other air traffic.",
+      "option_b": "To ensure separation from other club glider traffic. ",
+      "option_c": "Because aerobatics in our area violate some FARs, which are waived when we fly inside our activated APA. ",
+      "option_d": "So that club members on the ground can watch and make videos of your aerobatics. ",
+      "correct_answer": "C",
+      "explanation": "<p>See 14 CFR 91.303(d) and (e)</p>",
+      "last_updated": "2022-11-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 322,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>Your tolerance to G loading:</p>",
+      "option_a": "<p>There's not much you can do. Some people can tolerate G&rsquo;s, and some can&rsquo;t.</p>",
+      "option_b": "<p>Can be enhanced by not working out hard the day before flying aerobatics.</p>",
+      "option_c": "<p>Can be enhanced by having good carbohydrate stores in your body.</p>",
+      "option_d": "<p>Both B and C are correct.</p>",
+      "correct_answer": "D",
+      "explanation": "<p>See Chapter 5 in the&nbsp;<em>SSC Advanced Flying Guide</em>, which quotes ad U.S. Air Force Web site for fighter pilots.&nbsp;</p>",
+      "last_updated": "2026-01-28",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 323,
+    "fields": {
+      "category": "ACRO",
+      "question_text": "<p>In the SSC Advanced Flying Guide, a NOTE signifies:</p>",
+      "option_a": "Operating procedures that will wow the crowd at an airshow. ",
+      "option_b": "Operating procedure or a condition that is essential to emphasize.",
+      "option_c": "Operating procedures that don\u2019t really matter. ",
+      "option_d": "Operating procedures that are especially disorienting. ",
+      "correct_answer": "B",
+      "explanation": "<p>See Chapter 1 in the&nbsp;<em>SSC Advanced Flying Guide</em></p>",
+      "last_updated": "2022-11-10",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 324,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>As part of the PW-5 preflight cockpit checks, confirm that the cable end connection is securely fastened at the pull-handle for the:</p>",
+      "option_a": "Tow hook release",
+      "option_b": "Rudder pedal adjust",
+      "option_c": "Emergency canopy jettison",
+      "option_d": "All of the above",
+      "correct_answer": "D",
+      "explanation": "<p>Although not listed specifically in the POH, loose connections have been found on our PW-5 in the past.&nbsp; Easy to check.</p>",
+      "last_updated": "2023-06-03",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 325,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>The demonstrated crosswind performance of the PW-5 at takeoff and landing is:&nbsp;</p>",
+      "option_a": "Not specified. ",
+      "option_b": "12 knots",
+      "option_c": "12 meters/second",
+      "option_d": "12 mph",
+      "correct_answer": "B",
+      "explanation": "<p>5.3 of the flight manual states that the demonstrated crosswind performance of the PW-5 at takeoff and landing is 12 knots. It further states that \"during the takeoff and landing ground run on two wheels the sailplane is practically non-sensitive to the crosswind action.\"</p>",
+      "last_updated": "2024-06-17",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 326,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>Who has the final authority on the field as to the sequencing of launches?</p>",
+      "option_a": "<p>Chief Duty Officer</p>",
+      "option_b": "<p>Primary Duty Instructor</p>",
+      "option_c": "<p>Duty Officer</p>",
+      "option_d": "<p>Tow Pilot</p>",
+      "correct_answer": "C",
+      "explanation": "<p>The ops manual says that the duty officer has the final authority about the launch order.&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 327,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>During the operating day the ADO is approached by a newcomer seeking information about SSC. &nbsp;What should the ADO do? &nbsp;</p>",
+      "option_a": "<p>Introduce yourself and describe the activities of the club. &nbsp;</p>",
+      "option_b": "<p>Politely refer the visitor to the DO who will describe the activities of the club. &nbsp;</p>",
+      "option_c": "<p>Politely refer the visitor to a club member other than the DO who will explain the activities of the club. &nbsp;</p>",
+      "option_d": "<p>Politely tell the visitor that as the ADO you must keep your full attention on the flight line and may not be distracted by conversations with visitors. &nbsp;</p>",
+      "correct_answer": "C",
+      "explanation": "<p>The Duty officer is busy keeping the operations running smoothly.&nbsp; There are plenty of members who would like to talk about the club.&nbsp; Direct the visitor to one of those people instead.&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 328,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>During the operating day at what time may the ADO be in a location or position where he cannot see both the runway and the pattern? &nbsp;</p>",
+      "option_a": "<p>When there is a lull in the operations and no gliders are staged for launch. &nbsp;</p>",
+      "option_b": "<p>Never</p>",
+      "option_c": "<p>When nature calls, with the permission of the DO &nbsp;</p>",
+      "option_d": "<p>When there are other members available to launch gliders and watch the pattern. &nbsp;</p>",
+      "correct_answer": "C",
+      "explanation": "<p>The ADO has to be around the runway as much as possible, potty breaks notwithstanding.&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 329,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>What is the highest wind speed at which hangar doors on both sides may be open simultaneously? &nbsp;</p>",
+      "option_a": "<p>8 knots</p>",
+      "option_b": "<p>10 knots</p>",
+      "option_c": "<p>12 knots</p>",
+      "option_d": "<p>14 knots</p>",
+      "correct_answer": "B",
+      "explanation": "<p>If both hangar doors are open, the wind will whip through the hangars, causing aircraft to shift around. Club policy is to have one shut at 10 knots or above.&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 330,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>At the beginning of the operating day prior to the DO briefing where should the gliders be positioned and what other action should be taken? &nbsp;</p>",
+      "option_a": "<p>Line the gliders side to side in the marked positions on the south side of the ramp. &nbsp;Ensure that there is no overlap of the wings, close and lock the canopies, place shot bags on the upwind wing tips if the winds exceed 10 knots, open the spoilers if possible.&nbsp;</p>",
+      "option_b": "<p>Line the gliders side to side in the marked positions on the south side of the ramp. &nbsp;Ensure that there is no overlap of the wings, close and lock the canopies, place shot bags on the downwind wing tips if the winds exceed 10 knots, open the spoilers if possible.&nbsp;</p>",
+      "option_c": "<p>Position the gliders in single file with tails pointed toward the taxiway in the sequence they will be launched. Place shot bags on the upwind wing tips if the winds exceed 10 knots. &nbsp;</p>",
+      "option_d": "<p>Position the gliders in single file with tails pointed toward the taxiway in the sequence they will be launched. Place shot bags on the downwind wing tips if the winds exceed 10 knots. &nbsp;</p>",
+      "correct_answer": "A",
+      "explanation": "<p>It is really important to close AND LOCK the canopies.&nbsp; Just having it closed isn't enough.&nbsp; We have had gusts of wind strong enough to open the canopies that were closed. (Even on the ASK-21!)&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 331,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>The club owns VHF airband handheld and base station radios. &nbsp;With regard to these radios: &nbsp;</p>",
+      "option_a": "<p>The ADO should carry a handheld VHF airband radio tuned to 123.0 at all times and use it to monitor the Front Royal Unicom and flight operations. &nbsp;</p>",
+      "option_b": "<p>The ADO should rely on the audio from the Front Royal Unicom and base station radios to monitor communications on 123.0. &nbsp;</p>",
+      "option_c": "<p>The ADO should carry a handheld VHF airband radio tuned to 123.3 at all times and use it monitor communications with gliders. &nbsp;</p>",
+      "option_d": "<p>The ADO should rely on the audio from the Front Royal Unicom and base station radios to monitor communications with gliders on 123.3. &nbsp;</p>",
+      "correct_answer": "A",
+      "explanation": "<p>It is really important to have the radio tuned to the correct frequency. The radio doesn't do you any good if it's not on your person and not tuned to the right frequency!&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 332,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>When may a guest be present on the ramp?</p>",
+      "option_a": "<p>Never</p>",
+      "option_b": "<p>When accompanied by a Skyline member with permission of the DO.&nbsp;</p>",
+      "option_c": "<p>When accompanied by a Skyline member.&nbsp;</p>",
+      "option_d": "<p>After the guest is briefed by a Skyline member regarding operations and safety.&nbsp;</p>",
+      "correct_answer": "C",
+      "explanation": "<p>We can't have random people milling about the launch line.&nbsp; Have them escorted by a Skyline member. Don't bother the DO with this.&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 333,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>When may a guest be present on the <span style=\"text-decoration: underline;\"><strong>runway</strong></span></p>",
+      "option_a": "<p>Never</p>",
+      "option_b": "<p>When accompanied by a Skyline member with permission of the DO</p>",
+      "option_c": "<p>When accompanied by a Skyline member.&nbsp;</p>",
+      "option_d": "<p>After the guest is briefed by a Skyline member regarding operations and safety.&nbsp;</p>",
+      "correct_answer": "B",
+      "explanation": "<p>The runway is a critical location with many safety hazards.&nbsp; The duty officer should be involved in who is on the runway.&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 334,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>When may a guest be present on the <strong>taxiway</strong></p>",
+      "option_a": "<p>Never</p>",
+      "option_b": "<p>When accompanied by a Skyline member with permission of the DO.&nbsp;</p>",
+      "option_c": "<p>When accompanied by a Skyline member.&nbsp;</p>",
+      "option_d": "<p>After the guest is briefed by a Skyline member regarding operation and safety.&nbsp;</p>",
+      "correct_answer": "B",
+      "explanation": "<p>There are plenty of hazards on the taxiway.&nbsp; The DO should be involved in allowing non-pilots to be escorted to the taxiway.&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 335,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>What are the primary duties of the ADO while operations are underway? &nbsp;</p>",
+      "option_a": "<p>Serve as launch officer for all launches. &nbsp;</p>",
+      "option_b": "<p>Serve as launch officer or retrieve gliders depending upon circumstances. &nbsp;</p>",
+      "option_c": "<p>Serve as launch officer or retrieve gliders depending upon the circumstances and monitor the pattern. &nbsp;</p>",
+      "option_d": "<p>Serve as launch officer for all launches (unless the ADO has designated a temporary launch officer who is known to be qualified to serve as a wing runner) and monitor the pattern. &nbsp;</p>",
+      "correct_answer": "D",
+      "explanation": "<p>Sometimes the ADO is needed elsewhere, at which point the DO can designate somebody to be the launch officer.&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 336,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>May the ADO be assisted by other Skyline members?&nbsp;</p>",
+      "option_a": "<p>The ADO may seek assistance from other Skyline members present at the field to perform any of the ADO duties.</p>",
+      "option_b": "<p>The ADO should generally serve as launch officer for all (or almost all) launches and may seek assistance from other Skyline members in positioning gliders or the ramp and retrieving gliders with tow vehicles. &nbsp;</p>",
+      "option_c": "<p>The ADO should generally retrieve gliders that have landed and delegate to other Skyline members the duty to serve as launch officer. &nbsp;</p>",
+      "option_d": "<p>The ADO should generally serve as launch officer and should retrieve gliders that have landed and to tow them back to the ramp area. &nbsp;</p>",
+      "correct_answer": "B",
+      "explanation": "<p>The ADO is supposed to be the primary person responsible for hooking up and launching gliders. The other tasks can be delegated by the ADO if conditions merit.&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 337,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>When a glider is positioned for launch and before the tow rope is connected the launch officer should: &nbsp;</p>",
+      "option_a": "<p>Present the end of the tow rope to the glider pilot for inspection and approval.</p>",
+      "option_b": "<p>Ensure that the canopy is locked.&nbsp;</p>",
+      "option_c": "<p>Ensure that the tail dolly has been removed.</p>",
+      "option_d": "<p>All of the above.</p>",
+      "correct_answer": "D",
+      "explanation": "<p>All of these are true statements.&nbsp;</p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 338,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>When the glider is positioned for launch and after the tow rope is connected, the launch officer should: &nbsp;</p>",
+      "option_a": "<p>Ask and confirm that the pilot is ready for launch.</p>",
+      "option_b": "<p>Move behind the spoiler of the wing.</p>",
+      "option_c": "<p>Signal the tow pilot to take up slack in the tow rope.&nbsp;</p>",
+      "option_d": "<p>All of the above, in the order stated</p>",
+      "correct_answer": "D",
+      "explanation": "",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 339,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>In this scenario, the launch officer is running the left wing, and the glider is taking off with a left crosswind. As the launch begins and the glider starts to move down the runway, the launch officer should: &nbsp;</p>",
+      "option_a": "<p>Release the wing</p>",
+      "option_b": "<p>Run beside the left wing holding the wing level and give a forward shove on the wing as it is released</p>",
+      "option_c": "<p>Run beside the wing holding the wing level, releasing the wing without imparting any fore or aft force on the wing tip</p>",
+      "option_d": "<p>Run beside the wing holding the wing slightly lower than neutral, releasing the wing without imparting any fore or aft force on the wing tip</p>",
+      "correct_answer": "D",
+      "explanation": "<p><a href=\"https://www.faa.gov/regulations_policies/handbooks_manuals/aviation/glider_handbook/gfh_chapter_7.pdf\">https://www.faa.gov/regulations_policies/handbooks_manuals/aviation/glider_handbook/gfh_chapter_7.pdf</a> Page 7-6, and figure 7-4</p>\r\n<p><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/mceclip0.png\"></p>",
+      "last_updated": "2026-01-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 340,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>As the tow plane is landing what should be the condition of the next glider to be launched and where should it be positioned? &nbsp;</p>",
+      "option_a": "<p>The pilot and passenger should be aboard and strapped in, the ADO should have confirmed that tow release and positive control checks have been performed, the radio is set to 123.0 and the pilot is ready for push out. &nbsp;The glider main gear should be on the hash mark on the taxiway at the entrance to the ramp. &nbsp;</p>",
+      "option_b": "<p>The pilot and passenger should be aboard and strapped in, the ADO should have confirmed that tow release and positive control checks have been performed, the radio is set to 123.0 and the pilot is ready for launch. &nbsp;The glider should be pushed onto the runway waiting for the tow plane. &nbsp;</p>",
+      "option_c": "<p>The pilot and passenger should be aboard and strapped in, the ADO should have confirmed that tow release and positive control checks have been performed, the radio is &nbsp;4 set to 123.0 and the pilot is ready for push out. &nbsp;The glider main gear should be on the hash mark on the taxiway at the entrance to the ramp. &nbsp;As soon as the tow plane clears the runway the ADO should confirm that the pattern is clear and begin pushing to the hold short line. As soon as the ADO confirms that the glider pilot has made a radio call announcing the launch, the pattern is still clear and the tow plane is approaching the glider may be pushed onto the runway. &nbsp;</p>",
+      "option_d": "<p>a and c are each correct &nbsp;</p>",
+      "correct_answer": "D",
+      "explanation": "",
+      "last_updated": "2026-01-13",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 341,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>The glider has just been pushed past the hold short line and the tow plane is approaching on the taxiway. &nbsp;The ADO hears a radio call from a glider entering the pattern and sees the glider beginning the downwind leg. &nbsp;The ADO should: &nbsp;</p>",
+      "option_a": "<p>Hurry the launch sequence so that the launching glider will be out of the way before the glider in the pattern reaches the runway. &nbsp;</p>",
+      "option_b": "<p>Stop the push out and push the glider back past the hold short line. &nbsp;</p>",
+      "option_c": "<p>Stop the push out and push the glider back to the hash mark at the ramp entrance so that the glider is clear of the taxiway and the grass area on the north side of the runway. &nbsp;</p>",
+      "option_d": "<p>Continue the launch without hurrying the launch sequence to avoid causing undue pressure on the glider pilot as he prepares for launch. &nbsp;</p>",
+      "correct_answer": "C",
+      "explanation": "<p>it is important to keep the runway clear if there is any inbound glider traffic.&nbsp;</p>",
+      "last_updated": "2026-01-13",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 342,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>The glider has been pushed onto the runway and the tow plane is positioned in front of the glider ready to take up slack in the tow line. &nbsp;The ADO hears a radio call from a glider entering the pattern and sees the glider beginning the downwind leg.</p>",
+      "option_a": "<p>Hurry the launch sequence so that the launching glider will be out of the way before the glider in the pattern reaches the runway.&nbsp;</p>",
+      "option_b": "<p>Stop the launch and push the glider back past the hold short line.</p>",
+      "option_c": "<p>Stop the launch and push the glider back to the hash mark at the entrance to the ramp so that the glider is clear of the grass area on the north side of the runway.</p>",
+      "option_d": "<p>Continue the launch without hurrying the launch sequence to avoid causing undue pressure on the glider pilot as he prepares for launch.&nbsp;</p>",
+      "correct_answer": "D",
+      "explanation": "<p>You should never rush the pilots into a launch!&nbsp;</p>\r\n<p>If you're already on the runway, it's unlikely you can get everything off in time before the glider is on final approach.&nbsp;</p>",
+      "last_updated": "2026-01-13",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 343,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>The glider is being pushed out to the hold short line and the tow plane is proceeding up the taxiway. &nbsp; The ADO hears a radio call from the tow plane indicating that the pilot is going to refuel the tow plane. &nbsp;What should the ADO do?&nbsp;</p>",
+      "option_a": "<p>Stop at the hold short line and wait until the tow plane is refueled and begins to taxi before pushing out the glider onto the runway.&nbsp;</p>",
+      "option_b": "<p>Ensure that the glider pilot has made a radio call announcing the launch and then push the glider onto the runway in the launch position to await the tow plane. &nbsp;</p>",
+      "option_c": "<p>Stop at the hold short line and wait until the tow plane is refueled and begins to taxi before pushing the glider onto the runway. &nbsp;Ask the pilot and any passengers to get out of the glider while waiting for the tow plane in case their help is needed to push the glider clear of the runway. &nbsp;</p>",
+      "option_d": "<p>Stop the push out and return the glider to the hash mark at the ramp entrance so that the glider is clear of the grass area north of the runway as well as the taxiway. When the tow plane is refueled and begins to taxi begin the push out if the pattern is clear. &nbsp;</p>",
+      "correct_answer": "D",
+      "explanation": "",
+      "last_updated": "2026-01-13",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 344,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>A glider is entering the downwind leg of the landing pattern. &nbsp;There is no wind and the glider is flying a normal pattern. &nbsp;Approximately how much time will elapse until the glider crosses the runway threshold? &nbsp;</p>",
+      "option_a": "<p>30 seconds</p>",
+      "option_b": "<p>90 seconds</p>",
+      "option_c": "<p>180 seconds</p>",
+      "option_d": "<p>2 minutes</p>",
+      "correct_answer": "B",
+      "explanation": "<p><img src=\"https://storage.googleapis.com/manage2soar/ssc/media/tinymce/mceclip0_pxZDqiq.png\"></p>\r\n<p>On average, it's 90 seconds from the moment the glider turns from the 45 to downwind.&nbsp; 60 seconds abeam the touchdown point on downwind, 30 seconds while on base.&nbsp;</p>",
+      "last_updated": "2026-04-02",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 345,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>The ADO observes a condition that he believes makes continued operations unsafe. &nbsp;He should: &nbsp;</p>",
+      "option_a": "<p>Notify the DO.</p>",
+      "option_b": "<p>Notify the Duty Instructor</p>",
+      "option_c": "<p>Notify the DO, Duty Instructor, and Tow Pilot</p>",
+      "option_d": "<p>Stop operations</p>",
+      "correct_answer": "D",
+      "explanation": "<p>every member at the airport is empowered to shut down operations at any time, due to a safety issue.&nbsp; Simply approach the duty officer, and say \"We need a safety stand-down\" and all operations will stop, and an emergency meeting will convene to discuss the issue.&nbsp;</p>",
+      "last_updated": "2026-01-13",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 346,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>How does the ADO know that the battery chargers are connected and turned on?</p>",
+      "option_a": "<p>All power cords are connected.&nbsp;</p>",
+      "option_b": "<p>Handheld radios are seated in their chargers and charge lights are on, charge lights are on for chargers connected to the glider batteries, the on/off switch on the base station radio charger is illuminated and the charge controller green and red lights are illuminated. &nbsp;The charge controller is inside the base station radio case above the battery. &nbsp;</p>",
+      "option_c": "<p>Everything looks good. &nbsp;</p>",
+      "option_d": "<p>The ADO hears the radios working</p>",
+      "correct_answer": "B",
+      "explanation": "<p>\"Everything looks good\" is insufficient.</p>",
+      "last_updated": "2026-01-13",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 347,
+    "fields": {
+      "category": "ADO",
+      "question_text": "<p>A glider is in the pattern preparing to land on runway 28. There is no tow vehicle waiting to retrieve the glider. What should the ADO do? &nbsp;</p>",
+      "option_a": "<p>Drive one of the tow vehicles down the taxiway to the midfield turn-off. &nbsp;Plan to arrive there before the glider stops rolling. &nbsp;When the glider has stopped, quickly walk/run out to the glider to assist the pilot (and passenger) in exiting the glider and pushing it off the runway. &nbsp;</p>",
+      "option_b": "<p>Drive one of the tow vehicles down the taxiway to the midfield turn-off. &nbsp;Plan to arrive there before the glider stops rolling. &nbsp;When the pilot (and passenger) have pushed the glider to the intersection of the taxiway and midfield turn-off hook up the glider and tow it back to the ramp. &nbsp;</p>",
+      "option_c": "<p>Ask one of the Skyline members to drive one of the tow vehicles down the taxiway to the midfield turn-off. &nbsp;Ask them to arrive there before the glider stops rolling. &nbsp;When the glider has stopped they should quickly walk/run out to the glider to assist the pilot (and passenger) in exiting the glider and pushing it off the runway. &nbsp;</p>",
+      "option_d": "<p>Ask one of the Skyline members to drive one of the tow vehicles down the taxiway to the midfield turn-off. &nbsp;When the pilot and passenger have pushed the glider to the intersection of the taxiway and midfield turn-off the tow driver should hook up the glider and tow it back to the ramp. &nbsp;</p>",
+      "correct_answer": "C",
+      "explanation": "",
+      "last_updated": "2026-01-13",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 348,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>What is the primary benefit of the 'Kiosk' user account on the club's duty laptop?</p>",
+      "option_a": "<p>It allows the duty officer to bypass the logsheet creation process</p>",
+      "option_b": "<p>It keeps the duty officer logged in without requiring manual credentials</p>",
+      "option_c": "<p>It provides full administrative access to site configurations</p>",
+      "option_d": "<p>it enables offline flight logging for the entire club membership</p>",
+      "correct_answer": "B",
+      "explanation": "<p>The 'Club Laptop' Kiosk user is pre-authenticated to streamline operations and ensure duty officers don't have to log in or log off. The kiosk mode has to be set up by a club webmaster, and the kiosk mode stays logged in on that device for a year, before its token expires.&nbsp;</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 349,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>A glider is airborne. Launch time is entered, but release altitude was left blank. What will happen if you attempt to finalize later without correcting it?</p>",
+      "option_a": "<p>It will auto-fill the most common altitude</p>",
+      "option_b": "<p>It will fail validation</p>",
+      "option_c": "<p>It will finalize with a warning</p>",
+      "option_d": "<p>It will assume 0 feet</p>",
+      "correct_answer": "B",
+      "explanation": "<p>Release altitude must not be blank (----). Remember that \"0\" (zero) is a valid entry, blank is not). Otherwise, validation will fail.</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 350,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>You attempt to finalize today's logsheet, after all the operations are done. After clicking \"Finalize\" you are redirected to the Finance page with a red banner. What is the most likely cause?</p>",
+      "option_a": "<p>Missing landing time</p>",
+      "option_b": "<p>Missing payment method</p>",
+      "option_c": "<p>Missing release altitude</p>",
+      "option_d": "<p>Towplane Hobbs times missing</p>",
+      "correct_answer": "B",
+      "explanation": "<p>Financial validation failures redirect to Finance page. Flight validation failures stay on logsheet page. All of the other potential validation failures don't have anything to do with the payments or who is paying for these fees.&nbsp; They're all missing information that are associated with the flight logs. It's best just to read the red banner and give the program what it wants for what's missing.&nbsp;</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 351,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>A self-launch glider is flown. You indicate the tow plane is \"Self-Launch\", but you accidentally assign a tow pilot. What is the likely result?</p>",
+      "option_a": "<p>Finalization will fail</p>",
+      "option_b": "<p>It&rsquo;s harmless</p>",
+      "option_c": "<p>Towplane closeout will require tach entries</p>",
+      "option_d": "<p>The flight converts to aerotow</p>",
+      "correct_answer": "C",
+      "explanation": "<p>Assigning a real towplane/tow pilot creates validation requirements for closeout data.</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 352,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>A glider is grounded due to a maintenance issue entered earlier. You attempt to log a new flight with it. What happens?</p>",
+      "option_a": "<p>It appears normally</p>",
+      "option_b": "<p>It appears but warns</p>",
+      "option_c": "<p>It does not appear in dropdown</p>",
+      "option_d": "<p>It blocks finalization later</p>",
+      "correct_answer": "C",
+      "explanation": "<p>Grounded aircraft are removed from available selection.</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 353,
+    "fields": {
+      "category": "DO",
+      "question_text": "<p>At the end of the day, you finalize without entering anything in Safety Issues because nothing notable happened. Is this correct?</p>",
+      "option_a": "<p>No, safety field is mandatory</p>",
+      "option_b": "<p>Yes, leave blank if no issues</p>",
+      "option_c": "<p>Must enter \"No Issues\"</p>",
+      "option_d": "<p>Admin must fill it</p>",
+      "correct_answer": "B",
+      "explanation": "<p>Safety field should be left blank if no notable safety issues occurred.</p>",
+      "last_updated": "2026-02-15",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 354,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>What is the Never Exceed Speed (V<sub>NE</sub>) for the PW-5 in smooth air?</p>\r\n<p>Hint: This limitation has changed since the initial flight manual was published.</p>",
+      "option_a": "<p>121 knots (225 km/h)</p>",
+      "option_b": "<p>151 knots (280 km/h)</p>",
+      "option_c": "<p>135 knots (250 km/h)</p>",
+      "option_d": "<p>108 knots (200 km/h)</p>",
+      "correct_answer": "A",
+      "explanation": "<p class=\"explanation\"><strong>Answer: A.</strong> The limitations were modified by a 2008 Service Bulletin (\"SB\").</p>\r\n<p class=\"explanation\">EASA TCDS on page 4, &para; A.III.7: Air Speeds - Never Exceed chart (for sea level to 3000m) sets V<sub>NE </sub>at 225 km/h (121 KIAS).</p>\r\n<p class=\"explanation\">The Limitations section of the Flight manual, at Page 2.2, listing V<sub>NE</sub> as 115 kts (See &para;&para; 2.2, 2.3, 2.7) has been superseded by the SB.</p>\r\n<p class=\"explanation\">&nbsp;</p>\r\n<p class=\"explanation\">&nbsp;</p>",
+      "last_updated": "2026-07-09",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 355,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>What is the Maneuvering Speed (V<sub>A</sub>) for the PW-5?</p>",
+      "option_a": "<p>70 knots (130 km/h)</p>",
+      "option_b": "<p>81 knots (150 km/h)</p>",
+      "option_c": "<p>86 knots (160 km/h)</p>",
+      "option_d": "<p>97 knots (180 km/h)</p>",
+      "correct_answer": "C",
+      "explanation": "<p class=\"explanation\"><strong>Answer: C.</strong> The design maneuvering speed is 160 km/h (86 kts). (Ref: Flight Manual Page 2.2)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 356,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>Which of the following maneuvers is PROHIBITED in the PW-5?</p>",
+      "option_a": "<p>Loop</p>",
+      "option_b": "<p>Stall</p>",
+      "option_c": "<p>Inverted Flight</p>",
+      "option_d": "<p>Lazy Eight</p>",
+      "correct_answer": "C",
+      "explanation": "<p class=\"explanation\"><strong>Answer: C.</strong> The PW-5 is certified in the Utility category; however, inverted flight and intentional spins are generally restricted or require specific supplemental approval. (Ref: Flight Manual Page 2.8)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 357,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>Up to what speed may the airbrakes be extended?</p>",
+      "option_a": "<p>Up to V<sub>NE</sub> (220 km/h)</p>",
+      "option_b": "<p>Only up to 150 km/h</p>",
+      "option_c": "<p>Up to V<sub>A</sub> (160 km/h)</p>",
+      "option_d": "<p>Only during the landing flare</p>",
+      "correct_answer": "A",
+      "explanation": "<p class=\"explanation\"><strong>Answer: A.</strong> The airbrakes can be opened up to the maximum speed V<sub>NE</sub>. (Ref: Flight Manual Page 2.3)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 358,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>How does the PW-5 typically behave during a straight-ahead stall?</p>",
+      "option_a": "<p>Violent wing drop</p>",
+      "option_b": "<p>Sudden pitch up</p>",
+      "option_c": "<p>Gentle nose drop with vibrating control stick</p>",
+      "option_d": "<p>It cannot be stalled</p>",
+      "correct_answer": "C",
+      "explanation": "<p class=\"explanation\"><strong>Answer: C.</strong> The PW-5 exhibits a gentle stall, usually preceded by a slight vibration of the stick and followed by a nose-down pitch. (Ref: Flight Manual Page 4.7)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 359,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>During rigging, the wing spar pins are secured by:</p>",
+      "option_a": "<p>Safety wire.</p>",
+      "option_b": "<p>Spring-loaded locking pins (Ball locks)</p>",
+      "option_c": "<p>Plastic tape only</p>",
+      "option_d": "<p>Large bolts and nuts</p>",
+      "correct_answer": "B",
+      "explanation": "<p class=\"explanation\"><strong>Answer: B.</strong> The main pins are secured by self-locking spring pins. (Ref: Flight Manual Page 4.2)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 360,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>According to the manual, what should be checked regarding the airbrakes during the daily inspection?</p>",
+      "option_a": "<p>That they only open on the left wing</p>",
+      "option_b": "<p>Proper extension and simultaneous locking</p>",
+      "option_c": "<p>That they are oiled with heavy grease</p>",
+      "option_d": "<p>Nothing; they are self-inspecting</p>",
+      "correct_answer": "B",
+      "explanation": "<p class=\"explanation\"><strong>Answer: B.</strong> Ensure both airbrakes extend fully and lock simultaneously in the closed position. (Ref: Flight Manual Page 4.5)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 361,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>How does rain affect the PW-5's performance?</p>",
+      "option_a": "<p>It improves the glide ratio</p>",
+      "option_b": "<p>It significantly increases the sink rate and stall speed</p>",
+      "option_c": "<p>It has no measurable effect</p>",
+      "option_d": "<p>It makes the glider more stable</p>",
+      "correct_answer": "B",
+      "explanation": "<p class=\"explanation\"><strong>Answer: B.</strong> Rain or contamination (bugs) on the wing increases sink rate and stall speed by about 5-10 km/h. (Ref: Flight Manual Page 4.11)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 362,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>Which of the following is part of the \"Minimum Equipment\" for VFR flight?</p>",
+      "option_a": "<p>Transponder</p>",
+      "option_b": "<p>Airspeed indicator and Altimeter</p>",
+      "option_c": "<p>Two-way Radio</p>",
+      "option_d": "<p>GPS Navigation</p>",
+      "correct_answer": "B",
+      "explanation": "<p class=\"explanation\"><strong>Answer: B.</strong> Basic VFR requires an airspeed indicator, altimeter, and a 4-point safety harness. (Ref: Flight Manual Page 2.9)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 363,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>According to the manual, what is the first action required for recovery from a developed spin?</p>",
+      "option_a": "<p>Push the stick full forward</p>",
+      "option_b": "<p>Apply full rudder opposite to the direction of the spin</p>",
+      "option_c": "<p>Check that the ailerons are neutral</p>",
+      "option_d": "<p>Open the airbrakes immediately</p>",
+      "correct_answer": "C",
+      "explanation": "<p class=\"explanation\"><strong>Answer: C.</strong> Section 3.5 specifies that the pilot must first check that ailerons are neutral before applying opposite rudder. (Ref: Flight Manual Page 3.2)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 364,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>During a spiral dive recovery, what is the correct sequence of control inputs?</p>",
+      "option_a": "<p>Pull back on the stick, then level the wings with ailerons.</p>",
+      "option_b": "<p>Level the wings with coordinated aileron and rudder, then recover from the dive.</p>",
+      "option_c": "<p>Deploy full airbrakes and wait for the nose to rise</p>",
+      "option_d": "<p>Apply full opposite rudder and push the stick forward</p>",
+      "correct_answer": "B",
+      "explanation": "<p class=\"explanation\"><strong>Answer: B.</strong> Recovery is achieved by canceling the bank with coordinated aileron/rudder first, then pulling out of the dive. (Ref: Flight Manual Page 3.2)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 365,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>How are the two main wing pins (spar pins) secured after they are pushed into the fuselage?</p>",
+      "option_a": "<p>By tightening a 19mm nut.</p>",
+      "option_b": "<p>By spring-loaded safety pins (ball-locks) on the pins themselves</p>",
+      "option_c": "<p>By safety wire through the pin heads</p>",
+      "option_d": "<p>By a secondary locking bolt located behind the pilot's head</p>",
+      "correct_answer": "B",
+      "explanation": "<p class=\"explanation\"><strong>Answer: B.</strong> The main pins are secured by self-locking spring pins. (Ref: Flight Manual Page 4.2)</p>",
+      "last_updated": "2026-03-12",
+      "updated_by": null,
+      "media": ""
+    }
+  },
+  {
+    "model": "knowledgetest.question",
+    "pk": 366,
+    "fields": {
+      "category": "PW5",
+      "question_text": "<p>When de-rigging the aircraft, which component should be removed FIRST?</p>",
+      "option_a": "<p>The left wing.</p>",
+      "option_b": "<p>The main spar pins.&nbsp;</p>",
+      "option_c": "<p>The horizontal stabilizer</p>",
+      "option_d": "<p>The pitot tube.</p>",
+      "correct_answer": "C",
+      "explanation": "<p class=\"explanation\"><strong>Answer: C.</strong> The manual specifies that the horizontal stabilizer should be removed first during the de-rigging sequence. (Ref: Flight Manual Page 4.4)</p>",
+      "last_updated": "2026-07-09",
+      "updated_by": null,
+      "media": ""
+    }
+  }
+]

--- a/loaddata/knowledge-test-demo/knowledgetest.QuestionCategory.json
+++ b/loaddata/knowledge-test-demo/knowledgetest.QuestionCategory.json
@@ -1,0 +1,107 @@
+[
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "ACRO",
+    "fields": {
+      "description": "Aerobatics"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "ADO",
+    "fields": {
+      "description": "Assistant Duty Officer"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "AIM",
+    "fields": {
+      "description": "Aeronautical Information Manual"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "AMF",
+    "fields": {
+      "description": "Aeromedical Factors"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "ASK21",
+    "fields": {
+      "description": "ASK-21 specific questions"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "Discus",
+    "fields": {
+      "description": "Discus CS Questions"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "DO",
+    "fields": {
+      "description": "Duty Officer Operations"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "FAR",
+    "fields": {
+      "description": "Federal Regulations"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "GF",
+    "fields": {
+      "description": "Glider Flying Technique"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "GFH",
+    "fields": {
+      "description": "Glider Flying General Knowledge"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "GNDOPS",
+    "fields": {
+      "description": "SSC Ground Operations"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "PW5",
+    "fields": {
+      "description": "PW-5 Presolo Questions"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "SSC",
+    "fields": {
+      "description": "Skyline Soaring Club questions"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "ST",
+    "fields": {
+      "description": "Soaring Technique"
+    }
+  },
+  {
+    "model": "knowledgetest.questioncategory",
+    "pk": "WX",
+    "fields": {
+      "description": "Weather"
+    }
+  }
+]

--- a/loaddata/knowledge-test-demo/knowledgetest.TestPreset.json
+++ b/loaddata/knowledge-test-demo/knowledgetest.TestPreset.json
@@ -1,0 +1,114 @@
+[
+  {
+    "model": "knowledgetest.testpreset",
+    "pk": 1,
+    "fields": {
+      "name": "ASK21",
+      "description": "ASK-21 glider type rating test - includes aircraft-specific questions plus fundamentals",
+      "category_weights": {
+        "DO": 0,
+        "GF": 10,
+        "ST": 5,
+        "WX": 4,
+        "AIM": 5,
+        "AMF": 0,
+        "FAR": 5,
+        "GFH": 10,
+        "PW5": 0,
+        "SSC": 5,
+        "ACRO": 0,
+        "ASK21": 19,
+        "Discus": 0,
+        "GNDOPS": 5
+      },
+      "is_active": true,
+      "sort_order": 10,
+      "created_at": "2026-01-05T03:02:01.885Z",
+      "updated_at": "2026-01-05T03:02:01.885Z"
+    }
+  },
+  {
+    "model": "knowledgetest.testpreset",
+    "pk": 2,
+    "fields": {
+      "name": "PW5",
+      "description": "PW-5 glider type rating test - includes aircraft-specific questions plus fundamentals",
+      "category_weights": {
+        "DO": 0,
+        "GF": 10,
+        "ST": 5,
+        "WX": 4,
+        "AIM": 5,
+        "AMF": 5,
+        "FAR": 5,
+        "GFH": 10,
+        "PW5": 24,
+        "SSC": 5,
+        "ACRO": 0,
+        "ASK21": 0,
+        "Discus": 0,
+        "GNDOPS": 5
+      },
+      "is_active": true,
+      "sort_order": 20,
+      "created_at": "2026-01-05T03:02:01.969Z",
+      "updated_at": "2026-01-05T03:02:01.969Z"
+    }
+  },
+  {
+    "model": "knowledgetest.testpreset",
+    "pk": 3,
+    "fields": {
+      "name": "DISCUS",
+      "description": "Discus glider type rating test - includes aircraft-specific questions",
+      "category_weights": {
+        "DO": 0,
+        "GF": 10,
+        "ST": 5,
+        "WX": 0,
+        "AIM": 0,
+        "AMF": 0,
+        "FAR": 5,
+        "GFH": 0,
+        "PW5": 0,
+        "SSC": 0,
+        "ACRO": 0,
+        "ASK21": 0,
+        "Discus": 22,
+        "GNDOPS": 5
+      },
+      "is_active": true,
+      "sort_order": 30,
+      "created_at": "2026-01-05T03:02:01.971Z",
+      "updated_at": "2026-01-05T03:02:01.971Z"
+    }
+  },
+  {
+    "model": "knowledgetest.testpreset",
+    "pk": 4,
+    "fields": {
+      "name": "ACRO",
+      "description": "Aerobatics test - focused on aerobatic maneuvers and safety",
+      "category_weights": {
+        "ACRO": 30
+      },
+      "is_active": true,
+      "sort_order": 40,
+      "created_at": "2026-01-05T03:02:01.972Z",
+      "updated_at": "2026-01-05T03:02:01.972Z"
+    }
+  },
+  {
+    "model": "knowledgetest.testpreset",
+    "pk": 5,
+    "fields": {
+      "name": "EMPTY",
+      "description": "Empty template - no questions pre-selected, allows manual question selection",
+      "category_weights": {},
+      "is_active": true,
+      "sort_order": 100,
+      "created_at": "2026-01-05T03:02:01.973Z",
+      "updated_at": "2026-01-05T03:02:01.973Z"
+    }
+  }
+]

--- a/loaddata/knowledge-test-demo/knowledgetest.WrittenTestTemplate.json
+++ b/loaddata/knowledge-test-demo/knowledgetest.WrittenTestTemplate.json
@@ -1,0 +1,530 @@
+[
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 1,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-02-15",
+      "description": "DO logsheet test. See email about this.",
+      "pass_percentage": "100.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-02-15T17:17:03.469Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 2,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-02-22",
+      "description": "Duty Officer Written Test Bank questions",
+      "pass_percentage": "100.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-02-22T20:22:08.196Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 3,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-02-22",
+      "description": "Duty Officer Written Test Bank questions.",
+      "pass_percentage": "100.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-02-22T20:22:35.929Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 4,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-02-22",
+      "description": "Duty Officer Written Test Bank questions",
+      "pass_percentage": "100.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-02-22T20:22:57.436Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 5,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-02-26",
+      "description": "ADO Written test",
+      "pass_percentage": "100.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-02-26T02:50:10.160Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 6,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-02-28",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-02-28T14:28:47.800Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 7,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-03-08",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-03-08T04:46:51.421Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 8,
+    "fields": {
+      "name": "Test by Rufus G Decker on 2026-03-13",
+      "description": "ASK 21 test",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-03-13T19:54:19.320Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 9,
+    "fields": {
+      "name": "Test by John Noss on 2026-03-15",
+      "description": "PW5 Only",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-03-15T02:16:32.574Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 10,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-03-17",
+      "description": "ADO Written Test.  Good Luck!",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-03-17T23:36:51.812Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 11,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-03-22",
+      "description": "Pw5 written test",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-03-22T14:43:12.258Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 12,
+    "fields": {
+      "name": "Test by Ron Wagner on 2026-03-23",
+      "description": "ADO Qualification",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-03-23T14:13:30.157Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 13,
+    "fields": {
+      "name": "Test by Robb Hohmann on 2026-04-02",
+      "description": "",
+      "pass_percentage": "100.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-04-02T01:18:15.580Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 14,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-04-11",
+      "description": "ADO written test",
+      "pass_percentage": "70.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-04-11T17:56:45.142Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 15,
+    "fields": {
+      "name": "Test by Rufus G Decker on 2026-04-17",
+      "description": "ASK 21 pre solo test",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-04-17T14:48:33.874Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 16,
+    "fields": {
+      "name": "Test by John Noss on 2026-07-04",
+      "description": "PW5-specific questions",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-04T00:02:33.615Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 17,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-07-06",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-06T14:19:11.665Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 18,
+    "fields": {
+      "name": "Test by Ron Wagner on 2026-07-06",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-06T14:20:39.468Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 19,
+    "fields": {
+      "name": "Test by Uwe Jettmar on 2026-07-07",
+      "description": "ASK-21",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-07T12:22:39.702Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 20,
+    "fields": {
+      "name": "Test by Ron Wagner on 2026-07-07",
+      "description": "ASK-21",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-07T12:24:41.813Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 21,
+    "fields": {
+      "name": "Test by Ron Wagner on 2026-07-07",
+      "description": "ASK-21",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-07T12:28:43.915Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 22,
+    "fields": {
+      "name": "Test by Chris Norris on 2026-07-07",
+      "description": "ASK-21 presolo written exam.",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-07T14:12:25.753Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 23,
+    "fields": {
+      "name": "Test by Uwe Jettmar on 2026-07-07",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-07T14:59:19.153Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 24,
+    "fields": {
+      "name": "Test by Uwe Jettmar on 2026-07-07",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-07T15:04:24.469Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 25,
+    "fields": {
+      "name": "Test by Uwe Jettmar on 2026-07-07",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-07T17:10:43.090Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 26,
+    "fields": {
+      "name": "Test by Uwe Jettmar on 2026-07-08",
+      "description": "PW5 Test",
+      "pass_percentage": "100.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-08T16:47:17.060Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 27,
+    "fields": {
+      "name": "Test by Uwe Jettmar on 2026-07-08",
+      "description": "AKS-21 pre-solo written test",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-08T17:36:49.446Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 28,
+    "fields": {
+      "name": "Test by Chris Norris on 2026-07-08",
+      "description": "PW5 presolo written exam.",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-08T19:45:28.728Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 29,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-07-09",
+      "description": "ASK-21 Pre-Solo written test",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-09T13:57:45.558Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 30,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-07-09",
+      "description": "ASK-21 Pre-Solo written test",
+      "pass_percentage": "70.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-09T13:59:45.796Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 31,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-07-09",
+      "description": "PW-5 Written test",
+      "pass_percentage": "70.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-09T14:00:13.071Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 32,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-07-09",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-09T14:01:44.787Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 33,
+    "fields": {
+      "name": "Test by Chris Norris on 2026-07-09",
+      "description": "PW5 retest",
+      "pass_percentage": "70.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-09T14:09:26.154Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 34,
+    "fields": {
+      "name": "Test by Chris Norris on 2026-07-09",
+      "description": "PW5",
+      "pass_percentage": "70.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-09T14:12:58.019Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 35,
+    "fields": {
+      "name": "Test by Uwe Jettmar on 2026-07-09",
+      "description": "PWTest",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-09T14:56:47.437Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 36,
+    "fields": {
+      "name": "Test by Piet Barber on 2026-07-10",
+      "description": "",
+      "pass_percentage": "70.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-10T00:46:05.205Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 37,
+    "fields": {
+      "name": "Test by Uwe Jettmar on 2026-07-11",
+      "description": "ASK-21 pre-solo test",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-11T03:49:36.717Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 38,
+    "fields": {
+      "name": "Test by Robb Hohmann on 2026-07-25",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-07-25T17:20:45.513Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 39,
+    "fields": {
+      "name": "Test by David Wacker on 2026-08-15",
+      "description": "",
+      "pass_percentage": "100.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-08-15T17:40:03.284Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 40,
+    "fields": {
+      "name": "Test by John Noss on 2026-08-16",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-08-16T16:29:46.631Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 41,
+    "fields": {
+      "name": "Test by John Noss on 2026-08-16",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-08-16T16:33:12.239Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 42,
+    "fields": {
+      "name": "Test by John Noss on 2026-08-16",
+      "description": "",
+      "pass_percentage": "80.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-08-16T16:35:46.841Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 43,
+    "fields": {
+      "name": "Test by John Noss on 2026-08-16",
+      "description": "",
+      "pass_percentage": "100.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-08-16T16:36:34.994Z"
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplate",
+    "pk": 44,
+    "fields": {
+      "name": "Test by John Noss on 2026-08-16",
+      "description": "",
+      "pass_percentage": "100.00",
+      "time_limit": null,
+      "created_by": null,
+      "created_at": "2026-08-16T16:53:28.662Z"
+    }
+  }
+]

--- a/loaddata/knowledge-test-demo/knowledgetest.WrittenTestTemplate.json
+++ b/loaddata/knowledge-test-demo/knowledgetest.WrittenTestTemplate.json
@@ -3,7 +3,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 1,
     "fields": {
-      "name": "Test by Piet Barber on 2026-02-15",
+      "name": "Written test 1",
       "description": "DO logsheet test. See email about this.",
       "pass_percentage": "100.00",
       "time_limit": null,
@@ -15,7 +15,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 2,
     "fields": {
-      "name": "Test by Piet Barber on 2026-02-22",
+      "name": "Written test 2",
       "description": "Duty Officer Written Test Bank questions",
       "pass_percentage": "100.00",
       "time_limit": null,
@@ -27,7 +27,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 3,
     "fields": {
-      "name": "Test by Piet Barber on 2026-02-22",
+      "name": "Written test 3",
       "description": "Duty Officer Written Test Bank questions.",
       "pass_percentage": "100.00",
       "time_limit": null,
@@ -39,7 +39,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 4,
     "fields": {
-      "name": "Test by Piet Barber on 2026-02-22",
+      "name": "Written test 4",
       "description": "Duty Officer Written Test Bank questions",
       "pass_percentage": "100.00",
       "time_limit": null,
@@ -51,7 +51,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 5,
     "fields": {
-      "name": "Test by Piet Barber on 2026-02-26",
+      "name": "Written test 5",
       "description": "ADO Written test",
       "pass_percentage": "100.00",
       "time_limit": null,
@@ -63,7 +63,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 6,
     "fields": {
-      "name": "Test by Piet Barber on 2026-02-28",
+      "name": "Written test 6",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -75,7 +75,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 7,
     "fields": {
-      "name": "Test by Piet Barber on 2026-03-08",
+      "name": "Written test 7",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -87,7 +87,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 8,
     "fields": {
-      "name": "Test by Rufus G Decker on 2026-03-13",
+      "name": "Written test 8",
       "description": "ASK 21 test",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -99,7 +99,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 9,
     "fields": {
-      "name": "Test by John Noss on 2026-03-15",
+      "name": "Written test 9",
       "description": "PW5 Only",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -111,7 +111,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 10,
     "fields": {
-      "name": "Test by Piet Barber on 2026-03-17",
+      "name": "Written test 10",
       "description": "ADO Written Test.  Good Luck!",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -123,7 +123,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 11,
     "fields": {
-      "name": "Test by Piet Barber on 2026-03-22",
+      "name": "Written test 11",
       "description": "Pw5 written test",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -135,7 +135,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 12,
     "fields": {
-      "name": "Test by Ron Wagner on 2026-03-23",
+      "name": "Written test 12",
       "description": "ADO Qualification",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -147,7 +147,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 13,
     "fields": {
-      "name": "Test by Robb Hohmann on 2026-04-02",
+      "name": "Written test 13",
       "description": "",
       "pass_percentage": "100.00",
       "time_limit": null,
@@ -159,7 +159,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 14,
     "fields": {
-      "name": "Test by Piet Barber on 2026-04-11",
+      "name": "Written test 14",
       "description": "ADO written test",
       "pass_percentage": "70.00",
       "time_limit": null,
@@ -171,7 +171,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 15,
     "fields": {
-      "name": "Test by Rufus G Decker on 2026-04-17",
+      "name": "Written test 15",
       "description": "ASK 21 pre solo test",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -183,7 +183,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 16,
     "fields": {
-      "name": "Test by John Noss on 2026-07-04",
+      "name": "Written test 16",
       "description": "PW5-specific questions",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -195,7 +195,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 17,
     "fields": {
-      "name": "Test by Piet Barber on 2026-07-06",
+      "name": "Written test 17",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -207,7 +207,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 18,
     "fields": {
-      "name": "Test by Ron Wagner on 2026-07-06",
+      "name": "Written test 18",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -219,7 +219,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 19,
     "fields": {
-      "name": "Test by Uwe Jettmar on 2026-07-07",
+      "name": "Written test 19",
       "description": "ASK-21",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -231,7 +231,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 20,
     "fields": {
-      "name": "Test by Ron Wagner on 2026-07-07",
+      "name": "Written test 20",
       "description": "ASK-21",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -243,7 +243,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 21,
     "fields": {
-      "name": "Test by Ron Wagner on 2026-07-07",
+      "name": "Written test 21",
       "description": "ASK-21",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -255,7 +255,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 22,
     "fields": {
-      "name": "Test by Chris Norris on 2026-07-07",
+      "name": "Written test 22",
       "description": "ASK-21 presolo written exam.",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -267,7 +267,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 23,
     "fields": {
-      "name": "Test by Uwe Jettmar on 2026-07-07",
+      "name": "Written test 23",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -279,7 +279,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 24,
     "fields": {
-      "name": "Test by Uwe Jettmar on 2026-07-07",
+      "name": "Written test 24",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -291,7 +291,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 25,
     "fields": {
-      "name": "Test by Uwe Jettmar on 2026-07-07",
+      "name": "Written test 25",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -303,7 +303,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 26,
     "fields": {
-      "name": "Test by Uwe Jettmar on 2026-07-08",
+      "name": "Written test 26",
       "description": "PW5 Test",
       "pass_percentage": "100.00",
       "time_limit": null,
@@ -315,7 +315,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 27,
     "fields": {
-      "name": "Test by Uwe Jettmar on 2026-07-08",
+      "name": "Written test 27",
       "description": "AKS-21 pre-solo written test",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -327,7 +327,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 28,
     "fields": {
-      "name": "Test by Chris Norris on 2026-07-08",
+      "name": "Written test 28",
       "description": "PW5 presolo written exam.",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -339,7 +339,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 29,
     "fields": {
-      "name": "Test by Piet Barber on 2026-07-09",
+      "name": "Written test 29",
       "description": "ASK-21 Pre-Solo written test",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -351,7 +351,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 30,
     "fields": {
-      "name": "Test by Piet Barber on 2026-07-09",
+      "name": "Written test 30",
       "description": "ASK-21 Pre-Solo written test",
       "pass_percentage": "70.00",
       "time_limit": null,
@@ -363,7 +363,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 31,
     "fields": {
-      "name": "Test by Piet Barber on 2026-07-09",
+      "name": "Written test 31",
       "description": "PW-5 Written test",
       "pass_percentage": "70.00",
       "time_limit": null,
@@ -375,7 +375,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 32,
     "fields": {
-      "name": "Test by Piet Barber on 2026-07-09",
+      "name": "Written test 32",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -387,7 +387,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 33,
     "fields": {
-      "name": "Test by Chris Norris on 2026-07-09",
+      "name": "Written test 33",
       "description": "PW5 retest",
       "pass_percentage": "70.00",
       "time_limit": null,
@@ -399,7 +399,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 34,
     "fields": {
-      "name": "Test by Chris Norris on 2026-07-09",
+      "name": "Written test 34",
       "description": "PW5",
       "pass_percentage": "70.00",
       "time_limit": null,
@@ -411,7 +411,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 35,
     "fields": {
-      "name": "Test by Uwe Jettmar on 2026-07-09",
+      "name": "Written test 35",
       "description": "PWTest",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -423,7 +423,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 36,
     "fields": {
-      "name": "Test by Piet Barber on 2026-07-10",
+      "name": "Written test 36",
       "description": "",
       "pass_percentage": "70.00",
       "time_limit": null,
@@ -435,7 +435,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 37,
     "fields": {
-      "name": "Test by Uwe Jettmar on 2026-07-11",
+      "name": "Written test 37",
       "description": "ASK-21 pre-solo test",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -447,7 +447,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 38,
     "fields": {
-      "name": "Test by Robb Hohmann on 2026-07-25",
+      "name": "Written test 38",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -459,7 +459,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 39,
     "fields": {
-      "name": "Test by David Wacker on 2026-08-15",
+      "name": "Written test 39",
       "description": "",
       "pass_percentage": "100.00",
       "time_limit": null,
@@ -471,7 +471,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 40,
     "fields": {
-      "name": "Test by John Noss on 2026-08-16",
+      "name": "Written test 40",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -483,7 +483,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 41,
     "fields": {
-      "name": "Test by John Noss on 2026-08-16",
+      "name": "Written test 41",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -495,7 +495,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 42,
     "fields": {
-      "name": "Test by John Noss on 2026-08-16",
+      "name": "Written test 42",
       "description": "",
       "pass_percentage": "80.00",
       "time_limit": null,
@@ -507,7 +507,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 43,
     "fields": {
-      "name": "Test by John Noss on 2026-08-16",
+      "name": "Written test 43",
       "description": "",
       "pass_percentage": "100.00",
       "time_limit": null,
@@ -519,7 +519,7 @@
     "model": "knowledgetest.writtentesttemplate",
     "pk": 44,
     "fields": {
-      "name": "Test by John Noss on 2026-08-16",
+      "name": "Written test 44",
       "description": "",
       "pass_percentage": "100.00",
       "time_limit": null,

--- a/loaddata/knowledge-test-demo/knowledgetest.WrittenTestTemplateQuestion.json
+++ b/loaddata/knowledge-test-demo/knowledgetest.WrittenTestTemplateQuestion.json
@@ -1,0 +1,15770 @@
+[
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1,
+    "fields": {
+      "template": 1,
+      "question": 352,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 2,
+    "fields": {
+      "template": 1,
+      "question": 199,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 3,
+    "fields": {
+      "template": 1,
+      "question": 177,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 4,
+    "fields": {
+      "template": 1,
+      "question": 196,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 5,
+    "fields": {
+      "template": 1,
+      "question": 185,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 6,
+    "fields": {
+      "template": 1,
+      "question": 348,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 7,
+    "fields": {
+      "template": 1,
+      "question": 176,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 8,
+    "fields": {
+      "template": 1,
+      "question": 194,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 9,
+    "fields": {
+      "template": 1,
+      "question": 193,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 10,
+    "fields": {
+      "template": 1,
+      "question": 198,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 11,
+    "fields": {
+      "template": 1,
+      "question": 226,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 12,
+    "fields": {
+      "template": 1,
+      "question": 205,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 13,
+    "fields": {
+      "template": 1,
+      "question": 203,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 14,
+    "fields": {
+      "template": 1,
+      "question": 192,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 15,
+    "fields": {
+      "template": 1,
+      "question": 183,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 16,
+    "fields": {
+      "template": 1,
+      "question": 209,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 17,
+    "fields": {
+      "template": 1,
+      "question": 188,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 18,
+    "fields": {
+      "template": 1,
+      "question": 227,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 19,
+    "fields": {
+      "template": 1,
+      "question": 187,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 20,
+    "fields": {
+      "template": 1,
+      "question": 184,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 21,
+    "fields": {
+      "template": 1,
+      "question": 245,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 22,
+    "fields": {
+      "template": 1,
+      "question": 173,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 23,
+    "fields": {
+      "template": 1,
+      "question": 206,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 24,
+    "fields": {
+      "template": 1,
+      "question": 353,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 25,
+    "fields": {
+      "template": 1,
+      "question": 201,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 26,
+    "fields": {
+      "template": 1,
+      "question": 349,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 27,
+    "fields": {
+      "template": 1,
+      "question": 242,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 28,
+    "fields": {
+      "template": 1,
+      "question": 204,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 29,
+    "fields": {
+      "template": 1,
+      "question": 189,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 30,
+    "fields": {
+      "template": 1,
+      "question": 207,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 31,
+    "fields": {
+      "template": 1,
+      "question": 171,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 32,
+    "fields": {
+      "template": 1,
+      "question": 191,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 33,
+    "fields": {
+      "template": 1,
+      "question": 350,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 34,
+    "fields": {
+      "template": 1,
+      "question": 351,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 35,
+    "fields": {
+      "template": 1,
+      "question": 186,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 36,
+    "fields": {
+      "template": 1,
+      "question": 172,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 37,
+    "fields": {
+      "template": 1,
+      "question": 246,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 38,
+    "fields": {
+      "template": 1,
+      "question": 208,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 39,
+    "fields": {
+      "template": 1,
+      "question": 244,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 40,
+    "fields": {
+      "template": 1,
+      "question": 200,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 41,
+    "fields": {
+      "template": 1,
+      "question": 197,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 42,
+    "fields": {
+      "template": 1,
+      "question": 202,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 43,
+    "fields": {
+      "template": 1,
+      "question": 170,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 44,
+    "fields": {
+      "template": 1,
+      "question": 190,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 45,
+    "fields": {
+      "template": 2,
+      "question": 172,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 46,
+    "fields": {
+      "template": 2,
+      "question": 197,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 47,
+    "fields": {
+      "template": 2,
+      "question": 183,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 48,
+    "fields": {
+      "template": 2,
+      "question": 206,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 49,
+    "fields": {
+      "template": 2,
+      "question": 202,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 50,
+    "fields": {
+      "template": 2,
+      "question": 353,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 51,
+    "fields": {
+      "template": 2,
+      "question": 226,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 52,
+    "fields": {
+      "template": 2,
+      "question": 208,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 53,
+    "fields": {
+      "template": 2,
+      "question": 203,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 54,
+    "fields": {
+      "template": 2,
+      "question": 205,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 55,
+    "fields": {
+      "template": 2,
+      "question": 348,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 56,
+    "fields": {
+      "template": 2,
+      "question": 185,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 57,
+    "fields": {
+      "template": 2,
+      "question": 191,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 58,
+    "fields": {
+      "template": 2,
+      "question": 204,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 59,
+    "fields": {
+      "template": 2,
+      "question": 177,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 60,
+    "fields": {
+      "template": 2,
+      "question": 207,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 61,
+    "fields": {
+      "template": 2,
+      "question": 192,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 62,
+    "fields": {
+      "template": 2,
+      "question": 193,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 63,
+    "fields": {
+      "template": 2,
+      "question": 190,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 64,
+    "fields": {
+      "template": 2,
+      "question": 201,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 65,
+    "fields": {
+      "template": 2,
+      "question": 196,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 66,
+    "fields": {
+      "template": 2,
+      "question": 194,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 67,
+    "fields": {
+      "template": 2,
+      "question": 176,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 68,
+    "fields": {
+      "template": 2,
+      "question": 188,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 69,
+    "fields": {
+      "template": 2,
+      "question": 350,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 70,
+    "fields": {
+      "template": 2,
+      "question": 184,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 71,
+    "fields": {
+      "template": 2,
+      "question": 200,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 72,
+    "fields": {
+      "template": 2,
+      "question": 170,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 73,
+    "fields": {
+      "template": 2,
+      "question": 352,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 74,
+    "fields": {
+      "template": 2,
+      "question": 186,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 75,
+    "fields": {
+      "template": 2,
+      "question": 349,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 76,
+    "fields": {
+      "template": 2,
+      "question": 246,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 77,
+    "fields": {
+      "template": 2,
+      "question": 173,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 78,
+    "fields": {
+      "template": 2,
+      "question": 189,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 79,
+    "fields": {
+      "template": 2,
+      "question": 209,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 80,
+    "fields": {
+      "template": 2,
+      "question": 187,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 81,
+    "fields": {
+      "template": 2,
+      "question": 351,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 82,
+    "fields": {
+      "template": 2,
+      "question": 244,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 83,
+    "fields": {
+      "template": 2,
+      "question": 242,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 84,
+    "fields": {
+      "template": 2,
+      "question": 199,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 85,
+    "fields": {
+      "template": 2,
+      "question": 198,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 86,
+    "fields": {
+      "template": 2,
+      "question": 171,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 87,
+    "fields": {
+      "template": 2,
+      "question": 227,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 88,
+    "fields": {
+      "template": 2,
+      "question": 245,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 89,
+    "fields": {
+      "template": 3,
+      "question": 170,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 90,
+    "fields": {
+      "template": 3,
+      "question": 349,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 91,
+    "fields": {
+      "template": 3,
+      "question": 191,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 92,
+    "fields": {
+      "template": 3,
+      "question": 208,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 93,
+    "fields": {
+      "template": 3,
+      "question": 192,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 94,
+    "fields": {
+      "template": 3,
+      "question": 187,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 95,
+    "fields": {
+      "template": 3,
+      "question": 198,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 96,
+    "fields": {
+      "template": 3,
+      "question": 246,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 97,
+    "fields": {
+      "template": 3,
+      "question": 173,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 98,
+    "fields": {
+      "template": 3,
+      "question": 209,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 99,
+    "fields": {
+      "template": 3,
+      "question": 196,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 100,
+    "fields": {
+      "template": 3,
+      "question": 193,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 101,
+    "fields": {
+      "template": 3,
+      "question": 203,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 102,
+    "fields": {
+      "template": 3,
+      "question": 206,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 103,
+    "fields": {
+      "template": 3,
+      "question": 176,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 104,
+    "fields": {
+      "template": 3,
+      "question": 184,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 105,
+    "fields": {
+      "template": 3,
+      "question": 242,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 106,
+    "fields": {
+      "template": 3,
+      "question": 171,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 107,
+    "fields": {
+      "template": 3,
+      "question": 185,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 108,
+    "fields": {
+      "template": 3,
+      "question": 350,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 109,
+    "fields": {
+      "template": 3,
+      "question": 186,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 110,
+    "fields": {
+      "template": 3,
+      "question": 226,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 111,
+    "fields": {
+      "template": 3,
+      "question": 348,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 112,
+    "fields": {
+      "template": 3,
+      "question": 172,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 113,
+    "fields": {
+      "template": 3,
+      "question": 197,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 114,
+    "fields": {
+      "template": 3,
+      "question": 352,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 115,
+    "fields": {
+      "template": 3,
+      "question": 201,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 116,
+    "fields": {
+      "template": 3,
+      "question": 244,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 117,
+    "fields": {
+      "template": 3,
+      "question": 188,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 118,
+    "fields": {
+      "template": 3,
+      "question": 245,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 119,
+    "fields": {
+      "template": 3,
+      "question": 189,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 120,
+    "fields": {
+      "template": 3,
+      "question": 183,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 121,
+    "fields": {
+      "template": 3,
+      "question": 205,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 122,
+    "fields": {
+      "template": 3,
+      "question": 353,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 123,
+    "fields": {
+      "template": 3,
+      "question": 190,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 124,
+    "fields": {
+      "template": 3,
+      "question": 227,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 125,
+    "fields": {
+      "template": 3,
+      "question": 204,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 126,
+    "fields": {
+      "template": 3,
+      "question": 177,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 127,
+    "fields": {
+      "template": 3,
+      "question": 199,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 128,
+    "fields": {
+      "template": 3,
+      "question": 194,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 129,
+    "fields": {
+      "template": 3,
+      "question": 351,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 130,
+    "fields": {
+      "template": 3,
+      "question": 202,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 131,
+    "fields": {
+      "template": 3,
+      "question": 200,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 132,
+    "fields": {
+      "template": 3,
+      "question": 207,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 133,
+    "fields": {
+      "template": 4,
+      "question": 171,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 134,
+    "fields": {
+      "template": 4,
+      "question": 196,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 135,
+    "fields": {
+      "template": 4,
+      "question": 176,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 136,
+    "fields": {
+      "template": 4,
+      "question": 352,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 137,
+    "fields": {
+      "template": 4,
+      "question": 201,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 138,
+    "fields": {
+      "template": 4,
+      "question": 246,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 139,
+    "fields": {
+      "template": 4,
+      "question": 227,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 140,
+    "fields": {
+      "template": 4,
+      "question": 209,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 141,
+    "fields": {
+      "template": 4,
+      "question": 242,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 142,
+    "fields": {
+      "template": 4,
+      "question": 177,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 143,
+    "fields": {
+      "template": 4,
+      "question": 204,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 144,
+    "fields": {
+      "template": 4,
+      "question": 189,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 145,
+    "fields": {
+      "template": 4,
+      "question": 172,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 146,
+    "fields": {
+      "template": 4,
+      "question": 170,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 147,
+    "fields": {
+      "template": 4,
+      "question": 202,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 148,
+    "fields": {
+      "template": 4,
+      "question": 207,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 149,
+    "fields": {
+      "template": 4,
+      "question": 350,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 150,
+    "fields": {
+      "template": 4,
+      "question": 190,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 151,
+    "fields": {
+      "template": 4,
+      "question": 192,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 152,
+    "fields": {
+      "template": 4,
+      "question": 205,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 153,
+    "fields": {
+      "template": 4,
+      "question": 188,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 154,
+    "fields": {
+      "template": 4,
+      "question": 183,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 155,
+    "fields": {
+      "template": 4,
+      "question": 353,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 156,
+    "fields": {
+      "template": 4,
+      "question": 187,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 157,
+    "fields": {
+      "template": 4,
+      "question": 197,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 158,
+    "fields": {
+      "template": 4,
+      "question": 185,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 159,
+    "fields": {
+      "template": 4,
+      "question": 191,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 160,
+    "fields": {
+      "template": 4,
+      "question": 200,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 161,
+    "fields": {
+      "template": 4,
+      "question": 203,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 162,
+    "fields": {
+      "template": 4,
+      "question": 208,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 163,
+    "fields": {
+      "template": 4,
+      "question": 186,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 164,
+    "fields": {
+      "template": 4,
+      "question": 348,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 165,
+    "fields": {
+      "template": 4,
+      "question": 198,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 166,
+    "fields": {
+      "template": 4,
+      "question": 173,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 167,
+    "fields": {
+      "template": 4,
+      "question": 184,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 168,
+    "fields": {
+      "template": 4,
+      "question": 206,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 169,
+    "fields": {
+      "template": 4,
+      "question": 199,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 170,
+    "fields": {
+      "template": 4,
+      "question": 245,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 171,
+    "fields": {
+      "template": 4,
+      "question": 349,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 172,
+    "fields": {
+      "template": 4,
+      "question": 226,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 173,
+    "fields": {
+      "template": 4,
+      "question": 194,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 174,
+    "fields": {
+      "template": 4,
+      "question": 244,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 175,
+    "fields": {
+      "template": 4,
+      "question": 193,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 176,
+    "fields": {
+      "template": 4,
+      "question": 351,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 177,
+    "fields": {
+      "template": 5,
+      "question": 330,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 178,
+    "fields": {
+      "template": 5,
+      "question": 329,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 179,
+    "fields": {
+      "template": 5,
+      "question": 339,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 180,
+    "fields": {
+      "template": 5,
+      "question": 327,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 181,
+    "fields": {
+      "template": 5,
+      "question": 343,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 182,
+    "fields": {
+      "template": 5,
+      "question": 338,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 183,
+    "fields": {
+      "template": 5,
+      "question": 336,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 184,
+    "fields": {
+      "template": 5,
+      "question": 342,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 185,
+    "fields": {
+      "template": 5,
+      "question": 331,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 186,
+    "fields": {
+      "template": 5,
+      "question": 341,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 187,
+    "fields": {
+      "template": 5,
+      "question": 347,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 188,
+    "fields": {
+      "template": 5,
+      "question": 340,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 189,
+    "fields": {
+      "template": 5,
+      "question": 326,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 190,
+    "fields": {
+      "template": 5,
+      "question": 345,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 191,
+    "fields": {
+      "template": 5,
+      "question": 332,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 192,
+    "fields": {
+      "template": 5,
+      "question": 344,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 193,
+    "fields": {
+      "template": 5,
+      "question": 337,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 194,
+    "fields": {
+      "template": 5,
+      "question": 346,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 195,
+    "fields": {
+      "template": 5,
+      "question": 333,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 196,
+    "fields": {
+      "template": 5,
+      "question": 328,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 197,
+    "fields": {
+      "template": 5,
+      "question": 335,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 198,
+    "fields": {
+      "template": 5,
+      "question": 334,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 199,
+    "fields": {
+      "template": 6,
+      "question": 27,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 200,
+    "fields": {
+      "template": 6,
+      "question": 30,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 201,
+    "fields": {
+      "template": 6,
+      "question": 25,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 202,
+    "fields": {
+      "template": 6,
+      "question": 24,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 203,
+    "fields": {
+      "template": 6,
+      "question": 122,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 204,
+    "fields": {
+      "template": 6,
+      "question": 132,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 205,
+    "fields": {
+      "template": 6,
+      "question": 123,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 206,
+    "fields": {
+      "template": 6,
+      "question": 134,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 207,
+    "fields": {
+      "template": 6,
+      "question": 121,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 208,
+    "fields": {
+      "template": 6,
+      "question": 135,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 209,
+    "fields": {
+      "template": 6,
+      "question": 34,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 210,
+    "fields": {
+      "template": 6,
+      "question": 120,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 211,
+    "fields": {
+      "template": 6,
+      "question": 31,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 212,
+    "fields": {
+      "template": 6,
+      "question": 39,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 213,
+    "fields": {
+      "template": 6,
+      "question": 9,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 214,
+    "fields": {
+      "template": 6,
+      "question": 16,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 215,
+    "fields": {
+      "template": 6,
+      "question": 297,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 216,
+    "fields": {
+      "template": 6,
+      "question": 300,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 217,
+    "fields": {
+      "template": 6,
+      "question": 308,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 218,
+    "fields": {
+      "template": 6,
+      "question": 298,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 219,
+    "fields": {
+      "template": 6,
+      "question": 325,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 220,
+    "fields": {
+      "template": 6,
+      "question": 304,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 221,
+    "fields": {
+      "template": 6,
+      "question": 313,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 222,
+    "fields": {
+      "template": 6,
+      "question": 316,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 223,
+    "fields": {
+      "template": 6,
+      "question": 126,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 224,
+    "fields": {
+      "template": 6,
+      "question": 53,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 225,
+    "fields": {
+      "template": 6,
+      "question": 32,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 226,
+    "fields": {
+      "template": 6,
+      "question": 55,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 227,
+    "fields": {
+      "template": 6,
+      "question": 44,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 228,
+    "fields": {
+      "template": 6,
+      "question": 17,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 229,
+    "fields": {
+      "template": 6,
+      "question": 64,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 230,
+    "fields": {
+      "template": 6,
+      "question": 67,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 231,
+    "fields": {
+      "template": 6,
+      "question": 79,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 232,
+    "fields": {
+      "template": 6,
+      "question": 59,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 233,
+    "fields": {
+      "template": 6,
+      "question": 65,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 234,
+    "fields": {
+      "template": 6,
+      "question": 20,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 235,
+    "fields": {
+      "template": 6,
+      "question": 51,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 236,
+    "fields": {
+      "template": 6,
+      "question": 61,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 237,
+    "fields": {
+      "template": 6,
+      "question": 22,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 238,
+    "fields": {
+      "template": 6,
+      "question": 78,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 239,
+    "fields": {
+      "template": 6,
+      "question": 46,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 240,
+    "fields": {
+      "template": 6,
+      "question": 48,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 241,
+    "fields": {
+      "template": 6,
+      "question": 42,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 242,
+    "fields": {
+      "template": 6,
+      "question": 77,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 243,
+    "fields": {
+      "template": 6,
+      "question": 21,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 244,
+    "fields": {
+      "template": 6,
+      "question": 40,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 245,
+    "fields": {
+      "template": 6,
+      "question": 15,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 246,
+    "fields": {
+      "template": 6,
+      "question": 1,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 247,
+    "fields": {
+      "template": 6,
+      "question": 6,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 248,
+    "fields": {
+      "template": 6,
+      "question": 156,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 249,
+    "fields": {
+      "template": 7,
+      "question": 330,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 250,
+    "fields": {
+      "template": 7,
+      "question": 335,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 251,
+    "fields": {
+      "template": 7,
+      "question": 341,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 252,
+    "fields": {
+      "template": 7,
+      "question": 334,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 253,
+    "fields": {
+      "template": 7,
+      "question": 346,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 254,
+    "fields": {
+      "template": 7,
+      "question": 328,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 255,
+    "fields": {
+      "template": 7,
+      "question": 347,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 256,
+    "fields": {
+      "template": 7,
+      "question": 327,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 257,
+    "fields": {
+      "template": 7,
+      "question": 344,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 258,
+    "fields": {
+      "template": 7,
+      "question": 329,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 259,
+    "fields": {
+      "template": 7,
+      "question": 345,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 260,
+    "fields": {
+      "template": 7,
+      "question": 337,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 261,
+    "fields": {
+      "template": 7,
+      "question": 340,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 262,
+    "fields": {
+      "template": 7,
+      "question": 338,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 263,
+    "fields": {
+      "template": 7,
+      "question": 342,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 264,
+    "fields": {
+      "template": 7,
+      "question": 331,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 265,
+    "fields": {
+      "template": 7,
+      "question": 333,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 266,
+    "fields": {
+      "template": 7,
+      "question": 332,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 267,
+    "fields": {
+      "template": 7,
+      "question": 339,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 268,
+    "fields": {
+      "template": 7,
+      "question": 326,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 269,
+    "fields": {
+      "template": 7,
+      "question": 336,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 270,
+    "fields": {
+      "template": 7,
+      "question": 343,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 271,
+    "fields": {
+      "template": 8,
+      "question": 74,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 272,
+    "fields": {
+      "template": 8,
+      "question": 159,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 273,
+    "fields": {
+      "template": 8,
+      "question": 63,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 274,
+    "fields": {
+      "template": 8,
+      "question": 120,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 275,
+    "fields": {
+      "template": 8,
+      "question": 39,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 276,
+    "fields": {
+      "template": 8,
+      "question": 88,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 277,
+    "fields": {
+      "template": 8,
+      "question": 136,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 278,
+    "fields": {
+      "template": 8,
+      "question": 235,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 279,
+    "fields": {
+      "template": 8,
+      "question": 92,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 280,
+    "fields": {
+      "template": 8,
+      "question": 236,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 281,
+    "fields": {
+      "template": 8,
+      "question": 239,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 282,
+    "fields": {
+      "template": 8,
+      "question": 229,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 283,
+    "fields": {
+      "template": 8,
+      "question": 157,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 284,
+    "fields": {
+      "template": 8,
+      "question": 237,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 285,
+    "fields": {
+      "template": 8,
+      "question": 158,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 286,
+    "fields": {
+      "template": 8,
+      "question": 3,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 287,
+    "fields": {
+      "template": 8,
+      "question": 234,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 288,
+    "fields": {
+      "template": 8,
+      "question": 91,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 289,
+    "fields": {
+      "template": 8,
+      "question": 20,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 290,
+    "fields": {
+      "template": 8,
+      "question": 80,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 291,
+    "fields": {
+      "template": 8,
+      "question": 41,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 292,
+    "fields": {
+      "template": 8,
+      "question": 51,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 293,
+    "fields": {
+      "template": 8,
+      "question": 22,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 294,
+    "fields": {
+      "template": 8,
+      "question": 18,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 295,
+    "fields": {
+      "template": 8,
+      "question": 64,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 296,
+    "fields": {
+      "template": 8,
+      "question": 44,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 297,
+    "fields": {
+      "template": 8,
+      "question": 84,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 298,
+    "fields": {
+      "template": 8,
+      "question": 68,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 299,
+    "fields": {
+      "template": 8,
+      "question": 73,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 300,
+    "fields": {
+      "template": 8,
+      "question": 71,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 301,
+    "fields": {
+      "template": 8,
+      "question": 42,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 302,
+    "fields": {
+      "template": 8,
+      "question": 121,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 303,
+    "fields": {
+      "template": 8,
+      "question": 133,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 304,
+    "fields": {
+      "template": 8,
+      "question": 124,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 305,
+    "fields": {
+      "template": 8,
+      "question": 127,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 306,
+    "fields": {
+      "template": 8,
+      "question": 125,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 307,
+    "fields": {
+      "template": 8,
+      "question": 132,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 308,
+    "fields": {
+      "template": 8,
+      "question": 83,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 309,
+    "fields": {
+      "template": 8,
+      "question": 69,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 310,
+    "fields": {
+      "template": 8,
+      "question": 15,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 311,
+    "fields": {
+      "template": 8,
+      "question": 52,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 312,
+    "fields": {
+      "template": 8,
+      "question": 47,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 313,
+    "fields": {
+      "template": 8,
+      "question": 25,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 314,
+    "fields": {
+      "template": 8,
+      "question": 29,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 315,
+    "fields": {
+      "template": 8,
+      "question": 28,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 316,
+    "fields": {
+      "template": 8,
+      "question": 57,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 317,
+    "fields": {
+      "template": 8,
+      "question": 26,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 318,
+    "fields": {
+      "template": 8,
+      "question": 30,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 319,
+    "fields": {
+      "template": 8,
+      "question": 62,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 320,
+    "fields": {
+      "template": 8,
+      "question": 90,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 321,
+    "fields": {
+      "template": 9,
+      "question": 315,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 322,
+    "fields": {
+      "template": 9,
+      "question": 361,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 323,
+    "fields": {
+      "template": 9,
+      "question": 317,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 324,
+    "fields": {
+      "template": 9,
+      "question": 324,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 325,
+    "fields": {
+      "template": 9,
+      "question": 301,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 326,
+    "fields": {
+      "template": 9,
+      "question": 305,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 327,
+    "fields": {
+      "template": 9,
+      "question": 308,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 328,
+    "fields": {
+      "template": 9,
+      "question": 365,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 329,
+    "fields": {
+      "template": 9,
+      "question": 358,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 330,
+    "fields": {
+      "template": 9,
+      "question": 304,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 331,
+    "fields": {
+      "template": 9,
+      "question": 363,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 332,
+    "fields": {
+      "template": 9,
+      "question": 366,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 333,
+    "fields": {
+      "template": 9,
+      "question": 310,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 334,
+    "fields": {
+      "template": 9,
+      "question": 303,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 335,
+    "fields": {
+      "template": 9,
+      "question": 309,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 336,
+    "fields": {
+      "template": 9,
+      "question": 325,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 337,
+    "fields": {
+      "template": 9,
+      "question": 297,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 338,
+    "fields": {
+      "template": 9,
+      "question": 313,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 339,
+    "fields": {
+      "template": 9,
+      "question": 300,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 340,
+    "fields": {
+      "template": 9,
+      "question": 316,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 341,
+    "fields": {
+      "template": 9,
+      "question": 362,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 342,
+    "fields": {
+      "template": 9,
+      "question": 356,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 343,
+    "fields": {
+      "template": 9,
+      "question": 314,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 344,
+    "fields": {
+      "template": 9,
+      "question": 306,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 345,
+    "fields": {
+      "template": 10,
+      "question": 341,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 346,
+    "fields": {
+      "template": 10,
+      "question": 338,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 347,
+    "fields": {
+      "template": 10,
+      "question": 339,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 348,
+    "fields": {
+      "template": 10,
+      "question": 337,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 349,
+    "fields": {
+      "template": 10,
+      "question": 331,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 350,
+    "fields": {
+      "template": 10,
+      "question": 345,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 351,
+    "fields": {
+      "template": 10,
+      "question": 336,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 352,
+    "fields": {
+      "template": 10,
+      "question": 347,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 353,
+    "fields": {
+      "template": 10,
+      "question": 333,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 354,
+    "fields": {
+      "template": 10,
+      "question": 344,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 355,
+    "fields": {
+      "template": 10,
+      "question": 334,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 356,
+    "fields": {
+      "template": 10,
+      "question": 340,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 357,
+    "fields": {
+      "template": 10,
+      "question": 335,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 358,
+    "fields": {
+      "template": 10,
+      "question": 346,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 359,
+    "fields": {
+      "template": 10,
+      "question": 329,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 360,
+    "fields": {
+      "template": 10,
+      "question": 328,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 361,
+    "fields": {
+      "template": 10,
+      "question": 326,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 362,
+    "fields": {
+      "template": 10,
+      "question": 342,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 363,
+    "fields": {
+      "template": 10,
+      "question": 327,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 364,
+    "fields": {
+      "template": 10,
+      "question": 343,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 365,
+    "fields": {
+      "template": 10,
+      "question": 332,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 366,
+    "fields": {
+      "template": 10,
+      "question": 330,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 367,
+    "fields": {
+      "template": 11,
+      "question": 42,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 368,
+    "fields": {
+      "template": 11,
+      "question": 64,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 369,
+    "fields": {
+      "template": 11,
+      "question": 76,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 370,
+    "fields": {
+      "template": 11,
+      "question": 2,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 371,
+    "fields": {
+      "template": 11,
+      "question": 84,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 372,
+    "fields": {
+      "template": 11,
+      "question": 78,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 373,
+    "fields": {
+      "template": 11,
+      "question": 59,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 374,
+    "fields": {
+      "template": 11,
+      "question": 19,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 375,
+    "fields": {
+      "template": 11,
+      "question": 21,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 376,
+    "fields": {
+      "template": 11,
+      "question": 71,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 377,
+    "fields": {
+      "template": 11,
+      "question": 23,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 378,
+    "fields": {
+      "template": 11,
+      "question": 87,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 379,
+    "fields": {
+      "template": 11,
+      "question": 27,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 380,
+    "fields": {
+      "template": 11,
+      "question": 25,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 381,
+    "fields": {
+      "template": 11,
+      "question": 28,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 382,
+    "fields": {
+      "template": 11,
+      "question": 5,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 383,
+    "fields": {
+      "template": 11,
+      "question": 4,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 384,
+    "fields": {
+      "template": 11,
+      "question": 89,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 385,
+    "fields": {
+      "template": 11,
+      "question": 39,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 386,
+    "fields": {
+      "template": 11,
+      "question": 31,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 387,
+    "fields": {
+      "template": 11,
+      "question": 56,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 388,
+    "fields": {
+      "template": 11,
+      "question": 315,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 389,
+    "fields": {
+      "template": 11,
+      "question": 298,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 390,
+    "fields": {
+      "template": 11,
+      "question": 358,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 391,
+    "fields": {
+      "template": 11,
+      "question": 296,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 392,
+    "fields": {
+      "template": 11,
+      "question": 308,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 393,
+    "fields": {
+      "template": 11,
+      "question": 307,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 394,
+    "fields": {
+      "template": 11,
+      "question": 359,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 395,
+    "fields": {
+      "template": 11,
+      "question": 297,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 396,
+    "fields": {
+      "template": 11,
+      "question": 360,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 397,
+    "fields": {
+      "template": 11,
+      "question": 305,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 398,
+    "fields": {
+      "template": 11,
+      "question": 303,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 399,
+    "fields": {
+      "template": 11,
+      "question": 354,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 400,
+    "fields": {
+      "template": 11,
+      "question": 62,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 401,
+    "fields": {
+      "template": 11,
+      "question": 13,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 402,
+    "fields": {
+      "template": 11,
+      "question": 12,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 403,
+    "fields": {
+      "template": 11,
+      "question": 122,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 404,
+    "fields": {
+      "template": 11,
+      "question": 124,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 405,
+    "fields": {
+      "template": 11,
+      "question": 132,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 406,
+    "fields": {
+      "template": 11,
+      "question": 127,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 407,
+    "fields": {
+      "template": 11,
+      "question": 123,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 408,
+    "fields": {
+      "template": 11,
+      "question": 134,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 409,
+    "fields": {
+      "template": 11,
+      "question": 128,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 410,
+    "fields": {
+      "template": 11,
+      "question": 75,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 411,
+    "fields": {
+      "template": 11,
+      "question": 60,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 412,
+    "fields": {
+      "template": 11,
+      "question": 47,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 413,
+    "fields": {
+      "template": 11,
+      "question": 52,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 414,
+    "fields": {
+      "template": 11,
+      "question": 55,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 415,
+    "fields": {
+      "template": 11,
+      "question": 126,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 416,
+    "fields": {
+      "template": 11,
+      "question": 159,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 417,
+    "fields": {
+      "template": 12,
+      "question": 331,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 418,
+    "fields": {
+      "template": 12,
+      "question": 337,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 419,
+    "fields": {
+      "template": 12,
+      "question": 338,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 420,
+    "fields": {
+      "template": 12,
+      "question": 339,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 421,
+    "fields": {
+      "template": 12,
+      "question": 335,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 422,
+    "fields": {
+      "template": 12,
+      "question": 326,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 423,
+    "fields": {
+      "template": 12,
+      "question": 340,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 424,
+    "fields": {
+      "template": 12,
+      "question": 341,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 425,
+    "fields": {
+      "template": 12,
+      "question": 342,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 426,
+    "fields": {
+      "template": 12,
+      "question": 346,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 427,
+    "fields": {
+      "template": 12,
+      "question": 333,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 428,
+    "fields": {
+      "template": 12,
+      "question": 330,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 429,
+    "fields": {
+      "template": 12,
+      "question": 327,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 430,
+    "fields": {
+      "template": 12,
+      "question": 329,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 431,
+    "fields": {
+      "template": 12,
+      "question": 332,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 432,
+    "fields": {
+      "template": 12,
+      "question": 336,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 433,
+    "fields": {
+      "template": 12,
+      "question": 345,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 434,
+    "fields": {
+      "template": 12,
+      "question": 334,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 435,
+    "fields": {
+      "template": 12,
+      "question": 347,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 436,
+    "fields": {
+      "template": 12,
+      "question": 328,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 437,
+    "fields": {
+      "template": 12,
+      "question": 344,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 438,
+    "fields": {
+      "template": 12,
+      "question": 343,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 439,
+    "fields": {
+      "template": 13,
+      "question": 331,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 440,
+    "fields": {
+      "template": 13,
+      "question": 347,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 441,
+    "fields": {
+      "template": 13,
+      "question": 328,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 442,
+    "fields": {
+      "template": 13,
+      "question": 336,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 443,
+    "fields": {
+      "template": 13,
+      "question": 329,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 444,
+    "fields": {
+      "template": 13,
+      "question": 340,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 445,
+    "fields": {
+      "template": 13,
+      "question": 338,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 446,
+    "fields": {
+      "template": 13,
+      "question": 339,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 447,
+    "fields": {
+      "template": 13,
+      "question": 335,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 448,
+    "fields": {
+      "template": 13,
+      "question": 333,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 449,
+    "fields": {
+      "template": 13,
+      "question": 334,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 450,
+    "fields": {
+      "template": 13,
+      "question": 337,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 451,
+    "fields": {
+      "template": 13,
+      "question": 342,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 452,
+    "fields": {
+      "template": 13,
+      "question": 326,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 453,
+    "fields": {
+      "template": 13,
+      "question": 327,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 454,
+    "fields": {
+      "template": 13,
+      "question": 341,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 455,
+    "fields": {
+      "template": 13,
+      "question": 332,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 456,
+    "fields": {
+      "template": 13,
+      "question": 343,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 457,
+    "fields": {
+      "template": 13,
+      "question": 346,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 458,
+    "fields": {
+      "template": 13,
+      "question": 330,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 459,
+    "fields": {
+      "template": 13,
+      "question": 345,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 460,
+    "fields": {
+      "template": 13,
+      "question": 344,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 461,
+    "fields": {
+      "template": 14,
+      "question": 333,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 462,
+    "fields": {
+      "template": 14,
+      "question": 335,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 463,
+    "fields": {
+      "template": 14,
+      "question": 331,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 464,
+    "fields": {
+      "template": 14,
+      "question": 346,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 465,
+    "fields": {
+      "template": 14,
+      "question": 332,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 466,
+    "fields": {
+      "template": 14,
+      "question": 334,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 467,
+    "fields": {
+      "template": 14,
+      "question": 330,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 468,
+    "fields": {
+      "template": 14,
+      "question": 347,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 469,
+    "fields": {
+      "template": 14,
+      "question": 342,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 470,
+    "fields": {
+      "template": 14,
+      "question": 340,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 471,
+    "fields": {
+      "template": 14,
+      "question": 343,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 472,
+    "fields": {
+      "template": 14,
+      "question": 327,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 473,
+    "fields": {
+      "template": 14,
+      "question": 337,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 474,
+    "fields": {
+      "template": 14,
+      "question": 341,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 475,
+    "fields": {
+      "template": 14,
+      "question": 344,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 476,
+    "fields": {
+      "template": 14,
+      "question": 339,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 477,
+    "fields": {
+      "template": 14,
+      "question": 345,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 478,
+    "fields": {
+      "template": 14,
+      "question": 338,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 479,
+    "fields": {
+      "template": 14,
+      "question": 328,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 480,
+    "fields": {
+      "template": 14,
+      "question": 329,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 481,
+    "fields": {
+      "template": 14,
+      "question": 336,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 482,
+    "fields": {
+      "template": 14,
+      "question": 326,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 483,
+    "fields": {
+      "template": 15,
+      "question": 45,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 484,
+    "fields": {
+      "template": 15,
+      "question": 42,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 485,
+    "fields": {
+      "template": 15,
+      "question": 20,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 486,
+    "fields": {
+      "template": 15,
+      "question": 18,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 487,
+    "fields": {
+      "template": 15,
+      "question": 84,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 488,
+    "fields": {
+      "template": 15,
+      "question": 68,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 489,
+    "fields": {
+      "template": 15,
+      "question": 22,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 490,
+    "fields": {
+      "template": 15,
+      "question": 65,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 491,
+    "fields": {
+      "template": 15,
+      "question": 79,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 492,
+    "fields": {
+      "template": 15,
+      "question": 87,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 493,
+    "fields": {
+      "template": 15,
+      "question": 46,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 494,
+    "fields": {
+      "template": 15,
+      "question": 2,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 495,
+    "fields": {
+      "template": 15,
+      "question": 21,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 496,
+    "fields": {
+      "template": 15,
+      "question": 80,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 497,
+    "fields": {
+      "template": 15,
+      "question": 43,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 498,
+    "fields": {
+      "template": 15,
+      "question": 59,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 499,
+    "fields": {
+      "template": 15,
+      "question": 17,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 500,
+    "fields": {
+      "template": 15,
+      "question": 86,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 501,
+    "fields": {
+      "template": 15,
+      "question": 66,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 502,
+    "fields": {
+      "template": 15,
+      "question": 90,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 503,
+    "fields": {
+      "template": 15,
+      "question": 133,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 504,
+    "fields": {
+      "template": 15,
+      "question": 123,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 505,
+    "fields": {
+      "template": 15,
+      "question": 128,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 506,
+    "fields": {
+      "template": 15,
+      "question": 122,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 507,
+    "fields": {
+      "template": 15,
+      "question": 125,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 508,
+    "fields": {
+      "template": 15,
+      "question": 124,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 509,
+    "fields": {
+      "template": 15,
+      "question": 127,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 510,
+    "fields": {
+      "template": 15,
+      "question": 4,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 511,
+    "fields": {
+      "template": 15,
+      "question": 28,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 512,
+    "fields": {
+      "template": 15,
+      "question": 29,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 513,
+    "fields": {
+      "template": 15,
+      "question": 85,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 514,
+    "fields": {
+      "template": 15,
+      "question": 89,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 515,
+    "fields": {
+      "template": 15,
+      "question": 34,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 516,
+    "fields": {
+      "template": 15,
+      "question": 120,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 517,
+    "fields": {
+      "template": 15,
+      "question": 31,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 518,
+    "fields": {
+      "template": 15,
+      "question": 38,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 519,
+    "fields": {
+      "template": 15,
+      "question": 39,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 520,
+    "fields": {
+      "template": 15,
+      "question": 63,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 521,
+    "fields": {
+      "template": 15,
+      "question": 159,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 522,
+    "fields": {
+      "template": 15,
+      "question": 55,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 523,
+    "fields": {
+      "template": 15,
+      "question": 32,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 524,
+    "fields": {
+      "template": 15,
+      "question": 74,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 525,
+    "fields": {
+      "template": 15,
+      "question": 75,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 526,
+    "fields": {
+      "template": 15,
+      "question": 1,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 527,
+    "fields": {
+      "template": 15,
+      "question": 83,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 528,
+    "fields": {
+      "template": 15,
+      "question": 52,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 529,
+    "fields": {
+      "template": 15,
+      "question": 157,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 530,
+    "fields": {
+      "template": 15,
+      "question": 241,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 531,
+    "fields": {
+      "template": 15,
+      "question": 235,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 532,
+    "fields": {
+      "template": 15,
+      "question": 234,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 533,
+    "fields": {
+      "template": 16,
+      "question": 302,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 534,
+    "fields": {
+      "template": 16,
+      "question": 357,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 535,
+    "fields": {
+      "template": 16,
+      "question": 311,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 536,
+    "fields": {
+      "template": 16,
+      "question": 366,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 537,
+    "fields": {
+      "template": 16,
+      "question": 301,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 538,
+    "fields": {
+      "template": 16,
+      "question": 365,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 539,
+    "fields": {
+      "template": 16,
+      "question": 355,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 540,
+    "fields": {
+      "template": 16,
+      "question": 309,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 541,
+    "fields": {
+      "template": 16,
+      "question": 299,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 542,
+    "fields": {
+      "template": 16,
+      "question": 300,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 543,
+    "fields": {
+      "template": 16,
+      "question": 361,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 544,
+    "fields": {
+      "template": 16,
+      "question": 310,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 545,
+    "fields": {
+      "template": 16,
+      "question": 317,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 546,
+    "fields": {
+      "template": 16,
+      "question": 315,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 547,
+    "fields": {
+      "template": 16,
+      "question": 307,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 548,
+    "fields": {
+      "template": 16,
+      "question": 296,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 549,
+    "fields": {
+      "template": 16,
+      "question": 325,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 550,
+    "fields": {
+      "template": 16,
+      "question": 303,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 551,
+    "fields": {
+      "template": 16,
+      "question": 354,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 552,
+    "fields": {
+      "template": 16,
+      "question": 358,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 553,
+    "fields": {
+      "template": 16,
+      "question": 305,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 554,
+    "fields": {
+      "template": 16,
+      "question": 316,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 555,
+    "fields": {
+      "template": 16,
+      "question": 304,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 556,
+    "fields": {
+      "template": 16,
+      "question": 308,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 557,
+    "fields": {
+      "template": 16,
+      "question": 364,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 558,
+    "fields": {
+      "template": 16,
+      "question": 356,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 559,
+    "fields": {
+      "template": 16,
+      "question": 313,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 560,
+    "fields": {
+      "template": 16,
+      "question": 363,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 561,
+    "fields": {
+      "template": 16,
+      "question": 306,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 562,
+    "fields": {
+      "template": 16,
+      "question": 324,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 563,
+    "fields": {
+      "template": 16,
+      "question": 360,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 564,
+    "fields": {
+      "template": 16,
+      "question": 297,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 565,
+    "fields": {
+      "template": 16,
+      "question": 298,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 566,
+    "fields": {
+      "template": 16,
+      "question": 312,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 567,
+    "fields": {
+      "template": 16,
+      "question": 362,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 568,
+    "fields": {
+      "template": 16,
+      "question": 359,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 569,
+    "fields": {
+      "template": 16,
+      "question": 314,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 570,
+    "fields": {
+      "template": 17,
+      "question": 41,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 571,
+    "fields": {
+      "template": 17,
+      "question": 18,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 572,
+    "fields": {
+      "template": 17,
+      "question": 61,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 573,
+    "fields": {
+      "template": 17,
+      "question": 79,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 574,
+    "fields": {
+      "template": 17,
+      "question": 21,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 575,
+    "fields": {
+      "template": 17,
+      "question": 22,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 576,
+    "fields": {
+      "template": 17,
+      "question": 84,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 577,
+    "fields": {
+      "template": 17,
+      "question": 2,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 578,
+    "fields": {
+      "template": 17,
+      "question": 76,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 579,
+    "fields": {
+      "template": 17,
+      "question": 46,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 580,
+    "fields": {
+      "template": 17,
+      "question": 5,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 581,
+    "fields": {
+      "template": 17,
+      "question": 58,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 582,
+    "fields": {
+      "template": 17,
+      "question": 6,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 583,
+    "fields": {
+      "template": 17,
+      "question": 160,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 584,
+    "fields": {
+      "template": 17,
+      "question": 12,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 585,
+    "fields": {
+      "template": 17,
+      "question": 8,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 586,
+    "fields": {
+      "template": 17,
+      "question": 9,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 587,
+    "fields": {
+      "template": 17,
+      "question": 297,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 588,
+    "fields": {
+      "template": 17,
+      "question": 314,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 589,
+    "fields": {
+      "template": 17,
+      "question": 315,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 590,
+    "fields": {
+      "template": 17,
+      "question": 304,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 591,
+    "fields": {
+      "template": 17,
+      "question": 317,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 592,
+    "fields": {
+      "template": 17,
+      "question": 356,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 593,
+    "fields": {
+      "template": 17,
+      "question": 301,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 594,
+    "fields": {
+      "template": 17,
+      "question": 361,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 595,
+    "fields": {
+      "template": 17,
+      "question": 308,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 596,
+    "fields": {
+      "template": 17,
+      "question": 357,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 597,
+    "fields": {
+      "template": 17,
+      "question": 313,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 598,
+    "fields": {
+      "template": 17,
+      "question": 300,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 599,
+    "fields": {
+      "template": 17,
+      "question": 363,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 600,
+    "fields": {
+      "template": 17,
+      "question": 325,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 601,
+    "fields": {
+      "template": 17,
+      "question": 362,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 602,
+    "fields": {
+      "template": 17,
+      "question": 312,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 603,
+    "fields": {
+      "template": 17,
+      "question": 124,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 604,
+    "fields": {
+      "template": 17,
+      "question": 134,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 605,
+    "fields": {
+      "template": 17,
+      "question": 128,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 606,
+    "fields": {
+      "template": 17,
+      "question": 123,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 607,
+    "fields": {
+      "template": 17,
+      "question": 133,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 608,
+    "fields": {
+      "template": 17,
+      "question": 135,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 609,
+    "fields": {
+      "template": 17,
+      "question": 88,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 610,
+    "fields": {
+      "template": 17,
+      "question": 49,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 611,
+    "fields": {
+      "template": 17,
+      "question": 89,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 612,
+    "fields": {
+      "template": 17,
+      "question": 14,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 613,
+    "fields": {
+      "template": 17,
+      "question": 57,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 614,
+    "fields": {
+      "template": 17,
+      "question": 29,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 615,
+    "fields": {
+      "template": 17,
+      "question": 26,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 616,
+    "fields": {
+      "template": 17,
+      "question": 30,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 617,
+    "fields": {
+      "template": 17,
+      "question": 60,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 618,
+    "fields": {
+      "template": 17,
+      "question": 47,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 619,
+    "fields": {
+      "template": 17,
+      "question": 1,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 620,
+    "fields": {
+      "template": 18,
+      "question": 128,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 621,
+    "fields": {
+      "template": 18,
+      "question": 121,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 622,
+    "fields": {
+      "template": 18,
+      "question": 127,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 623,
+    "fields": {
+      "template": 18,
+      "question": 134,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 624,
+    "fields": {
+      "template": 18,
+      "question": 129,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 625,
+    "fields": {
+      "template": 18,
+      "question": 122,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 626,
+    "fields": {
+      "template": 18,
+      "question": 133,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 627,
+    "fields": {
+      "template": 18,
+      "question": 132,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 628,
+    "fields": {
+      "template": 18,
+      "question": 123,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 629,
+    "fields": {
+      "template": 18,
+      "question": 16,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 630,
+    "fields": {
+      "template": 18,
+      "question": 168,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 631,
+    "fields": {
+      "template": 18,
+      "question": 9,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 632,
+    "fields": {
+      "template": 18,
+      "question": 42,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 633,
+    "fields": {
+      "template": 18,
+      "question": 68,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 634,
+    "fields": {
+      "template": 18,
+      "question": 71,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 635,
+    "fields": {
+      "template": 18,
+      "question": 64,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 636,
+    "fields": {
+      "template": 18,
+      "question": 78,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 637,
+    "fields": {
+      "template": 18,
+      "question": 51,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 638,
+    "fields": {
+      "template": 18,
+      "question": 46,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 639,
+    "fields": {
+      "template": 18,
+      "question": 77,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 640,
+    "fields": {
+      "template": 18,
+      "question": 21,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 641,
+    "fields": {
+      "template": 18,
+      "question": 41,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 642,
+    "fields": {
+      "template": 18,
+      "question": 19,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 643,
+    "fields": {
+      "template": 18,
+      "question": 76,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 644,
+    "fields": {
+      "template": 18,
+      "question": 65,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 645,
+    "fields": {
+      "template": 18,
+      "question": 135,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 646,
+    "fields": {
+      "template": 18,
+      "question": 88,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 647,
+    "fields": {
+      "template": 18,
+      "question": 14,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 648,
+    "fields": {
+      "template": 18,
+      "question": 63,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 649,
+    "fields": {
+      "template": 18,
+      "question": 89,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 650,
+    "fields": {
+      "template": 18,
+      "question": 355,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 651,
+    "fields": {
+      "template": 18,
+      "question": 309,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 652,
+    "fields": {
+      "template": 18,
+      "question": 358,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 653,
+    "fields": {
+      "template": 18,
+      "question": 302,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 654,
+    "fields": {
+      "template": 18,
+      "question": 304,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 655,
+    "fields": {
+      "template": 18,
+      "question": 324,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 656,
+    "fields": {
+      "template": 18,
+      "question": 298,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 657,
+    "fields": {
+      "template": 18,
+      "question": 314,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 658,
+    "fields": {
+      "template": 18,
+      "question": 362,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 659,
+    "fields": {
+      "template": 18,
+      "question": 359,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 660,
+    "fields": {
+      "template": 18,
+      "question": 315,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 661,
+    "fields": {
+      "template": 18,
+      "question": 47,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 662,
+    "fields": {
+      "template": 18,
+      "question": 15,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 663,
+    "fields": {
+      "template": 18,
+      "question": 24,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 664,
+    "fields": {
+      "template": 18,
+      "question": 26,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 665,
+    "fields": {
+      "template": 18,
+      "question": 27,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 666,
+    "fields": {
+      "template": 18,
+      "question": 28,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 667,
+    "fields": {
+      "template": 18,
+      "question": 29,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 668,
+    "fields": {
+      "template": 18,
+      "question": 58,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 669,
+    "fields": {
+      "template": 18,
+      "question": 74,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 670,
+    "fields": {
+      "template": 19,
+      "question": 229,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 671,
+    "fields": {
+      "template": 19,
+      "question": 158,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 672,
+    "fields": {
+      "template": 19,
+      "question": 238,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 673,
+    "fields": {
+      "template": 19,
+      "question": 236,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 674,
+    "fields": {
+      "template": 19,
+      "question": 231,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 675,
+    "fields": {
+      "template": 19,
+      "question": 228,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 676,
+    "fields": {
+      "template": 19,
+      "question": 235,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 677,
+    "fields": {
+      "template": 19,
+      "question": 239,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 678,
+    "fields": {
+      "template": 19,
+      "question": 157,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 679,
+    "fields": {
+      "template": 19,
+      "question": 29,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 680,
+    "fields": {
+      "template": 19,
+      "question": 28,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 681,
+    "fields": {
+      "template": 19,
+      "question": 30,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 682,
+    "fields": {
+      "template": 19,
+      "question": 24,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 683,
+    "fields": {
+      "template": 19,
+      "question": 25,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 684,
+    "fields": {
+      "template": 19,
+      "question": 39,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 685,
+    "fields": {
+      "template": 19,
+      "question": 135,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 686,
+    "fields": {
+      "template": 19,
+      "question": 35,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 687,
+    "fields": {
+      "template": 19,
+      "question": 34,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 688,
+    "fields": {
+      "template": 19,
+      "question": 38,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 689,
+    "fields": {
+      "template": 19,
+      "question": 49,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 690,
+    "fields": {
+      "template": 19,
+      "question": 89,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 691,
+    "fields": {
+      "template": 19,
+      "question": 90,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 692,
+    "fields": {
+      "template": 19,
+      "question": 62,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 693,
+    "fields": {
+      "template": 19,
+      "question": 53,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 694,
+    "fields": {
+      "template": 19,
+      "question": 126,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 695,
+    "fields": {
+      "template": 19,
+      "question": 55,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 696,
+    "fields": {
+      "template": 19,
+      "question": 32,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 697,
+    "fields": {
+      "template": 19,
+      "question": 6,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 698,
+    "fields": {
+      "template": 19,
+      "question": 5,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 699,
+    "fields": {
+      "template": 19,
+      "question": 75,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 700,
+    "fields": {
+      "template": 19,
+      "question": 15,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 701,
+    "fields": {
+      "template": 19,
+      "question": 69,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 702,
+    "fields": {
+      "template": 19,
+      "question": 1,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 703,
+    "fields": {
+      "template": 19,
+      "question": 82,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 704,
+    "fields": {
+      "template": 19,
+      "question": 125,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 705,
+    "fields": {
+      "template": 19,
+      "question": 127,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 706,
+    "fields": {
+      "template": 19,
+      "question": 123,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 707,
+    "fields": {
+      "template": 19,
+      "question": 121,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 708,
+    "fields": {
+      "template": 19,
+      "question": 132,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 709,
+    "fields": {
+      "template": 19,
+      "question": 133,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 710,
+    "fields": {
+      "template": 19,
+      "question": 22,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 711,
+    "fields": {
+      "template": 19,
+      "question": 40,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 712,
+    "fields": {
+      "template": 19,
+      "question": 44,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 713,
+    "fields": {
+      "template": 19,
+      "question": 71,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 714,
+    "fields": {
+      "template": 19,
+      "question": 61,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 715,
+    "fields": {
+      "template": 19,
+      "question": 77,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 716,
+    "fields": {
+      "template": 19,
+      "question": 73,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 717,
+    "fields": {
+      "template": 19,
+      "question": 68,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 718,
+    "fields": {
+      "template": 19,
+      "question": 43,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 719,
+    "fields": {
+      "template": 19,
+      "question": 45,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 720,
+    "fields": {
+      "template": 20,
+      "question": 31,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 721,
+    "fields": {
+      "template": 20,
+      "question": 120,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 722,
+    "fields": {
+      "template": 20,
+      "question": 88,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 723,
+    "fields": {
+      "template": 20,
+      "question": 56,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 724,
+    "fields": {
+      "template": 20,
+      "question": 35,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 725,
+    "fields": {
+      "template": 20,
+      "question": 70,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 726,
+    "fields": {
+      "template": 20,
+      "question": 38,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 727,
+    "fields": {
+      "template": 20,
+      "question": 47,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 728,
+    "fields": {
+      "template": 20,
+      "question": 82,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 729,
+    "fields": {
+      "template": 20,
+      "question": 60,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 730,
+    "fields": {
+      "template": 20,
+      "question": 75,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 731,
+    "fields": {
+      "template": 20,
+      "question": 52,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 732,
+    "fields": {
+      "template": 20,
+      "question": 157,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 733,
+    "fields": {
+      "template": 20,
+      "question": 234,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 734,
+    "fields": {
+      "template": 20,
+      "question": 235,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 735,
+    "fields": {
+      "template": 20,
+      "question": 228,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 736,
+    "fields": {
+      "template": 20,
+      "question": 91,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 737,
+    "fields": {
+      "template": 20,
+      "question": 236,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 738,
+    "fields": {
+      "template": 20,
+      "question": 241,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 739,
+    "fields": {
+      "template": 20,
+      "question": 158,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 740,
+    "fields": {
+      "template": 20,
+      "question": 229,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 741,
+    "fields": {
+      "template": 20,
+      "question": 237,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 742,
+    "fields": {
+      "template": 20,
+      "question": 230,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 743,
+    "fields": {
+      "template": 20,
+      "question": 90,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 744,
+    "fields": {
+      "template": 20,
+      "question": 62,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 745,
+    "fields": {
+      "template": 20,
+      "question": 156,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 746,
+    "fields": {
+      "template": 20,
+      "question": 20,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 747,
+    "fields": {
+      "template": 20,
+      "question": 2,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 748,
+    "fields": {
+      "template": 20,
+      "question": 22,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 749,
+    "fields": {
+      "template": 20,
+      "question": 44,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 750,
+    "fields": {
+      "template": 20,
+      "question": 65,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 751,
+    "fields": {
+      "template": 20,
+      "question": 46,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 752,
+    "fields": {
+      "template": 20,
+      "question": 77,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 753,
+    "fields": {
+      "template": 20,
+      "question": 80,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 754,
+    "fields": {
+      "template": 20,
+      "question": 18,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 755,
+    "fields": {
+      "template": 20,
+      "question": 45,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 756,
+    "fields": {
+      "template": 20,
+      "question": 51,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 757,
+    "fields": {
+      "template": 20,
+      "question": 85,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 758,
+    "fields": {
+      "template": 20,
+      "question": 57,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 759,
+    "fields": {
+      "template": 20,
+      "question": 26,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 760,
+    "fields": {
+      "template": 20,
+      "question": 30,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 761,
+    "fields": {
+      "template": 20,
+      "question": 4,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 762,
+    "fields": {
+      "template": 20,
+      "question": 37,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 763,
+    "fields": {
+      "template": 20,
+      "question": 58,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 764,
+    "fields": {
+      "template": 20,
+      "question": 5,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 765,
+    "fields": {
+      "template": 20,
+      "question": 6,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 766,
+    "fields": {
+      "template": 20,
+      "question": 32,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 767,
+    "fields": {
+      "template": 20,
+      "question": 55,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 768,
+    "fields": {
+      "template": 20,
+      "question": 122,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 769,
+    "fields": {
+      "template": 20,
+      "question": 128,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 770,
+    "fields": {
+      "template": 21,
+      "question": 60,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 771,
+    "fields": {
+      "template": 21,
+      "question": 47,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 772,
+    "fields": {
+      "template": 21,
+      "question": 15,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 773,
+    "fields": {
+      "template": 21,
+      "question": 69,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 774,
+    "fields": {
+      "template": 21,
+      "question": 82,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 775,
+    "fields": {
+      "template": 21,
+      "question": 83,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 776,
+    "fields": {
+      "template": 21,
+      "question": 84,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 777,
+    "fields": {
+      "template": 21,
+      "question": 67,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 778,
+    "fields": {
+      "template": 21,
+      "question": 87,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 779,
+    "fields": {
+      "template": 21,
+      "question": 46,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 780,
+    "fields": {
+      "template": 21,
+      "question": 19,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 781,
+    "fields": {
+      "template": 21,
+      "question": 17,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 782,
+    "fields": {
+      "template": 21,
+      "question": 64,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 783,
+    "fields": {
+      "template": 21,
+      "question": 77,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 784,
+    "fields": {
+      "template": 21,
+      "question": 61,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 785,
+    "fields": {
+      "template": 21,
+      "question": 73,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 786,
+    "fields": {
+      "template": 21,
+      "question": 76,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 787,
+    "fields": {
+      "template": 21,
+      "question": 20,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 788,
+    "fields": {
+      "template": 21,
+      "question": 22,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 789,
+    "fields": {
+      "template": 21,
+      "question": 55,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 790,
+    "fields": {
+      "template": 21,
+      "question": 53,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 791,
+    "fields": {
+      "template": 21,
+      "question": 74,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 792,
+    "fields": {
+      "template": 21,
+      "question": 38,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 793,
+    "fields": {
+      "template": 21,
+      "question": 88,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 794,
+    "fields": {
+      "template": 21,
+      "question": 63,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 795,
+    "fields": {
+      "template": 21,
+      "question": 31,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 796,
+    "fields": {
+      "template": 21,
+      "question": 135,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 797,
+    "fields": {
+      "template": 21,
+      "question": 125,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 798,
+    "fields": {
+      "template": 21,
+      "question": 132,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 799,
+    "fields": {
+      "template": 21,
+      "question": 123,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 800,
+    "fields": {
+      "template": 21,
+      "question": 127,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 801,
+    "fields": {
+      "template": 21,
+      "question": 124,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 802,
+    "fields": {
+      "template": 21,
+      "question": 129,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 803,
+    "fields": {
+      "template": 21,
+      "question": 85,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 804,
+    "fields": {
+      "template": 21,
+      "question": 29,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 805,
+    "fields": {
+      "template": 21,
+      "question": 25,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 806,
+    "fields": {
+      "template": 21,
+      "question": 57,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 807,
+    "fields": {
+      "template": 21,
+      "question": 30,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 808,
+    "fields": {
+      "template": 21,
+      "question": 26,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 809,
+    "fields": {
+      "template": 21,
+      "question": 91,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 810,
+    "fields": {
+      "template": 21,
+      "question": 236,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 811,
+    "fields": {
+      "template": 21,
+      "question": 241,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 812,
+    "fields": {
+      "template": 21,
+      "question": 136,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 813,
+    "fields": {
+      "template": 21,
+      "question": 234,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 814,
+    "fields": {
+      "template": 21,
+      "question": 3,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 815,
+    "fields": {
+      "template": 21,
+      "question": 233,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 816,
+    "fields": {
+      "template": 21,
+      "question": 62,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 817,
+    "fields": {
+      "template": 21,
+      "question": 90,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 818,
+    "fields": {
+      "template": 21,
+      "question": 156,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 819,
+    "fields": {
+      "template": 21,
+      "question": 4,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 820,
+    "fields": {
+      "template": 22,
+      "question": 37,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 821,
+    "fields": {
+      "template": 22,
+      "question": 5,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 822,
+    "fields": {
+      "template": 22,
+      "question": 20,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 823,
+    "fields": {
+      "template": 22,
+      "question": 2,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 824,
+    "fields": {
+      "template": 22,
+      "question": 67,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 825,
+    "fields": {
+      "template": 22,
+      "question": 59,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 826,
+    "fields": {
+      "template": 22,
+      "question": 71,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 827,
+    "fields": {
+      "template": 22,
+      "question": 79,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 828,
+    "fields": {
+      "template": 22,
+      "question": 51,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 829,
+    "fields": {
+      "template": 22,
+      "question": 78,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 830,
+    "fields": {
+      "template": 22,
+      "question": 61,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 831,
+    "fields": {
+      "template": 22,
+      "question": 65,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 832,
+    "fields": {
+      "template": 22,
+      "question": 68,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 833,
+    "fields": {
+      "template": 22,
+      "question": 42,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 834,
+    "fields": {
+      "template": 22,
+      "question": 76,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 835,
+    "fields": {
+      "template": 22,
+      "question": 48,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 836,
+    "fields": {
+      "template": 22,
+      "question": 73,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 837,
+    "fields": {
+      "template": 22,
+      "question": 41,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 838,
+    "fields": {
+      "template": 22,
+      "question": 77,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 839,
+    "fields": {
+      "template": 22,
+      "question": 232,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 840,
+    "fields": {
+      "template": 22,
+      "question": 92,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 841,
+    "fields": {
+      "template": 22,
+      "question": 231,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 842,
+    "fields": {
+      "template": 22,
+      "question": 136,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 843,
+    "fields": {
+      "template": 22,
+      "question": 229,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 844,
+    "fields": {
+      "template": 22,
+      "question": 238,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 845,
+    "fields": {
+      "template": 22,
+      "question": 228,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 846,
+    "fields": {
+      "template": 22,
+      "question": 236,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 847,
+    "fields": {
+      "template": 22,
+      "question": 91,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 848,
+    "fields": {
+      "template": 22,
+      "question": 241,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 849,
+    "fields": {
+      "template": 22,
+      "question": 233,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 850,
+    "fields": {
+      "template": 22,
+      "question": 75,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 851,
+    "fields": {
+      "template": 22,
+      "question": 47,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 852,
+    "fields": {
+      "template": 22,
+      "question": 81,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 853,
+    "fields": {
+      "template": 22,
+      "question": 15,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 854,
+    "fields": {
+      "template": 22,
+      "question": 52,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 855,
+    "fields": {
+      "template": 22,
+      "question": 134,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 856,
+    "fields": {
+      "template": 22,
+      "question": 133,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 857,
+    "fields": {
+      "template": 22,
+      "question": 128,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 858,
+    "fields": {
+      "template": 22,
+      "question": 29,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 859,
+    "fields": {
+      "template": 22,
+      "question": 30,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 860,
+    "fields": {
+      "template": 22,
+      "question": 85,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 861,
+    "fields": {
+      "template": 22,
+      "question": 90,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 862,
+    "fields": {
+      "template": 22,
+      "question": 66,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 863,
+    "fields": {
+      "template": 22,
+      "question": 86,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 864,
+    "fields": {
+      "template": 22,
+      "question": 156,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 865,
+    "fields": {
+      "template": 22,
+      "question": 63,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 866,
+    "fields": {
+      "template": 22,
+      "question": 120,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 867,
+    "fields": {
+      "template": 22,
+      "question": 34,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 868,
+    "fields": {
+      "template": 22,
+      "question": 88,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 869,
+    "fields": {
+      "template": 22,
+      "question": 126,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 870,
+    "fields": {
+      "template": 23,
+      "question": 41,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 871,
+    "fields": {
+      "template": 23,
+      "question": 71,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 872,
+    "fields": {
+      "template": 23,
+      "question": 48,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 873,
+    "fields": {
+      "template": 23,
+      "question": 22,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 874,
+    "fields": {
+      "template": 23,
+      "question": 21,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 875,
+    "fields": {
+      "template": 23,
+      "question": 17,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 876,
+    "fields": {
+      "template": 23,
+      "question": 44,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 877,
+    "fields": {
+      "template": 23,
+      "question": 79,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 878,
+    "fields": {
+      "template": 23,
+      "question": 2,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 879,
+    "fields": {
+      "template": 23,
+      "question": 42,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 880,
+    "fields": {
+      "template": 23,
+      "question": 78,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 881,
+    "fields": {
+      "template": 23,
+      "question": 159,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 882,
+    "fields": {
+      "template": 23,
+      "question": 53,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 883,
+    "fields": {
+      "template": 23,
+      "question": 32,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 884,
+    "fields": {
+      "template": 23,
+      "question": 49,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 885,
+    "fields": {
+      "template": 23,
+      "question": 89,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 886,
+    "fields": {
+      "template": 23,
+      "question": 88,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 887,
+    "fields": {
+      "template": 23,
+      "question": 135,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 888,
+    "fields": {
+      "template": 23,
+      "question": 31,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 889,
+    "fields": {
+      "template": 23,
+      "question": 14,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 890,
+    "fields": {
+      "template": 23,
+      "question": 38,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 891,
+    "fields": {
+      "template": 23,
+      "question": 63,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 892,
+    "fields": {
+      "template": 23,
+      "question": 35,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 893,
+    "fields": {
+      "template": 23,
+      "question": 57,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 894,
+    "fields": {
+      "template": 23,
+      "question": 85,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 895,
+    "fields": {
+      "template": 23,
+      "question": 29,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 896,
+    "fields": {
+      "template": 23,
+      "question": 28,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 897,
+    "fields": {
+      "template": 23,
+      "question": 25,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 898,
+    "fields": {
+      "template": 23,
+      "question": 24,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 899,
+    "fields": {
+      "template": 23,
+      "question": 82,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 900,
+    "fields": {
+      "template": 23,
+      "question": 60,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 901,
+    "fields": {
+      "template": 23,
+      "question": 47,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 902,
+    "fields": {
+      "template": 23,
+      "question": 235,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 903,
+    "fields": {
+      "template": 23,
+      "question": 231,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 904,
+    "fields": {
+      "template": 23,
+      "question": 228,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 905,
+    "fields": {
+      "template": 23,
+      "question": 237,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 906,
+    "fields": {
+      "template": 23,
+      "question": 241,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 907,
+    "fields": {
+      "template": 23,
+      "question": 157,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 908,
+    "fields": {
+      "template": 23,
+      "question": 91,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 909,
+    "fields": {
+      "template": 23,
+      "question": 127,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 910,
+    "fields": {
+      "template": 23,
+      "question": 121,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 911,
+    "fields": {
+      "template": 23,
+      "question": 132,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 912,
+    "fields": {
+      "template": 23,
+      "question": 134,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 913,
+    "fields": {
+      "template": 23,
+      "question": 128,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 914,
+    "fields": {
+      "template": 23,
+      "question": 122,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 915,
+    "fields": {
+      "template": 23,
+      "question": 62,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 916,
+    "fields": {
+      "template": 23,
+      "question": 66,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 917,
+    "fields": {
+      "template": 23,
+      "question": 86,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 918,
+    "fields": {
+      "template": 23,
+      "question": 58,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 919,
+    "fields": {
+      "template": 23,
+      "question": 37,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 920,
+    "fields": {
+      "template": 24,
+      "question": 92,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 921,
+    "fields": {
+      "template": 24,
+      "question": 236,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 922,
+    "fields": {
+      "template": 24,
+      "question": 235,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 923,
+    "fields": {
+      "template": 24,
+      "question": 237,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 924,
+    "fields": {
+      "template": 24,
+      "question": 230,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 925,
+    "fields": {
+      "template": 24,
+      "question": 233,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 926,
+    "fields": {
+      "template": 24,
+      "question": 3,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 927,
+    "fields": {
+      "template": 24,
+      "question": 232,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 928,
+    "fields": {
+      "template": 24,
+      "question": 91,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 929,
+    "fields": {
+      "template": 24,
+      "question": 234,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 930,
+    "fields": {
+      "template": 24,
+      "question": 37,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 931,
+    "fields": {
+      "template": 24,
+      "question": 4,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 932,
+    "fields": {
+      "template": 24,
+      "question": 6,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 933,
+    "fields": {
+      "template": 24,
+      "question": 18,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 934,
+    "fields": {
+      "template": 24,
+      "question": 65,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 935,
+    "fields": {
+      "template": 24,
+      "question": 48,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 936,
+    "fields": {
+      "template": 24,
+      "question": 68,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 937,
+    "fields": {
+      "template": 24,
+      "question": 87,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 938,
+    "fields": {
+      "template": 24,
+      "question": 42,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 939,
+    "fields": {
+      "template": 24,
+      "question": 22,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 940,
+    "fields": {
+      "template": 24,
+      "question": 73,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 941,
+    "fields": {
+      "template": 24,
+      "question": 80,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 942,
+    "fields": {
+      "template": 24,
+      "question": 19,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 943,
+    "fields": {
+      "template": 24,
+      "question": 84,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 944,
+    "fields": {
+      "template": 24,
+      "question": 76,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 945,
+    "fields": {
+      "template": 24,
+      "question": 71,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 946,
+    "fields": {
+      "template": 24,
+      "question": 45,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 947,
+    "fields": {
+      "template": 24,
+      "question": 17,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 948,
+    "fields": {
+      "template": 24,
+      "question": 124,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 949,
+    "fields": {
+      "template": 24,
+      "question": 125,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 950,
+    "fields": {
+      "template": 24,
+      "question": 127,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 951,
+    "fields": {
+      "template": 24,
+      "question": 128,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 952,
+    "fields": {
+      "template": 24,
+      "question": 121,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 953,
+    "fields": {
+      "template": 24,
+      "question": 133,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 954,
+    "fields": {
+      "template": 24,
+      "question": 83,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 955,
+    "fields": {
+      "template": 24,
+      "question": 47,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 956,
+    "fields": {
+      "template": 24,
+      "question": 81,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 957,
+    "fields": {
+      "template": 24,
+      "question": 52,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 958,
+    "fields": {
+      "template": 24,
+      "question": 69,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 959,
+    "fields": {
+      "template": 24,
+      "question": 60,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 960,
+    "fields": {
+      "template": 24,
+      "question": 24,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 961,
+    "fields": {
+      "template": 24,
+      "question": 85,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 962,
+    "fields": {
+      "template": 24,
+      "question": 27,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 963,
+    "fields": {
+      "template": 24,
+      "question": 49,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 964,
+    "fields": {
+      "template": 24,
+      "question": 38,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 965,
+    "fields": {
+      "template": 24,
+      "question": 120,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 966,
+    "fields": {
+      "template": 24,
+      "question": 88,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 967,
+    "fields": {
+      "template": 24,
+      "question": 34,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 968,
+    "fields": {
+      "template": 24,
+      "question": 156,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 969,
+    "fields": {
+      "template": 24,
+      "question": 126,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 970,
+    "fields": {
+      "template": 25,
+      "question": 73,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 971,
+    "fields": {
+      "template": 25,
+      "question": 41,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 972,
+    "fields": {
+      "template": 25,
+      "question": 20,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 973,
+    "fields": {
+      "template": 25,
+      "question": 43,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 974,
+    "fields": {
+      "template": 25,
+      "question": 45,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 975,
+    "fields": {
+      "template": 25,
+      "question": 48,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 976,
+    "fields": {
+      "template": 25,
+      "question": 84,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 977,
+    "fields": {
+      "template": 25,
+      "question": 22,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 978,
+    "fields": {
+      "template": 25,
+      "question": 78,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 979,
+    "fields": {
+      "template": 25,
+      "question": 77,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 980,
+    "fields": {
+      "template": 25,
+      "question": 68,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 981,
+    "fields": {
+      "template": 25,
+      "question": 23,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 982,
+    "fields": {
+      "template": 25,
+      "question": 51,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 983,
+    "fields": {
+      "template": 25,
+      "question": 52,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 984,
+    "fields": {
+      "template": 25,
+      "question": 15,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 985,
+    "fields": {
+      "template": 25,
+      "question": 81,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 986,
+    "fields": {
+      "template": 25,
+      "question": 75,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 987,
+    "fields": {
+      "template": 25,
+      "question": 126,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 988,
+    "fields": {
+      "template": 25,
+      "question": 53,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 989,
+    "fields": {
+      "template": 25,
+      "question": 159,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 990,
+    "fields": {
+      "template": 25,
+      "question": 133,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 991,
+    "fields": {
+      "template": 25,
+      "question": 125,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 992,
+    "fields": {
+      "template": 25,
+      "question": 127,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 993,
+    "fields": {
+      "template": 25,
+      "question": 134,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 994,
+    "fields": {
+      "template": 25,
+      "question": 129,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 995,
+    "fields": {
+      "template": 25,
+      "question": 25,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 996,
+    "fields": {
+      "template": 25,
+      "question": 57,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 997,
+    "fields": {
+      "template": 25,
+      "question": 28,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 998,
+    "fields": {
+      "template": 25,
+      "question": 30,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 999,
+    "fields": {
+      "template": 25,
+      "question": 27,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1000,
+    "fields": {
+      "template": 25,
+      "question": 85,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1001,
+    "fields": {
+      "template": 25,
+      "question": 38,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1002,
+    "fields": {
+      "template": 25,
+      "question": 88,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1003,
+    "fields": {
+      "template": 25,
+      "question": 56,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1004,
+    "fields": {
+      "template": 25,
+      "question": 14,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1005,
+    "fields": {
+      "template": 25,
+      "question": 34,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1006,
+    "fields": {
+      "template": 25,
+      "question": 49,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1007,
+    "fields": {
+      "template": 25,
+      "question": 92,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1008,
+    "fields": {
+      "template": 25,
+      "question": 237,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1009,
+    "fields": {
+      "template": 25,
+      "question": 239,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1010,
+    "fields": {
+      "template": 25,
+      "question": 157,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1011,
+    "fields": {
+      "template": 25,
+      "question": 233,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1012,
+    "fields": {
+      "template": 25,
+      "question": 232,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1013,
+    "fields": {
+      "template": 25,
+      "question": 229,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1014,
+    "fields": {
+      "template": 25,
+      "question": 91,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1015,
+    "fields": {
+      "template": 25,
+      "question": 3,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1016,
+    "fields": {
+      "template": 25,
+      "question": 90,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1017,
+    "fields": {
+      "template": 25,
+      "question": 86,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1018,
+    "fields": {
+      "template": 25,
+      "question": 4,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1019,
+    "fields": {
+      "template": 25,
+      "question": 37,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1020,
+    "fields": {
+      "template": 26,
+      "question": 8,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1021,
+    "fields": {
+      "template": 26,
+      "question": 13,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1022,
+    "fields": {
+      "template": 26,
+      "question": 9,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1023,
+    "fields": {
+      "template": 26,
+      "question": 11,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1024,
+    "fields": {
+      "template": 26,
+      "question": 69,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1025,
+    "fields": {
+      "template": 26,
+      "question": 60,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1026,
+    "fields": {
+      "template": 26,
+      "question": 1,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1027,
+    "fields": {
+      "template": 26,
+      "question": 82,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1028,
+    "fields": {
+      "template": 26,
+      "question": 23,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1029,
+    "fields": {
+      "template": 26,
+      "question": 43,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1030,
+    "fields": {
+      "template": 26,
+      "question": 87,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1031,
+    "fields": {
+      "template": 26,
+      "question": 80,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1032,
+    "fields": {
+      "template": 26,
+      "question": 71,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1033,
+    "fields": {
+      "template": 26,
+      "question": 78,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1034,
+    "fields": {
+      "template": 26,
+      "question": 18,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1035,
+    "fields": {
+      "template": 26,
+      "question": 46,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1036,
+    "fields": {
+      "template": 26,
+      "question": 51,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1037,
+    "fields": {
+      "template": 26,
+      "question": 79,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1038,
+    "fields": {
+      "template": 26,
+      "question": 65,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1039,
+    "fields": {
+      "template": 26,
+      "question": 42,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1040,
+    "fields": {
+      "template": 26,
+      "question": 67,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1041,
+    "fields": {
+      "template": 26,
+      "question": 19,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1042,
+    "fields": {
+      "template": 26,
+      "question": 77,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1043,
+    "fields": {
+      "template": 26,
+      "question": 127,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1044,
+    "fields": {
+      "template": 26,
+      "question": 128,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1045,
+    "fields": {
+      "template": 26,
+      "question": 324,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1046,
+    "fields": {
+      "template": 26,
+      "question": 307,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1047,
+    "fields": {
+      "template": 26,
+      "question": 313,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1048,
+    "fields": {
+      "template": 26,
+      "question": 325,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1049,
+    "fields": {
+      "template": 26,
+      "question": 302,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1050,
+    "fields": {
+      "template": 26,
+      "question": 315,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1051,
+    "fields": {
+      "template": 26,
+      "question": 356,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1052,
+    "fields": {
+      "template": 26,
+      "question": 317,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1053,
+    "fields": {
+      "template": 26,
+      "question": 362,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1054,
+    "fields": {
+      "template": 26,
+      "question": 311,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1055,
+    "fields": {
+      "template": 26,
+      "question": 365,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1056,
+    "fields": {
+      "template": 26,
+      "question": 299,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1057,
+    "fields": {
+      "template": 26,
+      "question": 55,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1058,
+    "fields": {
+      "template": 26,
+      "question": 32,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1059,
+    "fields": {
+      "template": 26,
+      "question": 30,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1060,
+    "fields": {
+      "template": 26,
+      "question": 26,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1061,
+    "fields": {
+      "template": 26,
+      "question": 25,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1062,
+    "fields": {
+      "template": 26,
+      "question": 24,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1063,
+    "fields": {
+      "template": 26,
+      "question": 35,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1064,
+    "fields": {
+      "template": 26,
+      "question": 38,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1065,
+    "fields": {
+      "template": 26,
+      "question": 31,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1066,
+    "fields": {
+      "template": 26,
+      "question": 37,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1067,
+    "fields": {
+      "template": 26,
+      "question": 4,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1068,
+    "fields": {
+      "template": 26,
+      "question": 66,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1069,
+    "fields": {
+      "template": 26,
+      "question": 156,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1070,
+    "fields": {
+      "template": 27,
+      "question": 19,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1071,
+    "fields": {
+      "template": 27,
+      "question": 77,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1072,
+    "fields": {
+      "template": 27,
+      "question": 61,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1073,
+    "fields": {
+      "template": 27,
+      "question": 84,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1074,
+    "fields": {
+      "template": 27,
+      "question": 64,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1075,
+    "fields": {
+      "template": 27,
+      "question": 17,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1076,
+    "fields": {
+      "template": 27,
+      "question": 87,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1077,
+    "fields": {
+      "template": 27,
+      "question": 48,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1078,
+    "fields": {
+      "template": 27,
+      "question": 59,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1079,
+    "fields": {
+      "template": 27,
+      "question": 71,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1080,
+    "fields": {
+      "template": 27,
+      "question": 234,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1081,
+    "fields": {
+      "template": 27,
+      "question": 91,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1082,
+    "fields": {
+      "template": 27,
+      "question": 229,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1083,
+    "fields": {
+      "template": 27,
+      "question": 231,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1084,
+    "fields": {
+      "template": 27,
+      "question": 3,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1085,
+    "fields": {
+      "template": 27,
+      "question": 157,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1086,
+    "fields": {
+      "template": 27,
+      "question": 238,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1087,
+    "fields": {
+      "template": 27,
+      "question": 241,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1088,
+    "fields": {
+      "template": 27,
+      "question": 128,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1089,
+    "fields": {
+      "template": 27,
+      "question": 133,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1090,
+    "fields": {
+      "template": 27,
+      "question": 121,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1091,
+    "fields": {
+      "template": 27,
+      "question": 132,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1092,
+    "fields": {
+      "template": 27,
+      "question": 123,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1093,
+    "fields": {
+      "template": 27,
+      "question": 6,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1094,
+    "fields": {
+      "template": 27,
+      "question": 5,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1095,
+    "fields": {
+      "template": 27,
+      "question": 4,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1096,
+    "fields": {
+      "template": 27,
+      "question": 66,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1097,
+    "fields": {
+      "template": 27,
+      "question": 86,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1098,
+    "fields": {
+      "template": 27,
+      "question": 90,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1099,
+    "fields": {
+      "template": 27,
+      "question": 30,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1100,
+    "fields": {
+      "template": 27,
+      "question": 29,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1101,
+    "fields": {
+      "template": 27,
+      "question": 27,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1102,
+    "fields": {
+      "template": 27,
+      "question": 25,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1103,
+    "fields": {
+      "template": 27,
+      "question": 70,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1104,
+    "fields": {
+      "template": 27,
+      "question": 88,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1105,
+    "fields": {
+      "template": 27,
+      "question": 34,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1106,
+    "fields": {
+      "template": 27,
+      "question": 135,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1107,
+    "fields": {
+      "template": 27,
+      "question": 35,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1108,
+    "fields": {
+      "template": 27,
+      "question": 39,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1109,
+    "fields": {
+      "template": 27,
+      "question": 63,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1110,
+    "fields": {
+      "template": 27,
+      "question": 60,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1111,
+    "fields": {
+      "template": 27,
+      "question": 82,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1112,
+    "fields": {
+      "template": 27,
+      "question": 75,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1113,
+    "fields": {
+      "template": 27,
+      "question": 15,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1114,
+    "fields": {
+      "template": 27,
+      "question": 52,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1115,
+    "fields": {
+      "template": 27,
+      "question": 81,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1116,
+    "fields": {
+      "template": 27,
+      "question": 1,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1117,
+    "fields": {
+      "template": 27,
+      "question": 83,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1118,
+    "fields": {
+      "template": 27,
+      "question": 32,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1119,
+    "fields": {
+      "template": 27,
+      "question": 126,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1120,
+    "fields": {
+      "template": 28,
+      "question": 31,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1121,
+    "fields": {
+      "template": 28,
+      "question": 14,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1122,
+    "fields": {
+      "template": 28,
+      "question": 135,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1123,
+    "fields": {
+      "template": 28,
+      "question": 70,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1124,
+    "fields": {
+      "template": 28,
+      "question": 49,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1125,
+    "fields": {
+      "template": 28,
+      "question": 34,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1126,
+    "fields": {
+      "template": 28,
+      "question": 9,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1127,
+    "fields": {
+      "template": 28,
+      "question": 13,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1128,
+    "fields": {
+      "template": 28,
+      "question": 7,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1129,
+    "fields": {
+      "template": 28,
+      "question": 16,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1130,
+    "fields": {
+      "template": 28,
+      "question": 8,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1131,
+    "fields": {
+      "template": 28,
+      "question": 168,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1132,
+    "fields": {
+      "template": 28,
+      "question": 29,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1133,
+    "fields": {
+      "template": 28,
+      "question": 26,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1134,
+    "fields": {
+      "template": 28,
+      "question": 304,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1135,
+    "fields": {
+      "template": 28,
+      "question": 366,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1136,
+    "fields": {
+      "template": 28,
+      "question": 362,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1137,
+    "fields": {
+      "template": 28,
+      "question": 324,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1138,
+    "fields": {
+      "template": 28,
+      "question": 296,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1139,
+    "fields": {
+      "template": 28,
+      "question": 297,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1140,
+    "fields": {
+      "template": 28,
+      "question": 354,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1141,
+    "fields": {
+      "template": 28,
+      "question": 298,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1142,
+    "fields": {
+      "template": 28,
+      "question": 356,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1143,
+    "fields": {
+      "template": 28,
+      "question": 309,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1144,
+    "fields": {
+      "template": 28,
+      "question": 303,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1145,
+    "fields": {
+      "template": 28,
+      "question": 312,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1146,
+    "fields": {
+      "template": 28,
+      "question": 42,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1147,
+    "fields": {
+      "template": 28,
+      "question": 80,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1148,
+    "fields": {
+      "template": 28,
+      "question": 61,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1149,
+    "fields": {
+      "template": 28,
+      "question": 59,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1150,
+    "fields": {
+      "template": 28,
+      "question": 84,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1151,
+    "fields": {
+      "template": 28,
+      "question": 22,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1152,
+    "fields": {
+      "template": 28,
+      "question": 23,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1153,
+    "fields": {
+      "template": 28,
+      "question": 78,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1154,
+    "fields": {
+      "template": 28,
+      "question": 17,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1155,
+    "fields": {
+      "template": 28,
+      "question": 48,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1156,
+    "fields": {
+      "template": 28,
+      "question": 68,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1157,
+    "fields": {
+      "template": 28,
+      "question": 64,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1158,
+    "fields": {
+      "template": 28,
+      "question": 19,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1159,
+    "fields": {
+      "template": 28,
+      "question": 51,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1160,
+    "fields": {
+      "template": 28,
+      "question": 60,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1161,
+    "fields": {
+      "template": 28,
+      "question": 69,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1162,
+    "fields": {
+      "template": 28,
+      "question": 47,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1163,
+    "fields": {
+      "template": 28,
+      "question": 1,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1164,
+    "fields": {
+      "template": 28,
+      "question": 121,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1165,
+    "fields": {
+      "template": 28,
+      "question": 133,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1166,
+    "fields": {
+      "template": 28,
+      "question": 132,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1167,
+    "fields": {
+      "template": 28,
+      "question": 123,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1168,
+    "fields": {
+      "template": 28,
+      "question": 126,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1169,
+    "fields": {
+      "template": 28,
+      "question": 6,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1170,
+    "fields": {
+      "template": 29,
+      "question": 81,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1171,
+    "fields": {
+      "template": 29,
+      "question": 1,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1172,
+    "fields": {
+      "template": 29,
+      "question": 47,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1173,
+    "fields": {
+      "template": 29,
+      "question": 15,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1174,
+    "fields": {
+      "template": 29,
+      "question": 83,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1175,
+    "fields": {
+      "template": 29,
+      "question": 21,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1176,
+    "fields": {
+      "template": 29,
+      "question": 64,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1177,
+    "fields": {
+      "template": 29,
+      "question": 22,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1178,
+    "fields": {
+      "template": 29,
+      "question": 41,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1179,
+    "fields": {
+      "template": 29,
+      "question": 78,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1180,
+    "fields": {
+      "template": 29,
+      "question": 42,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1181,
+    "fields": {
+      "template": 29,
+      "question": 44,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1182,
+    "fields": {
+      "template": 29,
+      "question": 68,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1183,
+    "fields": {
+      "template": 29,
+      "question": 46,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1184,
+    "fields": {
+      "template": 29,
+      "question": 19,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1185,
+    "fields": {
+      "template": 29,
+      "question": 76,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1186,
+    "fields": {
+      "template": 29,
+      "question": 73,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1187,
+    "fields": {
+      "template": 29,
+      "question": 40,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1188,
+    "fields": {
+      "template": 29,
+      "question": 20,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1189,
+    "fields": {
+      "template": 29,
+      "question": 71,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1190,
+    "fields": {
+      "template": 29,
+      "question": 239,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1191,
+    "fields": {
+      "template": 29,
+      "question": 157,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1192,
+    "fields": {
+      "template": 29,
+      "question": 235,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1193,
+    "fields": {
+      "template": 29,
+      "question": 234,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1194,
+    "fields": {
+      "template": 29,
+      "question": 238,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1195,
+    "fields": {
+      "template": 29,
+      "question": 91,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1196,
+    "fields": {
+      "template": 29,
+      "question": 92,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1197,
+    "fields": {
+      "template": 29,
+      "question": 236,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1198,
+    "fields": {
+      "template": 29,
+      "question": 136,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1199,
+    "fields": {
+      "template": 29,
+      "question": 231,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1200,
+    "fields": {
+      "template": 29,
+      "question": 156,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1201,
+    "fields": {
+      "template": 29,
+      "question": 86,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1202,
+    "fields": {
+      "template": 29,
+      "question": 5,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1203,
+    "fields": {
+      "template": 29,
+      "question": 129,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1204,
+    "fields": {
+      "template": 29,
+      "question": 132,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1205,
+    "fields": {
+      "template": 29,
+      "question": 122,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1206,
+    "fields": {
+      "template": 29,
+      "question": 123,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1207,
+    "fields": {
+      "template": 29,
+      "question": 127,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1208,
+    "fields": {
+      "template": 29,
+      "question": 121,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1209,
+    "fields": {
+      "template": 29,
+      "question": 125,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1210,
+    "fields": {
+      "template": 29,
+      "question": 133,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1211,
+    "fields": {
+      "template": 29,
+      "question": 24,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1212,
+    "fields": {
+      "template": 29,
+      "question": 26,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1213,
+    "fields": {
+      "template": 29,
+      "question": 29,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1214,
+    "fields": {
+      "template": 29,
+      "question": 57,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1215,
+    "fields": {
+      "template": 29,
+      "question": 38,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1216,
+    "fields": {
+      "template": 29,
+      "question": 70,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1217,
+    "fields": {
+      "template": 29,
+      "question": 39,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1218,
+    "fields": {
+      "template": 29,
+      "question": 89,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1219,
+    "fields": {
+      "template": 29,
+      "question": 126,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1220,
+    "fields": {
+      "template": 30,
+      "question": 123,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1221,
+    "fields": {
+      "template": 30,
+      "question": 128,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1222,
+    "fields": {
+      "template": 30,
+      "question": 122,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1223,
+    "fields": {
+      "template": 30,
+      "question": 121,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1224,
+    "fields": {
+      "template": 30,
+      "question": 129,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1225,
+    "fields": {
+      "template": 30,
+      "question": 76,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1226,
+    "fields": {
+      "template": 30,
+      "question": 77,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1227,
+    "fields": {
+      "template": 30,
+      "question": 46,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1228,
+    "fields": {
+      "template": 30,
+      "question": 61,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1229,
+    "fields": {
+      "template": 30,
+      "question": 22,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1230,
+    "fields": {
+      "template": 30,
+      "question": 43,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1231,
+    "fields": {
+      "template": 30,
+      "question": 84,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1232,
+    "fields": {
+      "template": 30,
+      "question": 71,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1233,
+    "fields": {
+      "template": 30,
+      "question": 20,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1234,
+    "fields": {
+      "template": 30,
+      "question": 67,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1235,
+    "fields": {
+      "template": 30,
+      "question": 40,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1236,
+    "fields": {
+      "template": 30,
+      "question": 79,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1237,
+    "fields": {
+      "template": 30,
+      "question": 59,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1238,
+    "fields": {
+      "template": 30,
+      "question": 68,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1239,
+    "fields": {
+      "template": 30,
+      "question": 87,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1240,
+    "fields": {
+      "template": 30,
+      "question": 48,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1241,
+    "fields": {
+      "template": 30,
+      "question": 2,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1242,
+    "fields": {
+      "template": 30,
+      "question": 85,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1243,
+    "fields": {
+      "template": 30,
+      "question": 25,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1244,
+    "fields": {
+      "template": 30,
+      "question": 27,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1245,
+    "fields": {
+      "template": 30,
+      "question": 32,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1246,
+    "fields": {
+      "template": 30,
+      "question": 159,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1247,
+    "fields": {
+      "template": 30,
+      "question": 55,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1248,
+    "fields": {
+      "template": 30,
+      "question": 126,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1249,
+    "fields": {
+      "template": 30,
+      "question": 53,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1250,
+    "fields": {
+      "template": 30,
+      "question": 234,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1251,
+    "fields": {
+      "template": 30,
+      "question": 235,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1252,
+    "fields": {
+      "template": 30,
+      "question": 232,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1253,
+    "fields": {
+      "template": 30,
+      "question": 228,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1254,
+    "fields": {
+      "template": 30,
+      "question": 158,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1255,
+    "fields": {
+      "template": 30,
+      "question": 136,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1256,
+    "fields": {
+      "template": 30,
+      "question": 239,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1257,
+    "fields": {
+      "template": 30,
+      "question": 91,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1258,
+    "fields": {
+      "template": 30,
+      "question": 56,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1259,
+    "fields": {
+      "template": 30,
+      "question": 39,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1260,
+    "fields": {
+      "template": 30,
+      "question": 49,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1261,
+    "fields": {
+      "template": 30,
+      "question": 38,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1262,
+    "fields": {
+      "template": 30,
+      "question": 34,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1263,
+    "fields": {
+      "template": 30,
+      "question": 70,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1264,
+    "fields": {
+      "template": 30,
+      "question": 14,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1265,
+    "fields": {
+      "template": 30,
+      "question": 156,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1266,
+    "fields": {
+      "template": 30,
+      "question": 66,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1267,
+    "fields": {
+      "template": 30,
+      "question": 81,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1268,
+    "fields": {
+      "template": 30,
+      "question": 5,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1269,
+    "fields": {
+      "template": 30,
+      "question": 37,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1270,
+    "fields": {
+      "template": 31,
+      "question": 43,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1271,
+    "fields": {
+      "template": 31,
+      "question": 68,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1272,
+    "fields": {
+      "template": 31,
+      "question": 46,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1273,
+    "fields": {
+      "template": 31,
+      "question": 17,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1274,
+    "fields": {
+      "template": 31,
+      "question": 84,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1275,
+    "fields": {
+      "template": 31,
+      "question": 18,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1276,
+    "fields": {
+      "template": 31,
+      "question": 22,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1277,
+    "fields": {
+      "template": 31,
+      "question": 67,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1278,
+    "fields": {
+      "template": 31,
+      "question": 65,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1279,
+    "fields": {
+      "template": 31,
+      "question": 48,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1280,
+    "fields": {
+      "template": 31,
+      "question": 59,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1281,
+    "fields": {
+      "template": 31,
+      "question": 31,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1282,
+    "fields": {
+      "template": 31,
+      "question": 35,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1283,
+    "fields": {
+      "template": 31,
+      "question": 89,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1284,
+    "fields": {
+      "template": 31,
+      "question": 135,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1285,
+    "fields": {
+      "template": 31,
+      "question": 38,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1286,
+    "fields": {
+      "template": 31,
+      "question": 88,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1287,
+    "fields": {
+      "template": 31,
+      "question": 81,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1288,
+    "fields": {
+      "template": 31,
+      "question": 83,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1289,
+    "fields": {
+      "template": 31,
+      "question": 53,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1290,
+    "fields": {
+      "template": 31,
+      "question": 55,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1291,
+    "fields": {
+      "template": 31,
+      "question": 156,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1292,
+    "fields": {
+      "template": 31,
+      "question": 66,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1293,
+    "fields": {
+      "template": 31,
+      "question": 307,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1294,
+    "fields": {
+      "template": 31,
+      "question": 357,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1295,
+    "fields": {
+      "template": 31,
+      "question": 360,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1296,
+    "fields": {
+      "template": 31,
+      "question": 302,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1297,
+    "fields": {
+      "template": 31,
+      "question": 359,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1298,
+    "fields": {
+      "template": 31,
+      "question": 305,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1299,
+    "fields": {
+      "template": 31,
+      "question": 304,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1300,
+    "fields": {
+      "template": 31,
+      "question": 356,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1301,
+    "fields": {
+      "template": 31,
+      "question": 315,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1302,
+    "fields": {
+      "template": 31,
+      "question": 310,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1303,
+    "fields": {
+      "template": 31,
+      "question": 297,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1304,
+    "fields": {
+      "template": 31,
+      "question": 311,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1305,
+    "fields": {
+      "template": 31,
+      "question": 160,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1306,
+    "fields": {
+      "template": 31,
+      "question": 8,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1307,
+    "fields": {
+      "template": 31,
+      "question": 7,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1308,
+    "fields": {
+      "template": 31,
+      "question": 167,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1309,
+    "fields": {
+      "template": 31,
+      "question": 9,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1310,
+    "fields": {
+      "template": 31,
+      "question": 11,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1311,
+    "fields": {
+      "template": 31,
+      "question": 29,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1312,
+    "fields": {
+      "template": 31,
+      "question": 28,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1313,
+    "fields": {
+      "template": 31,
+      "question": 85,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1314,
+    "fields": {
+      "template": 31,
+      "question": 30,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1315,
+    "fields": {
+      "template": 31,
+      "question": 27,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1316,
+    "fields": {
+      "template": 31,
+      "question": 5,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1317,
+    "fields": {
+      "template": 31,
+      "question": 4,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1318,
+    "fields": {
+      "template": 31,
+      "question": 127,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1319,
+    "fields": {
+      "template": 31,
+      "question": 128,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1320,
+    "fields": {
+      "template": 32,
+      "question": 307,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1321,
+    "fields": {
+      "template": 32,
+      "question": 310,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1322,
+    "fields": {
+      "template": 32,
+      "question": 309,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1323,
+    "fields": {
+      "template": 32,
+      "question": 325,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1324,
+    "fields": {
+      "template": 32,
+      "question": 315,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1325,
+    "fields": {
+      "template": 32,
+      "question": 301,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1326,
+    "fields": {
+      "template": 32,
+      "question": 311,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1327,
+    "fields": {
+      "template": 32,
+      "question": 308,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1328,
+    "fields": {
+      "template": 32,
+      "question": 305,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1329,
+    "fields": {
+      "template": 32,
+      "question": 302,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1330,
+    "fields": {
+      "template": 32,
+      "question": 303,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1331,
+    "fields": {
+      "template": 32,
+      "question": 306,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1332,
+    "fields": {
+      "template": 32,
+      "question": 299,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1333,
+    "fields": {
+      "template": 32,
+      "question": 357,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1334,
+    "fields": {
+      "template": 32,
+      "question": 127,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1335,
+    "fields": {
+      "template": 32,
+      "question": 124,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1336,
+    "fields": {
+      "template": 32,
+      "question": 123,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1337,
+    "fields": {
+      "template": 32,
+      "question": 133,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1338,
+    "fields": {
+      "template": 32,
+      "question": 129,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1339,
+    "fields": {
+      "template": 32,
+      "question": 82,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1340,
+    "fields": {
+      "template": 32,
+      "question": 15,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1341,
+    "fields": {
+      "template": 32,
+      "question": 75,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1342,
+    "fields": {
+      "template": 32,
+      "question": 83,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1343,
+    "fields": {
+      "template": 32,
+      "question": 60,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1344,
+    "fields": {
+      "template": 32,
+      "question": 41,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1345,
+    "fields": {
+      "template": 32,
+      "question": 80,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1346,
+    "fields": {
+      "template": 32,
+      "question": 21,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1347,
+    "fields": {
+      "template": 32,
+      "question": 22,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1348,
+    "fields": {
+      "template": 32,
+      "question": 73,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1349,
+    "fields": {
+      "template": 32,
+      "question": 44,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1350,
+    "fields": {
+      "template": 32,
+      "question": 40,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1351,
+    "fields": {
+      "template": 32,
+      "question": 78,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1352,
+    "fields": {
+      "template": 32,
+      "question": 67,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1353,
+    "fields": {
+      "template": 32,
+      "question": 87,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1354,
+    "fields": {
+      "template": 32,
+      "question": 71,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1355,
+    "fields": {
+      "template": 32,
+      "question": 17,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1356,
+    "fields": {
+      "template": 32,
+      "question": 4,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1357,
+    "fields": {
+      "template": 32,
+      "question": 58,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1358,
+    "fields": {
+      "template": 32,
+      "question": 167,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1359,
+    "fields": {
+      "template": 32,
+      "question": 16,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1360,
+    "fields": {
+      "template": 32,
+      "question": 160,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1361,
+    "fields": {
+      "template": 32,
+      "question": 57,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1362,
+    "fields": {
+      "template": 32,
+      "question": 135,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1363,
+    "fields": {
+      "template": 32,
+      "question": 89,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1364,
+    "fields": {
+      "template": 32,
+      "question": 120,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1365,
+    "fields": {
+      "template": 32,
+      "question": 32,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1366,
+    "fields": {
+      "template": 32,
+      "question": 62,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1367,
+    "fields": {
+      "template": 32,
+      "question": 90,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1368,
+    "fields": {
+      "template": 32,
+      "question": 66,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1369,
+    "fields": {
+      "template": 32,
+      "question": 156,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1370,
+    "fields": {
+      "template": 34,
+      "question": 159,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1371,
+    "fields": {
+      "template": 34,
+      "question": 55,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1372,
+    "fields": {
+      "template": 34,
+      "question": 126,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1373,
+    "fields": {
+      "template": 34,
+      "question": 53,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1374,
+    "fields": {
+      "template": 34,
+      "question": 24,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1375,
+    "fields": {
+      "template": 34,
+      "question": 29,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1376,
+    "fields": {
+      "template": 34,
+      "question": 85,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1377,
+    "fields": {
+      "template": 34,
+      "question": 30,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1378,
+    "fields": {
+      "template": 34,
+      "question": 168,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1379,
+    "fields": {
+      "template": 34,
+      "question": 7,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1380,
+    "fields": {
+      "template": 34,
+      "question": 13,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1381,
+    "fields": {
+      "template": 34,
+      "question": 70,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1382,
+    "fields": {
+      "template": 34,
+      "question": 63,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1383,
+    "fields": {
+      "template": 34,
+      "question": 49,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1384,
+    "fields": {
+      "template": 34,
+      "question": 132,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1385,
+    "fields": {
+      "template": 34,
+      "question": 133,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1386,
+    "fields": {
+      "template": 34,
+      "question": 121,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1387,
+    "fields": {
+      "template": 34,
+      "question": 65,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1388,
+    "fields": {
+      "template": 34,
+      "question": 67,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1389,
+    "fields": {
+      "template": 34,
+      "question": 51,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1390,
+    "fields": {
+      "template": 34,
+      "question": 68,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1391,
+    "fields": {
+      "template": 34,
+      "question": 22,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1392,
+    "fields": {
+      "template": 34,
+      "question": 79,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1393,
+    "fields": {
+      "template": 34,
+      "question": 19,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1394,
+    "fields": {
+      "template": 34,
+      "question": 44,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1395,
+    "fields": {
+      "template": 34,
+      "question": 46,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1396,
+    "fields": {
+      "template": 34,
+      "question": 42,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1397,
+    "fields": {
+      "template": 34,
+      "question": 48,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1398,
+    "fields": {
+      "template": 34,
+      "question": 84,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1399,
+    "fields": {
+      "template": 34,
+      "question": 78,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1400,
+    "fields": {
+      "template": 34,
+      "question": 58,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1401,
+    "fields": {
+      "template": 34,
+      "question": 37,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1402,
+    "fields": {
+      "template": 34,
+      "question": 86,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1403,
+    "fields": {
+      "template": 34,
+      "question": 302,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1404,
+    "fields": {
+      "template": 34,
+      "question": 316,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1405,
+    "fields": {
+      "template": 34,
+      "question": 308,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1406,
+    "fields": {
+      "template": 34,
+      "question": 306,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1407,
+    "fields": {
+      "template": 34,
+      "question": 303,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1408,
+    "fields": {
+      "template": 34,
+      "question": 304,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1409,
+    "fields": {
+      "template": 34,
+      "question": 324,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1410,
+    "fields": {
+      "template": 34,
+      "question": 363,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1411,
+    "fields": {
+      "template": 34,
+      "question": 325,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1412,
+    "fields": {
+      "template": 34,
+      "question": 296,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1413,
+    "fields": {
+      "template": 34,
+      "question": 360,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1414,
+    "fields": {
+      "template": 34,
+      "question": 312,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1415,
+    "fields": {
+      "template": 34,
+      "question": 311,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1416,
+    "fields": {
+      "template": 34,
+      "question": 75,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1417,
+    "fields": {
+      "template": 34,
+      "question": 83,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1418,
+    "fields": {
+      "template": 34,
+      "question": 47,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1419,
+    "fields": {
+      "template": 34,
+      "question": 69,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1420,
+    "fields": {
+      "template": 35,
+      "question": 297,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1421,
+    "fields": {
+      "template": 35,
+      "question": 305,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1422,
+    "fields": {
+      "template": 35,
+      "question": 298,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1423,
+    "fields": {
+      "template": 35,
+      "question": 310,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1424,
+    "fields": {
+      "template": 35,
+      "question": 307,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1425,
+    "fields": {
+      "template": 35,
+      "question": 359,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1426,
+    "fields": {
+      "template": 35,
+      "question": 308,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1427,
+    "fields": {
+      "template": 35,
+      "question": 300,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1428,
+    "fields": {
+      "template": 35,
+      "question": 354,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1429,
+    "fields": {
+      "template": 35,
+      "question": 357,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1430,
+    "fields": {
+      "template": 35,
+      "question": 301,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1431,
+    "fields": {
+      "template": 35,
+      "question": 358,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1432,
+    "fields": {
+      "template": 35,
+      "question": 84,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1433,
+    "fields": {
+      "template": 35,
+      "question": 19,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1434,
+    "fields": {
+      "template": 35,
+      "question": 43,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1435,
+    "fields": {
+      "template": 35,
+      "question": 65,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1436,
+    "fields": {
+      "template": 35,
+      "question": 67,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1437,
+    "fields": {
+      "template": 35,
+      "question": 2,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1438,
+    "fields": {
+      "template": 35,
+      "question": 18,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1439,
+    "fields": {
+      "template": 35,
+      "question": 79,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1440,
+    "fields": {
+      "template": 35,
+      "question": 48,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1441,
+    "fields": {
+      "template": 35,
+      "question": 41,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1442,
+    "fields": {
+      "template": 35,
+      "question": 45,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1443,
+    "fields": {
+      "template": 35,
+      "question": 39,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1444,
+    "fields": {
+      "template": 35,
+      "question": 35,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1445,
+    "fields": {
+      "template": 35,
+      "question": 38,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1446,
+    "fields": {
+      "template": 35,
+      "question": 31,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1447,
+    "fields": {
+      "template": 35,
+      "question": 56,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1448,
+    "fields": {
+      "template": 35,
+      "question": 14,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1449,
+    "fields": {
+      "template": 35,
+      "question": 63,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1450,
+    "fields": {
+      "template": 35,
+      "question": 120,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1451,
+    "fields": {
+      "template": 35,
+      "question": 159,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1452,
+    "fields": {
+      "template": 35,
+      "question": 126,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1453,
+    "fields": {
+      "template": 35,
+      "question": 74,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1454,
+    "fields": {
+      "template": 35,
+      "question": 29,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1455,
+    "fields": {
+      "template": 35,
+      "question": 26,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1456,
+    "fields": {
+      "template": 35,
+      "question": 28,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1457,
+    "fields": {
+      "template": 35,
+      "question": 24,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1458,
+    "fields": {
+      "template": 35,
+      "question": 15,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1459,
+    "fields": {
+      "template": 35,
+      "question": 52,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1460,
+    "fields": {
+      "template": 35,
+      "question": 121,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1461,
+    "fields": {
+      "template": 35,
+      "question": 125,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1462,
+    "fields": {
+      "template": 35,
+      "question": 127,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1463,
+    "fields": {
+      "template": 35,
+      "question": 124,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1464,
+    "fields": {
+      "template": 35,
+      "question": 128,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1465,
+    "fields": {
+      "template": 35,
+      "question": 132,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1466,
+    "fields": {
+      "template": 35,
+      "question": 7,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1467,
+    "fields": {
+      "template": 35,
+      "question": 9,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1468,
+    "fields": {
+      "template": 35,
+      "question": 86,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1469,
+    "fields": {
+      "template": 35,
+      "question": 6,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1470,
+    "fields": {
+      "template": 36,
+      "question": 55,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1471,
+    "fields": {
+      "template": 36,
+      "question": 159,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1472,
+    "fields": {
+      "template": 36,
+      "question": 32,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1473,
+    "fields": {
+      "template": 36,
+      "question": 241,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1474,
+    "fields": {
+      "template": 36,
+      "question": 236,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1475,
+    "fields": {
+      "template": 36,
+      "question": 237,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1476,
+    "fields": {
+      "template": 36,
+      "question": 233,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1477,
+    "fields": {
+      "template": 36,
+      "question": 238,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1478,
+    "fields": {
+      "template": 36,
+      "question": 234,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1479,
+    "fields": {
+      "template": 36,
+      "question": 228,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1480,
+    "fields": {
+      "template": 36,
+      "question": 157,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1481,
+    "fields": {
+      "template": 36,
+      "question": 136,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1482,
+    "fields": {
+      "template": 36,
+      "question": 230,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1483,
+    "fields": {
+      "template": 36,
+      "question": 58,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1484,
+    "fields": {
+      "template": 36,
+      "question": 4,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1485,
+    "fields": {
+      "template": 36,
+      "question": 37,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1486,
+    "fields": {
+      "template": 36,
+      "question": 5,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1487,
+    "fields": {
+      "template": 36,
+      "question": 47,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1488,
+    "fields": {
+      "template": 36,
+      "question": 60,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1489,
+    "fields": {
+      "template": 36,
+      "question": 75,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1490,
+    "fields": {
+      "template": 36,
+      "question": 81,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1491,
+    "fields": {
+      "template": 36,
+      "question": 120,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1492,
+    "fields": {
+      "template": 36,
+      "question": 135,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1493,
+    "fields": {
+      "template": 36,
+      "question": 34,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1494,
+    "fields": {
+      "template": 36,
+      "question": 38,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1495,
+    "fields": {
+      "template": 36,
+      "question": 78,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1496,
+    "fields": {
+      "template": 36,
+      "question": 68,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1497,
+    "fields": {
+      "template": 36,
+      "question": 79,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1498,
+    "fields": {
+      "template": 36,
+      "question": 18,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1499,
+    "fields": {
+      "template": 36,
+      "question": 44,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1500,
+    "fields": {
+      "template": 36,
+      "question": 64,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1501,
+    "fields": {
+      "template": 36,
+      "question": 2,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1502,
+    "fields": {
+      "template": 36,
+      "question": 40,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1503,
+    "fields": {
+      "template": 36,
+      "question": 87,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1504,
+    "fields": {
+      "template": 36,
+      "question": 41,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1505,
+    "fields": {
+      "template": 36,
+      "question": 17,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1506,
+    "fields": {
+      "template": 36,
+      "question": 42,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1507,
+    "fields": {
+      "template": 36,
+      "question": 84,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1508,
+    "fields": {
+      "template": 36,
+      "question": 80,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1509,
+    "fields": {
+      "template": 36,
+      "question": 45,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1510,
+    "fields": {
+      "template": 36,
+      "question": 67,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1511,
+    "fields": {
+      "template": 36,
+      "question": 51,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1512,
+    "fields": {
+      "template": 36,
+      "question": 71,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1513,
+    "fields": {
+      "template": 36,
+      "question": 28,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1514,
+    "fields": {
+      "template": 36,
+      "question": 57,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1515,
+    "fields": {
+      "template": 36,
+      "question": 24,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1516,
+    "fields": {
+      "template": 36,
+      "question": 25,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1517,
+    "fields": {
+      "template": 36,
+      "question": 127,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1518,
+    "fields": {
+      "template": 36,
+      "question": 134,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1519,
+    "fields": {
+      "template": 36,
+      "question": 123,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1520,
+    "fields": {
+      "template": 37,
+      "question": 158,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1521,
+    "fields": {
+      "template": 37,
+      "question": 237,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1522,
+    "fields": {
+      "template": 37,
+      "question": 229,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1523,
+    "fields": {
+      "template": 37,
+      "question": 228,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1524,
+    "fields": {
+      "template": 37,
+      "question": 233,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1525,
+    "fields": {
+      "template": 37,
+      "question": 236,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1526,
+    "fields": {
+      "template": 37,
+      "question": 239,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1527,
+    "fields": {
+      "template": 37,
+      "question": 3,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1528,
+    "fields": {
+      "template": 37,
+      "question": 92,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1529,
+    "fields": {
+      "template": 37,
+      "question": 241,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1530,
+    "fields": {
+      "template": 37,
+      "question": 29,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1531,
+    "fields": {
+      "template": 37,
+      "question": 26,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1532,
+    "fields": {
+      "template": 37,
+      "question": 25,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1533,
+    "fields": {
+      "template": 37,
+      "question": 85,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1534,
+    "fields": {
+      "template": 37,
+      "question": 61,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1535,
+    "fields": {
+      "template": 37,
+      "question": 77,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1536,
+    "fields": {
+      "template": 37,
+      "question": 18,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1537,
+    "fields": {
+      "template": 37,
+      "question": 73,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1538,
+    "fields": {
+      "template": 37,
+      "question": 67,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1539,
+    "fields": {
+      "template": 37,
+      "question": 20,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1540,
+    "fields": {
+      "template": 37,
+      "question": 87,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1541,
+    "fields": {
+      "template": 37,
+      "question": 76,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1542,
+    "fields": {
+      "template": 37,
+      "question": 48,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1543,
+    "fields": {
+      "template": 37,
+      "question": 41,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1544,
+    "fields": {
+      "template": 37,
+      "question": 79,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1545,
+    "fields": {
+      "template": 37,
+      "question": 43,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1546,
+    "fields": {
+      "template": 37,
+      "question": 44,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1547,
+    "fields": {
+      "template": 37,
+      "question": 45,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1548,
+    "fields": {
+      "template": 37,
+      "question": 5,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1549,
+    "fields": {
+      "template": 37,
+      "question": 6,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1550,
+    "fields": {
+      "template": 37,
+      "question": 37,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1551,
+    "fields": {
+      "template": 37,
+      "question": 128,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1552,
+    "fields": {
+      "template": 37,
+      "question": 133,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1553,
+    "fields": {
+      "template": 37,
+      "question": 132,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1554,
+    "fields": {
+      "template": 37,
+      "question": 134,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1555,
+    "fields": {
+      "template": 37,
+      "question": 129,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1556,
+    "fields": {
+      "template": 37,
+      "question": 1,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1557,
+    "fields": {
+      "template": 37,
+      "question": 69,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1558,
+    "fields": {
+      "template": 37,
+      "question": 52,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1559,
+    "fields": {
+      "template": 37,
+      "question": 62,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1560,
+    "fields": {
+      "template": 37,
+      "question": 66,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1561,
+    "fields": {
+      "template": 37,
+      "question": 86,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1562,
+    "fields": {
+      "template": 37,
+      "question": 156,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1563,
+    "fields": {
+      "template": 37,
+      "question": 31,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1564,
+    "fields": {
+      "template": 37,
+      "question": 34,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1565,
+    "fields": {
+      "template": 37,
+      "question": 63,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1566,
+    "fields": {
+      "template": 37,
+      "question": 39,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1567,
+    "fields": {
+      "template": 37,
+      "question": 49,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1568,
+    "fields": {
+      "template": 37,
+      "question": 159,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1569,
+    "fields": {
+      "template": 37,
+      "question": 53,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1570,
+    "fields": {
+      "template": 38,
+      "question": 60,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1571,
+    "fields": {
+      "template": 38,
+      "question": 83,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1572,
+    "fields": {
+      "template": 38,
+      "question": 15,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1573,
+    "fields": {
+      "template": 38,
+      "question": 47,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1574,
+    "fields": {
+      "template": 38,
+      "question": 89,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1575,
+    "fields": {
+      "template": 38,
+      "question": 49,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1576,
+    "fields": {
+      "template": 38,
+      "question": 63,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1577,
+    "fields": {
+      "template": 38,
+      "question": 70,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1578,
+    "fields": {
+      "template": 38,
+      "question": 53,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1579,
+    "fields": {
+      "template": 38,
+      "question": 126,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1580,
+    "fields": {
+      "template": 38,
+      "question": 311,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1581,
+    "fields": {
+      "template": 38,
+      "question": 354,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1582,
+    "fields": {
+      "template": 38,
+      "question": 305,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1583,
+    "fields": {
+      "template": 38,
+      "question": 317,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1584,
+    "fields": {
+      "template": 38,
+      "question": 299,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1585,
+    "fields": {
+      "template": 38,
+      "question": 297,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1586,
+    "fields": {
+      "template": 38,
+      "question": 365,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1587,
+    "fields": {
+      "template": 38,
+      "question": 357,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1588,
+    "fields": {
+      "template": 38,
+      "question": 324,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1589,
+    "fields": {
+      "template": 38,
+      "question": 362,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1590,
+    "fields": {
+      "template": 38,
+      "question": 307,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1591,
+    "fields": {
+      "template": 38,
+      "question": 308,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1592,
+    "fields": {
+      "template": 38,
+      "question": 363,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1593,
+    "fields": {
+      "template": 38,
+      "question": 43,
+      "order": 24
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1594,
+    "fields": {
+      "template": 38,
+      "question": 48,
+      "order": 25
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1595,
+    "fields": {
+      "template": 38,
+      "question": 19,
+      "order": 26
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1596,
+    "fields": {
+      "template": 38,
+      "question": 77,
+      "order": 27
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1597,
+    "fields": {
+      "template": 38,
+      "question": 84,
+      "order": 28
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1598,
+    "fields": {
+      "template": 38,
+      "question": 64,
+      "order": 29
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1599,
+    "fields": {
+      "template": 38,
+      "question": 22,
+      "order": 30
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1600,
+    "fields": {
+      "template": 38,
+      "question": 40,
+      "order": 31
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1601,
+    "fields": {
+      "template": 38,
+      "question": 87,
+      "order": 32
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1602,
+    "fields": {
+      "template": 38,
+      "question": 21,
+      "order": 33
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1603,
+    "fields": {
+      "template": 38,
+      "question": 46,
+      "order": 34
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1604,
+    "fields": {
+      "template": 38,
+      "question": 67,
+      "order": 35
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1605,
+    "fields": {
+      "template": 38,
+      "question": 42,
+      "order": 36
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1606,
+    "fields": {
+      "template": 38,
+      "question": 41,
+      "order": 37
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1607,
+    "fields": {
+      "template": 38,
+      "question": 68,
+      "order": 38
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1608,
+    "fields": {
+      "template": 38,
+      "question": 61,
+      "order": 39
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1609,
+    "fields": {
+      "template": 38,
+      "question": 58,
+      "order": 40
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1610,
+    "fields": {
+      "template": 38,
+      "question": 37,
+      "order": 41
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1611,
+    "fields": {
+      "template": 38,
+      "question": 167,
+      "order": 42
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1612,
+    "fields": {
+      "template": 38,
+      "question": 8,
+      "order": 43
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1613,
+    "fields": {
+      "template": 38,
+      "question": 16,
+      "order": 44
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1614,
+    "fields": {
+      "template": 38,
+      "question": 30,
+      "order": 45
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1615,
+    "fields": {
+      "template": 38,
+      "question": 26,
+      "order": 46
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1616,
+    "fields": {
+      "template": 38,
+      "question": 24,
+      "order": 47
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1617,
+    "fields": {
+      "template": 38,
+      "question": 27,
+      "order": 48
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1618,
+    "fields": {
+      "template": 38,
+      "question": 123,
+      "order": 49
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1619,
+    "fields": {
+      "template": 38,
+      "question": 86,
+      "order": 50
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1620,
+    "fields": {
+      "template": 39,
+      "question": 1,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1621,
+    "fields": {
+      "template": 39,
+      "question": 266,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1622,
+    "fields": {
+      "template": 39,
+      "question": 270,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1623,
+    "fields": {
+      "template": 39,
+      "question": 259,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1624,
+    "fields": {
+      "template": 39,
+      "question": 267,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1625,
+    "fields": {
+      "template": 39,
+      "question": 260,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1626,
+    "fields": {
+      "template": 39,
+      "question": 265,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1627,
+    "fields": {
+      "template": 39,
+      "question": 256,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1628,
+    "fields": {
+      "template": 39,
+      "question": 263,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1629,
+    "fields": {
+      "template": 39,
+      "question": 264,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1630,
+    "fields": {
+      "template": 39,
+      "question": 254,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1631,
+    "fields": {
+      "template": 39,
+      "question": 255,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1632,
+    "fields": {
+      "template": 39,
+      "question": 271,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1633,
+    "fields": {
+      "template": 39,
+      "question": 261,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1634,
+    "fields": {
+      "template": 39,
+      "question": 258,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1635,
+    "fields": {
+      "template": 39,
+      "question": 268,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1636,
+    "fields": {
+      "template": 39,
+      "question": 250,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1637,
+    "fields": {
+      "template": 39,
+      "question": 252,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1638,
+    "fields": {
+      "template": 39,
+      "question": 251,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1639,
+    "fields": {
+      "template": 39,
+      "question": 269,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1640,
+    "fields": {
+      "template": 39,
+      "question": 262,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1641,
+    "fields": {
+      "template": 39,
+      "question": 257,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1642,
+    "fields": {
+      "template": 39,
+      "question": 253,
+      "order": 23
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1643,
+    "fields": {
+      "template": 40,
+      "question": 260,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1644,
+    "fields": {
+      "template": 40,
+      "question": 265,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1645,
+    "fields": {
+      "template": 40,
+      "question": 257,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1646,
+    "fields": {
+      "template": 40,
+      "question": 252,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1647,
+    "fields": {
+      "template": 40,
+      "question": 251,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1648,
+    "fields": {
+      "template": 40,
+      "question": 253,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1649,
+    "fields": {
+      "template": 40,
+      "question": 255,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1650,
+    "fields": {
+      "template": 40,
+      "question": 258,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1651,
+    "fields": {
+      "template": 40,
+      "question": 261,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1652,
+    "fields": {
+      "template": 40,
+      "question": 266,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1653,
+    "fields": {
+      "template": 40,
+      "question": 268,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1654,
+    "fields": {
+      "template": 40,
+      "question": 263,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1655,
+    "fields": {
+      "template": 40,
+      "question": 254,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1656,
+    "fields": {
+      "template": 40,
+      "question": 271,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1657,
+    "fields": {
+      "template": 40,
+      "question": 264,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1658,
+    "fields": {
+      "template": 40,
+      "question": 259,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1659,
+    "fields": {
+      "template": 40,
+      "question": 250,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1660,
+    "fields": {
+      "template": 40,
+      "question": 256,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1661,
+    "fields": {
+      "template": 40,
+      "question": 262,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1662,
+    "fields": {
+      "template": 40,
+      "question": 270,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1663,
+    "fields": {
+      "template": 40,
+      "question": 269,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1664,
+    "fields": {
+      "template": 40,
+      "question": 267,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1665,
+    "fields": {
+      "template": 41,
+      "question": 262,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1666,
+    "fields": {
+      "template": 41,
+      "question": 257,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1667,
+    "fields": {
+      "template": 41,
+      "question": 261,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1668,
+    "fields": {
+      "template": 41,
+      "question": 269,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1669,
+    "fields": {
+      "template": 41,
+      "question": 250,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1670,
+    "fields": {
+      "template": 41,
+      "question": 260,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1671,
+    "fields": {
+      "template": 41,
+      "question": 255,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1672,
+    "fields": {
+      "template": 41,
+      "question": 251,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1673,
+    "fields": {
+      "template": 41,
+      "question": 253,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1674,
+    "fields": {
+      "template": 41,
+      "question": 270,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1675,
+    "fields": {
+      "template": 41,
+      "question": 252,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1676,
+    "fields": {
+      "template": 41,
+      "question": 271,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1677,
+    "fields": {
+      "template": 41,
+      "question": 264,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1678,
+    "fields": {
+      "template": 41,
+      "question": 267,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1679,
+    "fields": {
+      "template": 41,
+      "question": 254,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1680,
+    "fields": {
+      "template": 41,
+      "question": 263,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1681,
+    "fields": {
+      "template": 41,
+      "question": 265,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1682,
+    "fields": {
+      "template": 41,
+      "question": 258,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1683,
+    "fields": {
+      "template": 41,
+      "question": 268,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1684,
+    "fields": {
+      "template": 41,
+      "question": 259,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1685,
+    "fields": {
+      "template": 41,
+      "question": 256,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1686,
+    "fields": {
+      "template": 41,
+      "question": 266,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1687,
+    "fields": {
+      "template": 42,
+      "question": 271,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1688,
+    "fields": {
+      "template": 42,
+      "question": 266,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1689,
+    "fields": {
+      "template": 42,
+      "question": 251,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1690,
+    "fields": {
+      "template": 42,
+      "question": 255,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1691,
+    "fields": {
+      "template": 42,
+      "question": 267,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1692,
+    "fields": {
+      "template": 42,
+      "question": 268,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1693,
+    "fields": {
+      "template": 42,
+      "question": 253,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1694,
+    "fields": {
+      "template": 42,
+      "question": 250,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1695,
+    "fields": {
+      "template": 42,
+      "question": 269,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1696,
+    "fields": {
+      "template": 42,
+      "question": 262,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1697,
+    "fields": {
+      "template": 42,
+      "question": 256,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1698,
+    "fields": {
+      "template": 42,
+      "question": 257,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1699,
+    "fields": {
+      "template": 42,
+      "question": 259,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1700,
+    "fields": {
+      "template": 42,
+      "question": 260,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1701,
+    "fields": {
+      "template": 42,
+      "question": 252,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1702,
+    "fields": {
+      "template": 42,
+      "question": 263,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1703,
+    "fields": {
+      "template": 42,
+      "question": 254,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1704,
+    "fields": {
+      "template": 42,
+      "question": 258,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1705,
+    "fields": {
+      "template": 42,
+      "question": 270,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1706,
+    "fields": {
+      "template": 42,
+      "question": 261,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1707,
+    "fields": {
+      "template": 42,
+      "question": 265,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1708,
+    "fields": {
+      "template": 42,
+      "question": 264,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1709,
+    "fields": {
+      "template": 43,
+      "question": 259,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1710,
+    "fields": {
+      "template": 43,
+      "question": 260,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1711,
+    "fields": {
+      "template": 43,
+      "question": 255,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1712,
+    "fields": {
+      "template": 43,
+      "question": 264,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1713,
+    "fields": {
+      "template": 43,
+      "question": 261,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1714,
+    "fields": {
+      "template": 43,
+      "question": 254,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1715,
+    "fields": {
+      "template": 43,
+      "question": 253,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1716,
+    "fields": {
+      "template": 43,
+      "question": 270,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1717,
+    "fields": {
+      "template": 43,
+      "question": 268,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1718,
+    "fields": {
+      "template": 43,
+      "question": 256,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1719,
+    "fields": {
+      "template": 43,
+      "question": 263,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1720,
+    "fields": {
+      "template": 43,
+      "question": 262,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1721,
+    "fields": {
+      "template": 43,
+      "question": 252,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1722,
+    "fields": {
+      "template": 43,
+      "question": 251,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1723,
+    "fields": {
+      "template": 43,
+      "question": 250,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1724,
+    "fields": {
+      "template": 43,
+      "question": 266,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1725,
+    "fields": {
+      "template": 43,
+      "question": 257,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1726,
+    "fields": {
+      "template": 43,
+      "question": 269,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1727,
+    "fields": {
+      "template": 43,
+      "question": 267,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1728,
+    "fields": {
+      "template": 43,
+      "question": 271,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1729,
+    "fields": {
+      "template": 43,
+      "question": 258,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1730,
+    "fields": {
+      "template": 43,
+      "question": 265,
+      "order": 22
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1731,
+    "fields": {
+      "template": 44,
+      "question": 269,
+      "order": 1
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1732,
+    "fields": {
+      "template": 44,
+      "question": 266,
+      "order": 2
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1733,
+    "fields": {
+      "template": 44,
+      "question": 255,
+      "order": 3
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1734,
+    "fields": {
+      "template": 44,
+      "question": 267,
+      "order": 4
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1735,
+    "fields": {
+      "template": 44,
+      "question": 251,
+      "order": 5
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1736,
+    "fields": {
+      "template": 44,
+      "question": 257,
+      "order": 6
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1737,
+    "fields": {
+      "template": 44,
+      "question": 256,
+      "order": 7
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1738,
+    "fields": {
+      "template": 44,
+      "question": 259,
+      "order": 8
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1739,
+    "fields": {
+      "template": 44,
+      "question": 250,
+      "order": 9
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1740,
+    "fields": {
+      "template": 44,
+      "question": 262,
+      "order": 10
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1741,
+    "fields": {
+      "template": 44,
+      "question": 260,
+      "order": 11
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1742,
+    "fields": {
+      "template": 44,
+      "question": 258,
+      "order": 12
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1743,
+    "fields": {
+      "template": 44,
+      "question": 253,
+      "order": 13
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1744,
+    "fields": {
+      "template": 44,
+      "question": 268,
+      "order": 14
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1745,
+    "fields": {
+      "template": 44,
+      "question": 261,
+      "order": 15
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1746,
+    "fields": {
+      "template": 44,
+      "question": 265,
+      "order": 16
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1747,
+    "fields": {
+      "template": 44,
+      "question": 254,
+      "order": 17
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1748,
+    "fields": {
+      "template": 44,
+      "question": 264,
+      "order": 18
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1749,
+    "fields": {
+      "template": 44,
+      "question": 270,
+      "order": 19
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1750,
+    "fields": {
+      "template": 44,
+      "question": 252,
+      "order": 20
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1751,
+    "fields": {
+      "template": 44,
+      "question": 263,
+      "order": 21
+    }
+  },
+  {
+    "model": "knowledgetest.writtentesttemplatequestion",
+    "pk": 1752,
+    "fields": {
+      "template": 44,
+      "question": 271,
+      "order": 22
+    }
+  }
+]

--- a/loaddata/knowledge-test-demo/refresh_seed_from_tenant.sh
+++ b/loaddata/knowledge-test-demo/refresh_seed_from_tenant.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# refresh_seed_from_tenant.sh
+#
+# Refreshes the knowledge-test seed fixtures in this repo by re-dumping the
+# full "test bank" from a SOURCE tenant (default: tenant-ssc, which holds the
+# large corpus of test questions) and SANITIZING them for portable import.
+#
+# Why sanitization is required (cross-tenant traps):
+#   * Question.updated_by        -> Member FK.  The member only exists in the
+#     source tenant; if left as a pk, `loaddata` FAILS against any other
+#     tenant (it tries to resolve a nonexistent Member).  -> nulled.
+#   * WrittenTestTemplate.created_by -> User FK.  Same problem.             -> nulled.
+#   * Question.media             -> FileField under {CLUB_PREFIX}/media/...,
+#     i.e. a per-tenant GCS path the target tenant does not have.           -> stripped.
+# Categories, templates, the template-question through table, and presets have
+# no member/user/media references and are exported verbatim.
+#
+# Models captured (the portable "test bank"):
+#   knowledgetest.QuestionCategory
+#   knowledgetest.Question
+#   knowledgetest.WrittenTestTemplate
+#   knowledgetest.WrittenTestTemplateQuestion   (the M2M through-table)
+#   knowledgetest.TestPreset
+#
+# Deliberately EXCLUDED (per-member history, not part of a question bank):
+#   WrittenTestAttempt, WrittenTestAnswer, WrittenTestAssignment
+#
+# What it does:
+#   1. Locates a long-running app pod in the source tenant's namespace.
+#   2. Dumps the five models inside that pod (plain FK pks, NOT --natural-foreign).
+#   3. Copies the JSON into loaddata/knowledge-test-demo/ and sanitizes in place.
+#   4. Prints before/after row counts and a per-file sanitization summary.
+#   5. Prints a `git diff --stat` hint. It does NOT commit or push.
+#
+# Usage:
+#   bash loaddata/knowledge-test-demo/refresh_seed_from_tenant.sh [namespace]
+#     namespace   optional, defaults to tenant-ssc
+#
+# Requirements: kubectl authenticated to the cluster, repo checked out.
+
+set -euo pipefail
+
+NS="${1:-tenant-ssc}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$SCRIPT_DIR"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# (Model label, app.Model for dumpdata, fixture filename)
+MODELS=(
+    "QuestionCategory|knowledgetest.QuestionCategory|knowledgetest.QuestionCategory.json"
+    "Question|knowledgetest.Question|knowledgetest.Question.json"
+    "WrittenTestTemplate|knowledgetest.WrittenTestTemplate|knowledgetest.WrittenTestTemplate.json"
+    "WrittenTestTemplateQuestion|knowledgetest.WrittenTestTemplateQuestion|knowledgetest.WrittenTestTemplateQuestion.json"
+    "TestPreset|knowledgetest.TestPreset|knowledgetest.TestPreset.json"
+)
+
+echo "==> Source namespace: $NS"
+
+POD="$(kubectl get pods -n "$NS" -o name \
+        | grep -E 'django-app' \
+        | grep -vE 'clearsessions|expire|notify|process|send|cron' \
+        | head -1 | sed -E 's#^pods?/##')"
+
+if [[ -z "$POD" ]]; then
+    echo "ERROR: no long-running app pod found in namespace $NS" >&2
+    exit 1
+fi
+echo "==> Source pod: $POD"
+
+echo
+echo "==> Row counts BEFORE refresh (repo)"
+python3 - "$FIXTURE_DIR" <<'PY'
+import json, os, sys
+d = sys.argv[1]
+for name in ("QuestionCategory", "Question", "WrittenTestTemplate",
+             "WrittenTestTemplateQuestion", "TestPreset"):
+    p = f"{d}/knowledgetest.{name}.json"
+    try:
+        print(f"    {name}: {len(json.load(open(p)))}")
+    except FileNotFoundError:
+        print(f"    {name}: (missing)")
+PY
+
+echo
+echo "==> Dumping from source tenant (plain FK pks, no --natural-foreign)"
+for entry in "${MODELS[@]}"; do
+    LABEL="${entry%%|*}"; rest="${entry#*|}"
+    MODEL="${rest%%|*}"
+    echo "    dumpdata $MODEL"
+    kubectl exec -n "$NS" -c django "$POD" -- \
+        python manage.py dumpdata "$MODEL" --indent 2 -o "/tmp/kt_$LABEL.json" 2>/dev/null
+    kubectl cp "$NS/$POD:/tmp/kt_$LABEL.json" "$FIXTURE_DIR/knowledgetest.$LABEL.json" -c django 2>&1 \
+        | grep -viE 'tar: Removing|exiting' || true
+done
+kubectl exec -n "$NS" -c django "$POD" -- bash -c 'rm -f /tmp/kt_*.json'
+
+echo
+echo "==> Sanitizing fixtures for portable import"
+python3 - "$FIXTURE_DIR" <<'PY'
+import json, sys
+d = sys.argv[1]
+
+# Per-model field sanitization: field -> rule.
+#   "null"  -> set the FK field to None (member/user only exists in source)
+#   "strip" -> set the media FileField to None (per-tenant GCS path)
+RULES = {
+    "knowledgetest.question": {"updated_by": "null", "media": "strip"},
+    "knowledgetest.writtentesttemplate": {"created_by": "null"},
+    # QuestionCategory, WrittenTestTemplateQuestion, TestPreset have no
+    # member/user/media references, so they are exported verbatim.
+}
+
+summary = {}
+for fn in (
+    "knowledgetest.QuestionCategory.json",
+    "knowledgetest.Question.json",
+    "knowledgetest.WrittenTestTemplate.json",
+    "knowledgetest.WrittenTestTemplateQuestion.json",
+    "knowledgetest.TestPreset.json",
+):
+    path = f"{d}/{fn}"
+    with open(path) as fh:
+        data = json.load(fh)
+    nulls = strips = 0
+    for obj in data:
+        model = obj.get("model")
+        fields = obj.get("fields", {})
+        for fname, rule in RULES.get(model, {}).items():
+            if rule == "null" and fields.get(fname) not in (None, ""):
+                nulls += 1
+                fields[fname] = None
+            elif rule == "strip" and fields.get(fname) not in (None, ""):
+                strips += 1
+                fields[fname] = None
+    with open(path, "w") as fh:
+        json.dump(data, fh, indent=2)
+        fh.write("\n")
+    summary[fn] = (len(data), nulls, strips)
+
+for fn, (n, nulls, strips) in summary.items():
+    extras = []
+    if nulls:
+        extras.append(f"{nulls} member/user FK(s) nulled")
+    if strips:
+        extras.append(f"{strips} media path(s) stripped")
+    suffix = (" (" + ", ".join(extras) + ")") if extras else " (no member/media refs)"
+    print(f"    {fn}: {n} objects{suffix}")
+PY
+
+echo
+echo "==> Row counts AFTER refresh (repo)"
+python3 - "$FIXTURE_DIR" <<'PY'
+import json, sys
+d = sys.argv[1]
+for name in ("QuestionCategory", "Question", "WrittenTestTemplate",
+             "WrittenTestTemplateQuestion", "TestPreset"):
+    n = len(json.load(open(f"{d}/knowledgetest.{name}.json")))
+    print(f"    {name}: {n}")
+PY
+
+echo
+echo "==> Review the diff before committing:"
+echo
+echo "    cd $REPO_ROOT"
+echo "    git status --short loaddata/knowledge-test-demo/"
+echo "    git diff --stat loaddata/knowledge-test-demo/"
+echo
+echo "Then commit via the normal feature-branch + PR flow (NEVER commit to main)."

--- a/loaddata/knowledge-test-demo/refresh_seed_from_tenant.sh
+++ b/loaddata/knowledge-test-demo/refresh_seed_from_tenant.sh
@@ -61,7 +61,7 @@ echo "==> Source namespace: $NS"
 POD="$(kubectl get pods -n "$NS" -o name \
         | grep -E 'django-app' \
         | grep -vE 'clearsessions|expire|notify|process|send|cron' \
-        | head -1 | sed -E 's#^pods?/##')"
+        | head -1 | sed -E 's#^pods?/##' || true)"
 
 if [[ -z "$POD" ]]; then
     echo "ERROR: no long-running app pod found in namespace $NS" >&2
@@ -103,13 +103,21 @@ import json, sys
 d = sys.argv[1]
 
 # Per-model field sanitization: field -> rule.
-#   "null"  -> set the FK field to None (member/user only exists in source)
-#   "strip" -> set the media FileField to None (per-tenant GCS path)
+#   "null"          -> set the FK field to None (member/user only exists in source)
+#   "strip"         -> set the media FileField to "" (per-tenant GCS path not in target)
+#   "generic_title" -> replace a personal-name-laden template name (e.g. "Test by
+#                      Piet Barber on 2026-02-15") with a stable, leakage-free
+#                      generic title ("Written test <pk>") so a receiving club
+#                      sees no source-club instructor names. The meaningful test
+#                      type is retained in the (preserved) description field.
 RULES = {
     "knowledgetest.question": {"updated_by": "null", "media": "strip"},
-    "knowledgetest.writtentesttemplate": {"created_by": "null"},
+    "knowledgetest.writtentesttemplate": {
+        "created_by": "null",
+        "name": "generic_title",
+    },
     # QuestionCategory, WrittenTestTemplateQuestion, TestPreset have no
-    # member/user/media references, so they are exported verbatim.
+    # member/user/media/name references, so they are exported verbatim.
 }
 
 summary = {}
@@ -123,7 +131,7 @@ for fn in (
     path = f"{d}/{fn}"
     with open(path) as fh:
         data = json.load(fh)
-    nulls = strips = 0
+    nulls = strips = generalized = 0
     for obj in data:
         model = obj.get("model")
         fields = obj.get("fields", {})
@@ -133,18 +141,24 @@ for fn in (
                 fields[fname] = None
             elif rule == "strip" and fields.get(fname) not in (None, ""):
                 strips += 1
-                fields[fname] = None
+                fields[fname] = ""
+            elif rule == "generic_title":
+                if fields.get("name") is not None:
+                    fields["name"] = f"Written test {obj['pk']}"
+                    generalized += 1
     with open(path, "w") as fh:
         json.dump(data, fh, indent=2)
         fh.write("\n")
-    summary[fn] = (len(data), nulls, strips)
+    summary[fn] = (len(data), nulls, strips, generalized)
 
-for fn, (n, nulls, strips) in summary.items():
+for fn, (n, nulls, strips, generalized) in summary.items():
     extras = []
     if nulls:
         extras.append(f"{nulls} member/user FK(s) nulled")
     if strips:
         extras.append(f"{strips} media path(s) stripped")
+    if generalized:
+        extras.append(f"{generalized} template name(s) generalized")
     suffix = (" (" + ", ".join(extras) + ")") if extras else " (no member/media refs)"
     print(f"    {fn}: {n} objects{suffix}")
 PY


### PR DESCRIPTION
## Summary

Exports the written-test question bank from a source tenant (default `tenant-ssc`) as sanitized `dumpdata` fixtures and imports them into an empty tenant. Mirrors the existing `syllabus-demo` pattern from PR #1019.

The intent is onboarding a new club with a ready-made knowledge-test bank without re-authoring hundreds of questions.

## What's in the seed

Full test bank, **member history excluded**:

| Model | Rows |
|---|---|
| `QuestionCategory` | 15 |
| `Question` | 276 |
| `WrittenTestTemplate` | 44 |
| `WrittenTestTemplateQuestion` (through) | 1752 |
| `TestPreset` | 5 |

`WrittenTestAttempt` / `WrittenTestAnswer` / `WrittenTestAssignment` are **deliberately not seeded** — they are per-member attempt history and must not leak across tenants.

## Cross-tenant traps handled at refresh time

| Trap | Handling |
|---|---|
| `Question.updated_by` (Member FK) | nulled — member doesn't exist in target |
| `WrittenTestTemplate.created_by` (User FK) | nulled — user doesn't exist in target |
| `Question.media` (per-tenant GCS path) | stripped — file not present in target |
| FK portability | dumped **without** `--natural-foreign` so FKs stay integer pks that can be nulled |

## Tooling

- `loaddata/knowledge-test-demo/refresh_seed_from_tenant.sh` — dump from a source tenant pod, `kubectl cp` to the repo, sanitize, print per-file tallies.
- `loaddata/knowledge-test-demo/import_knowledge_test_demo.sh` — safe-by-default importer:
  - preflight reads current row counts;
  - **aborts (exit 3)** if the target already has a bank unless `--force` is given;
  - loads the 5 fixtures in dependency order;
  - verifies **every fixture primary key is present** post-load (a delta-based count would be wrong when pks overlap on a non-empty tenant).
  - Exit codes: `0` ok · `1` missing fixture · `2` bad args · `3` already populated · `4` can't read counts · `5` verification failed.

## Docs

- `docs/runbooks/knowledge-test-import.md` — full runbook (prereqs, refresh, in-pod import, expected output, rollback, troubleshooting, exit codes).
- `docs/runbooks/README.md` — index row added.

## Validation

Live-tested against the `tenant-demo` cluster:
- `--force` import → 15 / 276 / 44 / 1752 / 5 loaded, **all fixture pks present**, exit 0.
- Re-run without `--force` → correctly **aborted (exit 3)** with the "already has a knowledge test bank (276 questions)" guard.

`tenant-demo` was left with the imported bank per decision during the session.

## Notes

- The deployed pod image does **not** ship the repo's `loaddata/` tree, so the import script must be copied into the pod first (`kubectl cp loaddata/knowledge-test-demo "$NS/$POD:/tmp/kseed" -c django`). Documented in the runbook.
- Unrelated to this change: the `legacy` database connection in `manage2soar/settings.py` points at a port (5555) that was a retired SSH tunnel to a long-gone legacy DB. Worth a separate cleanup issue at some point, since it blocks creating Django test databases locally.