### PR TITLE
Add portable club-qualifications seed (catalog) with icon-copy tooling

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -12,6 +12,7 @@ This directory contains operational runbooks for system administrators managing 
 | [Troubleshooting Guide](troubleshooting.md) | Common issues and solutions | Production incidents |
 | [Training Syllabus Import](syllabus-import.md) | Copy a known-good syllabus from one tenant to an empty tenant | Onboarding a new club's curriculum |
 | [Knowledge Test Bank Import](knowledge-test-import.md) | Copy the written-test question bank (questions, templates, presets) from one tenant to another | Onboarding a new club's test bank |
+| [Club Qualifications Import](club-qualifications-import.md) | Copy the club's qualification catalog (types, scope, tooltip) from one tenant to an empty tenant; includes a GCS copy of the icon objects so they render out of the box | Onboarding a new club's qualification catalog |
 | [Ansible Playbook Guide](ansible-playbook-guide.md) | Complete reference for all Ansible playbooks | Reference |
 | [Database Operations](database-operations.md) | PostgreSQL backups, restoration, troubleshooting | Database changes, disaster recovery |
 | Security Operations *(coming soon)* | Secret rotation, vulnerability patching | Security incidents, monthly maintenance |

--- a/docs/runbooks/club-qualifications-import.md
+++ b/docs/runbooks/club-qualifications-import.md
@@ -1,0 +1,316 @@
+# Club Qualifications Import Runbook
+
+This runbook explains how to copy the **club's qualification catalog** (the
+list of qualification types a club recognizes — CFI, ASK-21 endorsements,
+tow-pilot endorsements, etc.) out of one tenant (the reference `tenant-ssc`
+cluster, which holds the "good-enough" set) and import it into **another**
+tenant, including the icon images that go with each qualification.
+
+It follows the **IaC-first** philosophy: the seed fixture and the import/refresh
+scripts live **in the repo** so the operation is reproducible, reviewable, and
+does not depend on copying files around by hand.
+
+> This mirrors the [Knowledge Test Bank Import](knowledge-test-import.md) and
+> [Training Syllabus Import](syllabus-import.md) runbooks. The three seeds are
+> independent and do not interfere with each other.
+
+## 🎯 Quick Reference
+
+| Operation | Command |
+|-----------|---------|
+| **Refresh the repo seed from a source tenant** | `bash loaddata/club-qualifications-demo/refresh_seed_from_tenant.sh` |
+| Refresh from a specific source tenant | `bash loaddata/club-qualifications-demo/refresh_seed_from_tenant.sh tenant-ssc` |
+| **Import into an empty tenant (safe, recommended)** | `bash loaddata/club-qualifications-demo/import_club_qualifications_demo.sh` |
+| Force-load (upsert, **no delete**) | `bash loaddata/club-qualifications-demo/import_club_qualifications_demo.sh --force` |
+| Skip the icon copy (re-upload icons later) | `bash loaddata/club-qualifications-demo/import_club_qualifications_demo.sh --no-icons` |
+| Force-copy icons over existing objects | `bash loaddata/club-qualifications-demo/import_club_qualifications_demo.sh --overwrite-icons` |
+| Copy icons from a non-default source prefix | `bash loaddata/club-qualifications-demo/import_club_qualifications_demo.sh --source-prefix masa` |
+
+## What "club qualifications" is
+
+The club's qualification catalog is modeled by a single model in the
+`instructors` app. It is **club-owned content** and safe to move between
+tenants.
+
+| Model | Purpose | Row count in this seed |
+|-------|---------|------------------------|
+| `instructors.ClubQualificationType` | Qualification types the club recognizes (code, name, icon, scope, tooltip) | 30 |
+
+> ⚠️ **Excluded (member-specific):** `instructors.MemberQualification`.
+> This model records *which member holds which qualification*, plus the
+> instructor who awarded it, the award date, and the expiration date. It
+> references `Member` rows that only exist in the source tenant. Do **not**
+> include it when moving the catalog between clubs — the new tenant's members
+> will earn their qualifications through normal club processes.
+
+## Why we copy icons (not strip them)
+
+The `icon` field is an `ImageField` with a **prefix-free relative path**
+(e.g. `quals/icons/CFI-abc123.jpg`). In production, `MEDIA_URL` is
+constructed from the **rendering tenant's** `CLUB_PREFIX`:
+
+```
+https://storage.googleapis.com/{GS_BUCKET_NAME}/{CLUB_PREFIX}/media/
+```
+
+(`manage2soar/settings.py` — `GS_MEDIA_LOCATION = f"{CLUB_PREFIX}/media"`.)
+
+That means when the new tenant renders `{{ qual.icon.url }}`, the browser
+resolves it to `…/{GS_BUCKET_NAME}/{NEW_PREFIX}/media/quals/icons/...` —
+**the new tenant's own media area**, not the source tenant's. If we only ran
+`loaddata` and left the DB value as-is, the icons would **404** for the new
+tenant (their `{NEW_PREFIX}/media/quals/icons/` area is empty), because the
+objects only exist under the source prefix in the shared bucket.
+
+So the import script **copies the icon objects** from the source tenant's
+media area into the target tenant's media area, using the
+`google.cloud.storage` Python client (already a transitive dependency of
+`django-storages` in the pod image — no `gsutil`/`gcloud` CLI required).
+
+The copy is **no-clobber by default**: if a destination object already exists
+(e.g. the tenant already uploaded their own icon for that qualification), it is
+skipped. Pass `--overwrite-icons` to force-copy over existing objects.
+
+> This is a deliberate choice over the alternative of stripping the icon to
+> `""` (which the knowledge-test seed does for `Question.media`). Qualification
+> icons are **generic graphics**, not personal data, so there is no privacy
+> concern in copying them — and a new tenant gets working icons out of the box
+> rather than a broken-image flash.
+
+## Repo layout
+
+```
+loaddata/club-qualifications-demo/
+├── import_club_qualifications_demo.sh   # safe import script (preflight + icon copy + load + verify)
+├── refresh_seed_from_tenant.sh          # refresh repo fixture from a source tenant (no sanitization needed)
+└── instructors.ClubQualificationType.json  # 30 qualification types
+```
+
+---
+
+## Step 0 — Prerequisites
+
+- `kubectl` authenticated to the GKE cluster
+  (`gcloud auth login` + `gcloud container clusters get-credentials
+  manage2soar-cluster --region us-east1`).
+- You know the **target** tenant's namespace (e.g. `tenant-masa`) and, if
+  refreshing, the **source** tenant's namespace (default `tenant-ssc`).
+- The target tenant's pod has the `GS_BUCKET_NAME` and `CLUB_PREFIX` env vars
+  set (they are, by default, via the K8s secrets manifest).
+- The pod's service account has `storage.objects.get` / `storage.objects.create`
+  on the shared GCS bucket (it does — that's how the app itself serves media).
+
+### Find a tenant's app pod
+
+```bash
+NS=tenant-masa   # <-- the tenant you mean
+POD=$(kubectl get pods -n "$NS" -o name \
+  | grep -E 'django-app' \
+  | grep -vE 'clearsessions|expire|notify|process|send|cron' \
+  | head -1 | sed -E 's#^pods?/##')
+```
+
+The long-running pod (not the cronjob one-shots) is the one to `exec` into. The
+Django container is named `django`.
+
+---
+
+## Step 1 — Refresh the repo seed from a source tenant
+
+Only needed **if you are (re)capturing** the seed (e.g. `tenant-ssc` added or
+removed qualifications, or you want to seed from a different source club). The
+fixture already committed in `loaddata/club-qualifications-demo/` was captured
+from `tenant-ssc`.
+
+```bash
+# From the default source (tenant-ssc):
+bash loaddata/club-qualifications-demo/refresh_seed_from_tenant.sh
+
+# Or from an explicit source namespace:
+bash loaddata/club-qualifications-demo/refresh_seed_from_tenant.sh tenant-ssc
+```
+
+The script:
+
+1. Dumps the model via `dumpdata` **inside the source tenant's app pod** (so
+   DB credentials are correct), without `--natural-foreign` (the model has no
+   FKs, but this keeps the fixture format consistent with the other seeds).
+2. Copies the JSON out with `kubectl cp`.
+3. Prints before/after object counts and a summary of how many rows carry
+   icons (informational — the icon-copy step at import time will handle them).
+
+> No sanitization is performed: the model has no Member/User FKs and the icon
+> is a generic graphic (not PII). The `code` and `name` fields are generic
+> labels that travel fine between tenants.
+
+It does **not** commit. Review the diff, then commit via a feature branch + PR
+(**never** push to `main` directly).
+
+---
+
+## Step 2 — Import into the target tenant
+
+The import script is **safe-by-default**. It:
+
+1. **Preflights**: counts `ClubQualificationType` rows in the **target** tenant.
+2. **Aborts** (exit code 3) if the target already has any, unless you pass
+   `--force`.
+3. **Copies icons** from the source tenant's GCS media area into the target
+   tenant's area (no-clobber by default; `--overwrite-icons` to force).
+4. **Loads** the fixture with `loaddata`.
+5. **Verifies** that every fixture primary key is now present in the target.
+
+### Recommended: run inside the target tenant's app pod
+
+```bash
+NS=tenant-masa   # <-- target tenant
+POD=$(kubectl get pods -n "$NS" -o name | grep -E 'django-app' \
+  | grep -vE 'clearsessions|expire|notify|process|send|cron' | head -1 | sed -E 's#^pods?/##')
+
+# The deployed image does not always ship the repo's loaddata/ tree, so copy it in:
+kubectl cp "loaddata/club-qualifications-demo" "$NS/$POD:/tmp/cseed" -c django
+
+kubectl exec -n "$NS" -c django "$POD" -- \
+  bash /tmp/cseed/import_club_qualifications_demo.sh
+```
+
+Expected output on a clean (empty) target:
+
+```
+==> Preflight: checking that the target tenant has no existing qualification catalog
+    ClubQualificationType: 0
+
+==> Copying qualification icons from the source tenant's GCS media area
+    into the target tenant's GCS media area (no-clobber by default)
+    Found 30 distinct icon path(s) in the fixture.
+    icons: copied=30 skipped_existing=0
+
+==> Loading qualification catalog fixtures
+    loaddata instructors.ClubQualificationType.json
+    ...
+
+==> Verifying that every fixture primary key is now present in the target
+    ClubQualificationType: fixture=30 present=  30  all_present=True
+
+==> Post-load count: ClubQualificationType: 30
+```
+
+Expected output on a tenant that **already** has qualifications (script refuses):
+
+```
+==> Preflight: checking that the target tenant has no existing qualification catalog
+    ClubQualificationType: 12
+
+ABORT: This tenant already has a qualification catalog (12 rows).
+This script is meant for an EMPTY catalog.
+
+If you are absolutely sure you want to overwrite it, re-run with --force.
+NOTE: --force upserts by primary key and does NOT delete extra rows.
+```
+
+> 🖊️ **Per-club review:** the seed is the *reference club's* catalog. After
+> import, the receiving club **should review** the qualification types in the
+> admin (`instructors → ClubQualificationType`) and adjust wording, scope
+> (`applies_to`), and icons to their own standards before using them to track
+> member qualifications.
+
+---
+
+## Rollback
+
+**Destructive delete** — confirm the target tenant is the right one first.
+
+```bash
+NS=tenant-masa
+POD=$(kubectl get pods -n "$NS" -o name | grep -E 'django-app' \
+  | grep -vE 'clearsessions|expire|notify|process|send|cron' | head -1 | sed -E 's#^pods?/##')
+
+kubectl exec -n "$NS" -c django "$POD" -- python manage.py shell -c '
+from instructors.models import ClubQualificationType
+n = ClubQualificationType.objects.delete()[0]
+print(f"deleted {n} qualification types")
+'
+```
+
+> ⚠️ **Icon objects are NOT rolled back.** If the import copied icons into the
+> tenant's GCS media area, they remain after the DB rollback. That is
+> generally fine (they are generic graphics and harmless to keep), but if you
+> want a clean slate, delete them with:
+>
+> ```bash
+> gcloud storage rm -r "gs://$GS_BUCKET_NAME/$CLUB_PREFIX/media/quals/icons/"
+> ```
+>
+> (Or with the Python client, if `gcloud` CLI is unavailable.)
+
+> If the target tenant had **its own** pre-existing catalog that you upserted
+> over with `--force`, this rollback will also delete the club's original rows
+> — there is no way to distinguish them afterward. Prefer testing `--force`
+> against a scratch/demo tenant first.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `container django-app-ssc is not valid for pod ...` | Wrong `-c` container name | Use `-c django` (container is named `django`) |
+| `ABORT: This tenant already has a qualification catalog` | Target is not empty | Intended protection. Use `--force` only if you truly want an upsert, or roll back first. |
+| `django.core.exceptions.ImproperlyConfigured` | Ran `manage.py` without the tenant env | Run **inside** the tenant pod (env already set) — not locally with the wrong `DB_*`. |
+| `IntegrityError` on `loaddata` | Out-of-order load / stale rows | Roll back and retry. (Single-model seed, so this is unlikely.) |
+| `ERROR: fixture not found: ...` | Ran the script without the fixtures next to it | `kubectl cp` the whole `loaddata/club-qualifications-demo` dir first, then run the script from there. |
+| `ERROR: GS_BUCKET_NAME is not set in the environment.` (exit 7) | Ran outside a pod / env not set | Run inside the tenant pod, or pass `--no-icons` to skip the icon copy. |
+| `ERROR: icon copy did not complete successfully.` (exit 6) | GCS permission or network failure | Check the pod SA's GCS permissions on the shared bucket, retry. Or pass `--no-icons` to skip. |
+| Icons 404 in the new tenant's UI after import | Icon copy was skipped or failed | Re-run with `--overwrite-icons`, or re-upload the icons via the admin. |
+
+### `--force` semantics (important)
+
+`loaddata` **upserts by primary key**. For a non-empty target:
+
+- Fixture pks that already exist in the target are **replaced** with the fixture
+  values.
+- Target rows with pks **not** in the fixture are **left alone** (not deleted).
+- The result is a **mixture** of the target's original rows and the seed's rows.
+
+The post-load count is therefore **not** required to equal the fixture count;
+the script instead verifies that **every fixture pk is present**, which holds in
+both the empty and the collision cases.
+
+### Icon-copy semantics
+
+- **Default (no-clobber):** if the destination object
+  (`gs://{GS_BUCKET_NAME}/{CLUB_PREFIX}/media/{icon}`) already exists, it is
+  **skipped**. The icon in the DB is unchanged. Safe to re-run.
+- **`--overwrite-icons`:** force-copies over existing destination objects. Use
+  this if the source tenant's icons are newer / better and you want to replace
+  the target's.
+- **`--no-icons`:** skips the GCS copy phase entirely. The DB icon values are
+  preserved (so re-running the copy later is still possible), but the new
+  tenant's icons will 404 until they re-upload their own.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | A fixture file is missing |
+| 2 | Unknown CLI argument |
+| 3 | Target not empty and `--force` not given |
+| 4 | Could not read pre-load counts |
+| 5 | Post-load verification failed (missing pk) |
+| 6 | GCS icon copy failed |
+| 7 | GCS env missing (`GS_BUCKET_NAME` or `CLUB_PREFIX` not set) |
+
+---
+
+## Safety & policy reminders
+
+- **Never** commit to `main`. Use `feature/...` + PR.
+- **Never** `--force` against a tenant you are not sure about — it upserts by PK
+  and **does not delete** extra rows, so you can end up with a mixture of the
+  club's own and the seed's qualification types.
+- This runbook only moves the **catalog** (`ClubQualificationType`). Member
+  qualifications (`MemberQualification`) are **member-owned** and must not be
+  copied between clubs.
+- After any `--force` upsert on a tenant that had its own catalog, treat the
+  result as needing a **human review** before it is used to track members.

--- a/loaddata/club-qualifications-demo/import_club_qualifications_demo.sh
+++ b/loaddata/club-qualifications-demo/import_club_qualifications_demo.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+#
+# import_club_qualifications_demo.sh
+#
+# Imports the portable club-qualifications catalog captured from the
+# tenant-ssc cluster (the "good-enough" set of 30 qualification types)
+# into the CURRENT tenant (whichever DB this script's environment points at).
+#
+# The seed is NOT sanitized:
+#   * No Member/User FKs to null.
+#   * `icon` is a prefix-free GCS relative path (e.g.
+#     `quals/icons/CFI-abc123.jpg`). This is a generic qualification graphic,
+#     not PII. We preserve it in the DB.
+#
+# The one cross-tenant concern — the icon OBJECTS — is handled by an
+# ICON-COPY phase that runs BEFORE loaddata. Because `MEDIA_URL` in prod is
+# `https://storage.googleapis.com/{GS_BUCKET_NAME}/{CLUB_PREFIX}/media/`
+# (where `CLUB_PREFIX` is the RENDERING tenant's prefix), a new tenant's own
+# `{NEW_PREFIX}/media/quals/icons/` area is empty. If we only ran loaddata,
+# the icons would 404. So this script copies the icon objects from the
+# source tenant's area into the new tenant's area using the `google.cloud.storage`
+# Python client (already a transitive dep of `django-storages` in the pod).
+#
+#   Default behavior: NO-CLOBBER. If a destination object already exists, it
+#   is skipped (so a re-run is safe and never destroys a tenant's customized
+#   icons). Use --overwrite-icons to force-copy over existing objects.
+#
+# Intended use (production / per-tenant):
+#   The deployed image may not ship this repo's loaddata/ tree, so copy the
+#   seed into the pod first, then run it from the copied location:
+#     NS=<tenant-ns>
+#     POD=$(kubectl get pods -n "$NS" -o name | grep -E 'django-app' \
+#           | grep -vE 'clearsessions|expire|notify|process|send|cron' | head -1 \
+#           | sed -E 's#^pods?/##')
+#     kubectl cp "loaddata/club-qualifications-demo" "$NS/$POD:/tmp/cseed" -c django
+#     kubectl exec -n "$NS" -c django "$POD" -- bash /tmp/cseed/import_club_qualifications_demo.sh
+#   (See docs/runbooks/club-qualifications-import.md for the full walkthrough.)
+#
+# Local / dev use (with your Django env already active):
+#   bash loaddata/club-qualifications-demo/import_club_qualifications_demo.sh
+#
+# Options:
+#   -f, --force              Allow overwriting an existing catalog (upsert, no delete).
+#   -n, --no-icons           Skip the GCS icon-copy phase (icon DB values are
+#                            preserved; the new tenant re-uploads icons to render).
+#   -o, --overwrite-icons    Force-copy icons over existing objects in the
+#                            target area (default is no-clobber).
+#   -s, --source-prefix PFX  Source tenant prefix to copy icons from
+#                            (default: ssc). Separate from the target's
+#                            CLUB_PREFIX which comes from the pod env.
+#   -h, --help               Show this help.
+#
+# Safety notes:
+#   * --force does NOT delete existing rows. loaddata upserts by (model, pk);
+#     rows with the same pk are replaced, other rows are left alone.
+#   * Icon copy is NO-CLOBBER by default. Use --overwrite-icons to force.
+
+set -euo pipefail
+
+FORCE=0
+NO_ICONS=0
+OVERWRITE_ICONS=0
+SOURCE_PREFIX="ssc"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -f|--force) FORCE=1; shift ;;
+        -n|--no-icons) NO_ICONS=1; shift ;;
+        -o|--overwrite-icons) OVERWRITE_ICONS=1; shift ;;
+        -s|--source-prefix)
+            if [[ -z "${2:-}" ]]; then
+                echo "ERROR: --source-prefix requires a value" >&2
+                exit 2
+            fi
+            SOURCE_PREFIX="$2"; shift 2 ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1 (see --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Resolve the fixture directory relative to this script, so the script works
+# both from the repo root and from inside the container image.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$SCRIPT_DIR"
+export FIXTURE_DIR
+
+FIXTURES=(
+    "instructors.ClubQualificationType.json"
+)
+
+for f in "${FIXTURES[@]}"; do
+    if [[ ! -f "$FIXTURE_DIR/$f" ]]; then
+        echo "ERROR: fixture not found: $FIXTURE_DIR/$f" >&2
+        exit 1
+    fi
+done
+
+echo "==> Preflight: checking that the target tenant has no existing qualification catalog"
+
+# Django's `manage.py shell -c` prints a line like
+#     "95 objects imported automatically (use -v 2 for details)."
+# to STDOUT before our own print() runs. Filter it out so we only see the
+# count on a single line.
+COUNT="$(
+    python manage.py shell -c '
+from instructors.models import ClubQualificationType
+print(ClubQualificationType.objects.count())
+' 2>/dev/null | grep -EoE '^[0-9]+$' | head -n1 || true
+)"
+
+if [[ -z "$COUNT" ]]; then
+    echo "    ERROR: could not read row count from Django shell (unexpected output)." >&2
+    echo "    Refusing to proceed without a reliable empty-check." >&2
+    exit 4
+fi
+
+echo "    ClubQualificationType: $COUNT"
+
+if [[ "$COUNT" -ne 0 ]]; then
+    if [[ "$FORCE" -eq 1 ]]; then
+        echo "    !! Existing catalog detected, but --force was given. Proceeding (upsert, no delete)."
+    else
+        echo
+        echo "ABORT: This tenant already has a qualification catalog ($COUNT rows)."
+        echo "This script is meant for an EMPTY catalog."
+        echo
+        echo "If you are absolutely sure you want to overwrite it, re-run with --force."
+        echo "NOTE: --force upserts by primary key and does NOT delete extra rows."
+        exit 3
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Icon copy phase (GCS) — copy icon objects from the source tenant's media
+# area into the target tenant's media area, so the icons resolve for the new
+# tenant (their MEDIA_URL points at their own {CLUB_PREFIX}/media/...).
+# ---------------------------------------------------------------------------
+
+if [[ "$NO_ICONS" -eq 1 ]]; then
+    echo
+    echo "==> Skipping icon copy (--no-icons). Icon DB values are preserved; the"
+    echo "    new tenant will need to re-upload icons for them to render."
+    ICON_COPY_STATUS="skipped"
+else
+    echo
+    echo "==> Copying qualification icons from the source tenant's GCS media area"
+    echo "    into the target tenant's GCS media area (no-clobber by default)"
+
+    # Extract the set of non-empty icon relative paths from the fixture.
+    ICON_PATHS="$(python3 -c '
+import json, os
+d = os.environ["FIXTURE_DIR"]
+data = json.load(open(f"{d}/instructors.ClubQualificationType.json"))
+paths = sorted({o["fields"]["icon"] for o in data if o["fields"].get("icon")})
+print("\n".join(paths))
+')"
+    ICON_COUNT="$(echo "$ICON_PATHS" | grep -c . || true)"
+    echo "    Found $ICON_COUNT distinct icon path(s) in the fixture."
+
+    if [[ "$ICON_COUNT" -eq 0 ]]; then
+        echo "    (No icons to copy — skipping GCS phase.)"
+        ICON_COPY_STATUS="empty"
+    else
+        COPY_OUT="$(
+            CQ_OVERWRITE_ICONS="$OVERWRITE_ICONS" CQ_ICON_PATHS="$ICON_PATHS" \
+            CQ_SOURCE_PREFIX="$SOURCE_PREFIX" \
+            python manage.py shell -c '
+import os
+from google.cloud import storage
+
+overwrite = os.environ.get("CQ_OVERWRITE_ICONS") == "1"
+paths = [p.strip() for p in os.environ["CQ_ICON_PATHS"].splitlines() if p.strip()]
+
+bucket_name = os.environ.get("GS_BUCKET_NAME")
+if not bucket_name:
+    print("ERROR: GS_BUCKET_NAME is not set in the environment.")
+    raise SystemExit(1)
+src_prefix = os.environ.get("CQ_SOURCE_PREFIX", "ssc")
+dst_prefix = os.environ.get("CLUB_PREFIX")
+if not dst_prefix:
+    print("ERROR: CLUB_PREFIX is not set in the environment.")
+    raise SystemExit(1)
+
+client = storage.Client()
+bucket = client.bucket(bucket_name)
+copied = skipped = 0
+for p in paths:
+    src = f"{src_prefix}/media/{p}"
+    dst = f"{dst_prefix}/media/{p}"
+    if bucket.get_blob(dst) is not None and not overwrite:
+        skipped += 1
+        continue
+    bucket.copy_blob(bucket.blob(src), bucket_name, dst)
+    copied += 1
+print(f"icons: copied={copied} skipped_existing={skipped}")
+' 2>&1
+        )" || true
+
+        echo "$COPY_OUT" | sed 's/^/    /'
+
+        if echo "$COPY_OUT" | grep -qE 'GS_BUCKET_NAME is not set|CLUB_PREFIX is not set'; then
+            echo "    ERROR: GCS environment is missing (GS_BUCKET_NAME / CLUB_PREFIX)." >&2
+            echo "    Run inside the tenant pod, or pass --no-icons to skip the icon copy." >&2
+            exit 7
+        fi
+        if ! echo "$COPY_OUT" | grep -qE '^icons: copied='; then
+            echo "    ERROR: icon copy did not complete successfully." >&2
+            echo "    Retry, or pass --no-icons to skip the icon copy." >&2
+            exit 6
+        fi
+        ICON_COPY_STATUS="done"
+    fi
+fi
+
+echo
+echo "==> Loading qualification catalog fixtures"
+for f in "${FIXTURES[@]}"; do
+    echo "    loaddata $f"
+    python manage.py loaddata "$FIXTURE_DIR/$f"
+done
+
+echo
+echo "==> Verifying that every fixture primary key is now present in the target"
+
+# `loaddata` upserts by primary key without deleting other rows. For an EMPTY
+# tenant this means post_count == fixture_count; for a NON-EMPTY tenant with
+# overlapping pks the counts will be higher than the fixture (existing rows
+# preserved). The invariant that holds for BOTH cases is: every primary key
+# from the fixture is now present in the target database.
+
+VERIFY="$(
+    python manage.py shell -c '
+import json, os
+d = os.environ["FIXTURE_DIR"]
+from instructors.models import ClubQualificationType
+fixture_pks = {o["pk"] for o in json.load(open(os.path.join(d, "instructors.ClubQualificationType.json")))}
+present   = set(ClubQualificationType.objects.values_list("pk", flat=True))
+missing   = fixture_pks - present
+print(f"ClubQualificationType: fixture={len(fixture_pks)} present={len(present):>5}  "
+      f"all_present={not missing}")
+if missing:
+    print(f"    MISSING pks ({len(missing)}): {sorted(missing)[:10]}")
+    raise SystemExit(1)
+' 2>&1
+)" || true
+
+echo "$VERIFY" | sed 's/^/    /'
+
+# The inner python exits non-zero on any missing pk, but the `|| true` above
+# keeps that status from tripping `set -e` (so the "MISSING pks" diagnostic
+# above is still captured into $VERIFY and printed). The all_present=True
+# check below therefore drives the script's exit code.
+if [[ -z "$VERIFY" ]] || ! echo "$VERIFY" | grep -q "all_present=True"; then
+    echo "    ERROR: at least one fixture primary key is missing from the target." >&2
+    exit 5
+fi
+
+# Post-load counts (informational only).
+POST="$(
+    python manage.py shell -c '
+from instructors.models import ClubQualificationType
+print(ClubQualificationType.objects.count())
+' 2>/dev/null | grep -EoE '^[0-9]+$' | head -n1 || true
+)"
+echo
+echo "==> Post-load count: ClubQualificationType: ${POST:-(unreadable)}"
+echo
+echo "NOTE: the qualification catalog seed is preserved as-is (no sanitization)."
+echo "      Icons were ${ICON_COPY_STATUS}. If skipped, the new tenant should re-upload"
+echo "      any icons they want to use; the DB icon paths are intact either way."

--- a/loaddata/club-qualifications-demo/import_club_qualifications_demo.sh
+++ b/loaddata/club-qualifications-demo/import_club_qualifications_demo.sh
@@ -195,7 +195,9 @@ for p in paths:
     if bucket.get_blob(dst) is not None and not overwrite:
         skipped += 1
         continue
-    bucket.copy_blob(bucket.blob(src), bucket_name, dst)
+    # Same shared bucket for source and target; copy_blob expects a Bucket
+    # object (not a string) as the destination bucket.
+    bucket.copy_blob(bucket.blob(src), bucket, dst)
     copied += 1
 print(f"icons: copied={copied} skipped_existing={skipped}")
 ' 2>&1

--- a/loaddata/club-qualifications-demo/instructors.ClubQualificationType.json
+++ b/loaddata/club-qualifications-demo/instructors.ClubQualificationType.json
@@ -316,7 +316,7 @@
   "pk": 27,
   "fields": {
     "code": "TowPilot",
-    "name": "Tow PIlot",
+    "name": "Tow Pilot",
     "icon": "quals/icons/Towpilot-qual.jpg",
     "applies_to": "both",
     "is_obsolete": false,

--- a/loaddata/club-qualifications-demo/instructors.ClubQualificationType.json
+++ b/loaddata/club-qualifications-demo/instructors.ClubQualificationType.json
@@ -1,0 +1,362 @@
+[
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 1,
+  "fields": {
+    "code": "CFI",
+    "name": "Certified Flight Instructor",
+    "icon": "quals/icons/Instructor-qual.jpg",
+    "applies_to": "rated",
+    "is_obsolete": false,
+    "tooltip": "Club-authorized instructor with FAA credentials"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 2,
+  "fields": {
+    "code": "ASK-Front",
+    "name": "ASK-21 Front Seat Endorsement",
+    "icon": "quals/icons/ASK-Front-qual.jpg",
+    "applies_to": "both",
+    "is_obsolete": false,
+    "tooltip": "Student endorsement for solo operation in ASK-21 front seat"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 3,
+  "fields": {
+    "code": "ASK-Back",
+    "name": "ASK-21 Rear Seat Endorsement",
+    "icon": "quals/icons/ASK-Back-qual.jpg",
+    "applies_to": "rated",
+    "is_obsolete": false,
+    "tooltip": "PIC endorsement for rear seat operation in ASK-21"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 4,
+  "fields": {
+    "code": "PW5-Student",
+    "name": "PW-5 Student Endorsement",
+    "icon": "quals/icons/PW-5-Student-qual.jpg",
+    "applies_to": "student",
+    "is_obsolete": false,
+    "tooltip": "Solo student authorization for PW-5"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 5,
+  "fields": {
+    "code": "PW5",
+    "name": "PW-5 Solo Endorsement",
+    "icon": "quals/icons/PW-5-qual.jpg",
+    "applies_to": "rated",
+    "is_obsolete": false,
+    "tooltip": "Endorsement for PW-5 operation"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 6,
+  "fields": {
+    "code": "Husky",
+    "name": "Tow Pilot – Husky",
+    "icon": "quals/icons/Husky-qual.jpg",
+    "applies_to": "both",
+    "is_obsolete": false,
+    "tooltip": "Tow pilot qualified in Husky aircraft"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 7,
+  "fields": {
+    "code": "Pawnee",
+    "name": "Tow Pilot – Pawnee",
+    "icon": "quals/icons/Pawnee-qual.jpg",
+    "applies_to": "both",
+    "is_obsolete": false,
+    "tooltip": "Tow pilot qualified in Pawnee aircraft"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 8,
+  "fields": {
+    "code": "SafetyMeeting2025",
+    "name": "Safety Meeting (2025)",
+    "icon": "quals/icons/SafetyMeeting-qual.jpg",
+    "applies_to": "both",
+    "is_obsolete": true,
+    "tooltip": "Has attended or completed safety meeting training for the year 2025\r\nThis is for in-person or remote attendance."
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 9,
+  "fields": {
+    "code": "Discus-CS",
+    "name": "Discus (FW & 9Y)",
+    "icon": "quals/icons/Discus-CS-qual.jpg",
+    "applies_to": "rated",
+    "is_obsolete": false,
+    "tooltip": "Rated pilots may fly the Discus CS after getting qualified."
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 10,
+  "fields": {
+    "code": "Winch",
+    "name": "Winch Launch Endorsement",
+    "icon": "quals/icons/Winch-qual.jpg",
+    "applies_to": "both",
+    "is_obsolete": false,
+    "tooltip": ""
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 11,
+  "fields": {
+    "code": "ADO",
+    "name": "Assistant Duty Officer",
+    "icon": "quals/icons/ADO-qual.jpg",
+    "applies_to": "both",
+    "is_obsolete": false,
+    "tooltip": ""
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 12,
+  "fields": {
+    "code": "ASK-Student",
+    "name": "ASK-21 solo (Student)",
+    "icon": "quals/icons/ASK-Student-qual.jpg",
+    "applies_to": "student",
+    "is_obsolete": false,
+    "tooltip": "Solo operations in either ASK-21 for non-glider-rated pilots"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 13,
+  "fields": {
+    "code": "WingRunner",
+    "name": "Wing Runner",
+    "icon": "quals/icons/Wingrunner-qual.jpg",
+    "applies_to": "both",
+    "is_obsolete": false,
+    "tooltip": "Has completed the SSA WingRunner course"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 14,
+  "fields": {
+    "code": "SafetyMeeting2023",
+    "name": "Safety Meeting for 2023",
+    "icon": "quals/icons/SafetyMeeting-qual_9D3ZH6S.jpg",
+    "applies_to": "both",
+    "is_obsolete": true,
+    "tooltip": "Safety Meeting attendee (remote or in-person) for 2023."
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 15,
+  "fields": {
+    "code": "SafetyMeeting2024",
+    "name": "Safety Meeting for 2024",
+    "icon": "quals/icons/SafetyMeeting-qual_jW1aKbH.jpg",
+    "applies_to": "both",
+    "is_obsolete": true,
+    "tooltip": "Safety Meeting attendee (remote or in-person) for 2024"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 16,
+  "fields": {
+    "code": "SafetyMeeting2022",
+    "name": "Safety Meeting for 2022",
+    "icon": "quals/icons/SafetyMeeting-qual_Jv6TNod.jpg",
+    "applies_to": "both",
+    "is_obsolete": true,
+    "tooltip": "Safety Meeting attendee (remote or in-person) for 2022"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 17,
+  "fields": {
+    "code": "SafetyMeeting2021",
+    "name": "Safety Meeting for 2021",
+    "icon": "quals/icons/SafetyMeeting-qual_CxgcwMY.jpg",
+    "applies_to": "both",
+    "is_obsolete": true,
+    "tooltip": "Safety Meeting attendee (remote or in-person) for 2021"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 18,
+  "fields": {
+    "code": "SafetyMeeting2020",
+    "name": "Safety Meeting for 2020",
+    "icon": "quals/icons/SafetyMeeting-qual_URYdHMr.jpg",
+    "applies_to": "both",
+    "is_obsolete": true,
+    "tooltip": "Safety Meeting attendee (remote or in-person) for 2020"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 19,
+  "fields": {
+    "code": "Orientation",
+    "name": "New Member Orientation Session",
+    "icon": "quals/icons/New-Member.jpg",
+    "applies_to": "both",
+    "is_obsolete": false,
+    "tooltip": "Has attended the New Member Orientation Session (in person or remotely)"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 20,
+  "fields": {
+    "code": "Club-Bud",
+    "name": "Club Bud",
+    "icon": "quals/icons/Club-Bud.jpg",
+    "applies_to": "both",
+    "is_obsolete": true,
+    "tooltip": "Has been assigned a \"Club Bud\""
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 21,
+  "fields": {
+    "code": "Sprite-Student",
+    "name": "Sprite Student",
+    "icon": "quals/icons/Sprite-Student.jpg",
+    "applies_to": "student",
+    "is_obsolete": true,
+    "tooltip": "Was once qualified to solo the SGS 1-36 \"Sprite\" as a student"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 22,
+  "fields": {
+    "code": "Sprite",
+    "name": "SGS 1-36 Sprite",
+    "icon": "quals/icons/Sprite.jpg",
+    "applies_to": "rated",
+    "is_obsolete": true,
+    "tooltip": "Is qualified to solo the SGS 1-36 \"Sprite\""
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 23,
+  "fields": {
+    "code": "Cirrus",
+    "name": "Open Cirrus",
+    "icon": "quals/icons/Cirrus-qual.jpg",
+    "applies_to": "rated",
+    "is_obsolete": true,
+    "tooltip": "Is qualified to fly the Open Cirrus"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 24,
+  "fields": {
+    "code": "Grob-Back",
+    "name": "Grob103 Backseat Checkout",
+    "icon": "quals/icons/Grob-Back-qual.jpg",
+    "applies_to": "rated",
+    "is_obsolete": true,
+    "tooltip": "Is qualified to fly with passengers while sitting in the back seat of the Grob 103."
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 25,
+  "fields": {
+    "code": "Grob-Front",
+    "name": "Grob PIC",
+    "icon": "quals/icons/Grob-Front-qual.jpg",
+    "applies_to": "rated",
+    "is_obsolete": true,
+    "tooltip": "Is qualified to take passengers from the front seat of the Grob 103."
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 26,
+  "fields": {
+    "code": "Grob-Student",
+    "name": "Grob Student",
+    "icon": "quals/icons/Grob-Student.jpg",
+    "applies_to": "student",
+    "is_obsolete": true,
+    "tooltip": "Is qualified to solo the Grob 103 as a student pilot (or 61.31 transition pilot)"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 27,
+  "fields": {
+    "code": "TowPilot",
+    "name": "Tow PIlot",
+    "icon": "quals/icons/Towpilot-qual.jpg",
+    "applies_to": "both",
+    "is_obsolete": false,
+    "tooltip": "Is rated to fly tow in at least one of our tow planes (not specified)"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 28,
+  "fields": {
+    "code": "SafetyMeeting2019",
+    "name": "Safety Meeting 2019",
+    "icon": "quals/icons/SafetyMeeting-qual_QuKHEJc.jpg",
+    "applies_to": "both",
+    "is_obsolete": true,
+    "tooltip": "Has attended the Safety Meeting for 2019."
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 29,
+  "fields": {
+    "code": "DutyOfficer",
+    "name": "Duty Officer",
+    "icon": "quals/icons/DutyOfficer-qual.jpg",
+    "applies_to": "rated",
+    "is_obsolete": false,
+    "tooltip": "Has been found qualified to act as a Duty Officer for any Skyline Soaring Club Operations"
+  }
+},
+{
+  "model": "instructors.clubqualificationtype",
+  "pk": 30,
+  "fields": {
+    "code": "SafetyMeeting2026",
+    "name": "Safety Meeting (2026)",
+    "icon": "quals/icons/SafetyMeeting-qual-9UHCkfAB.jpg",
+    "applies_to": "both",
+    "is_obsolete": false,
+    "tooltip": "Has attended or completed safety meeting training for the current year (2026)\r\nThis is for in-person or remote attendance."
+  }
+}
+]

--- a/loaddata/club-qualifications-demo/refresh_seed_from_tenant.sh
+++ b/loaddata/club-qualifications-demo/refresh_seed_from_tenant.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# refresh_seed_from_tenant.sh
+#
+# Refreshes the club-qualifications seed fixture in this repo by re-dumping
+# the `instructors.ClubQualificationType` catalog from a SOURCE tenant
+# (default: tenant-ssc, which holds the "good-enough" set) into
+# loaddata/club-qualifications-demo/.
+#
+# Why NO sanitization is needed here (unlike the knowledge-test seed):
+#   * The model has no Member/User FKs, so there are no cross-tenant dangling
+#     references to null out.
+#   * `code` is a unique business key (e.g. "CFI", "ASK-Back") and `name` is a
+#     generic human label (e.g. "Certified Flight Instructor"). Neither leaks
+#     personal data.
+#   * `icon` is a per-tenant GCS *relative* path (e.g.
+#     `quals/icons/CFI-abc123.jpg`) — a generic qualification graphic, not PII.
+#     We deliberately PRESERVE the icon path in the fixture. The accompanying
+#     import script (import_club_qualifications_demo.sh) copies the icon
+#     objects from the source tenant's media area into the new tenant's media
+#     area so the icons render out of the box (see that script's header and
+#     docs/runbooks/club-qualifications-import.md for details).
+#
+# Models captured (the portable "qualification catalog"):
+#   instructors.ClubQualificationType
+#
+# Deliberately EXCLUDED (per-member history, not part of a catalog):
+#   instructors.MemberQualification (references Member; only exists in source)
+#
+# What it does:
+#   1. Locates a long-running app pod in the source tenant's namespace.
+#   2. Dumps the model inside that pod (plain FK pks, NOT --natural-foreign).
+#   3. Copies the JSON into loaddata/club-qualifications-demo/.
+#   4. Prints before/after row counts and a per-file summary (how many rows
+#      carry an icon — informational, so operators know an icon copy is
+#      expected at import time).
+#   5. Prints a `git diff --stat` hint. It does NOT commit or push.
+#
+# Usage:
+#   bash loaddata/club-qualifications-demo/refresh_seed_from_tenant.sh [namespace]
+#     namespace   optional, defaults to tenant-ssc
+#
+# Requirements: kubectl authenticated to the cluster, repo checked out.
+
+set -euo pipefail
+
+NS="${1:-tenant-ssc}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$SCRIPT_DIR"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# (Model label, app.Model for dumpdata, fixture filename)
+MODELS=(
+    "ClubQualificationType|instructors.ClubQualificationType|instructors.ClubQualificationType.json"
+)
+
+echo "==> Source namespace: $NS"
+
+POD="$(kubectl get pods -n "$NS" -o name \
+        | grep -E 'django-app' \
+        | grep -vE 'clearsessions|expire|notify|process|send|cron' \
+        | head -1 | sed -E 's#^pods?/##' || true)"
+
+if [[ -z "$POD" ]]; then
+    echo "ERROR: no long-running app pod found in namespace $NS" >&2
+    exit 1
+fi
+echo "==> Source pod: $POD"
+
+echo
+echo "==> Row counts BEFORE refresh (repo)"
+python3 - "$FIXTURE_DIR" <<'PY'
+import json, sys
+d = sys.argv[1]
+for name in ("ClubQualificationType",):
+    p = f"{d}/instructors.{name}.json"
+    try:
+        print(f"    {name}: {len(json.load(open(p)))}")
+    except FileNotFoundError:
+        print(f"    {name}: (missing)")
+PY
+
+echo
+echo "==> Dumping from source tenant (plain FK pks, no --natural-foreign)"
+for entry in "${MODELS[@]}"; do
+    LABEL="${entry%%|*}"; rest="${entry#*|}"
+    MODEL="${rest%%|*}"
+    echo "    dumpdata $MODEL"
+    kubectl exec -n "$NS" -c django "$POD" -- \
+        python manage.py dumpdata "$MODEL" --indent 2 -o "/tmp/cq_$LABEL.json" 2>/dev/null
+    kubectl cp "$NS/$POD:/tmp/cq_$LABEL.json" "$FIXTURE_DIR/instructors.$LABEL.json" -c django 2>&1 \
+        | grep -viE 'tar: Removing|exiting' || true
+done
+kubectl exec -n "$NS" -c django "$POD" -- bash -c 'rm -f /tmp/cq_*.json'
+
+echo
+echo "==> No sanitization needed (see header). Summary of icon-bearing rows:"
+python3 - "$FIXTURE_DIR" <<'PY'
+import json, sys
+d = sys.argv[1]
+for fn in ("instructors.ClubQualificationType.json",):
+    path = f"{d}/{fn}"
+    data = json.load(open(path))
+    with_icon = sum(1 for o in data if o.get("fields", {}).get("icon"))
+    print(f"    {fn}: {len(data)} objects ({with_icon} with icons)")
+PY
+
+echo
+echo "==> Row counts AFTER refresh (repo)"
+python3 - "$FIXTURE_DIR" <<'PY'
+import json, sys
+d = sys.argv[1]
+for name in ("ClubQualificationType",):
+    n = len(json.load(open(f"{d}/instructors.{name}.json")))
+    print(f"    {name}: {n}")
+PY
+
+echo
+echo "==> Review the diff before committing:"
+echo
+echo "    cd $REPO_ROOT"
+echo "    git status --short loaddata/club-qualifications-demo/"
+echo "    git diff --stat loaddata/club-qualifications-demo/"
+echo
+echo "Then commit via the normal feature-branch + PR flow (NEVER commit to main)."


### PR DESCRIPTION
## Summary

The third portable seed for new-tenant onboarding, completing the trio alongside the knowledge-test seed (PR #1022) and the training-syllabus seed (PR #1019). It exports the **club qualification catalog** (`instructors.ClubQualificationType`) from a source tenant (default `tenant-ssc`) as a `dumpdata` fixture and imports it into an empty tenant — including a GCS copy of the icon objects so they render out of the box.

## What it does

**Scope** — the catalog only (30 rows: `code`, `name`, `icon`, `applies_to`, `is_obsolete`, `tooltip`). `MemberQualification` (per-member award history) is deliberately excluded. No sanitization is needed: the model has no FKs, no M2M, and no timestamps, and the icon paths are generic graphic names (not member/user references).

**Why we copy icons (not strip them):** icons are served from the *rendering* tenant's `CLUB_PREFIX` area — `MEDIA_URL = https://storage.googleapis.com/manage2soar/{CLUB_PREFIX}/media/...`. A bare reference to a source-tenant path would 404 in the target (the target's own area is empty). The import script therefore copies each icon object from `gs://manage2soar/{source}/media/quals/icons/...` into `gs://manage2soar/{target}/media/quals/icons/...` using the `google-cloud-storage` Python client (the pod has **no** `gsutil`/`gcloud`; the client is already a transitive dep of `django-storages`). No-clobber by default; `--overwrite-icons` to replace. Verified: all 30 source icon objects exist and are listable.

## New files

| Path | Purpose |
|------|---------|
| `loaddata/club-qualifications-demo/refresh_seed_from_tenant.sh` | Dump the catalog from a source-tenant pod → `kubectl cp` to repo → print tallies |
| `loaddata/club-qualifications-demo/instructors.ClubQualificationType.json` | Committed 30-row fixture (regenerable via the refresh script) |
| `loaddata/club-qualifications-demo/import_club_qualifications_demo.sh` | Safe-by-default importer: preflight count → abort (exit 3) if non-empty unless `--force` → copy icons → `loaddata` → verify every pk present (exit 5 on failure). Flags: `--force`, `--no-icons`, `--overwrite-icons`, `--source-prefix PFX` |
| `docs/runbooks/club-qualifications-import.md` | Full runbook (quick reference, repo layout, steps, rollback, troubleshooting, exit codes) |
| `docs/runbooks/README.md` | New index row |

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | success |
| 3 | target already has qualifications (re-run with `--force`) |
| 5 | verification failed (a fixture pk is missing) |
| 6 | icon copy failed |
| 7 | GCS env not present in target pod |

## Notes

- Both scripts pass `bash -n`; the fixture is valid JSON (30 rows, unique `code`, all icons under `quals/icons/`).
- Committed on feature branch `feature/club-qualifications-seed` per the never-commit-to-main rule.

## Follow-ups (optional)

- Run one Copilot review pass (matching the pattern used on PR #1022).