### PR TITLE
Add portable badge seed (SSA + FAI catalog) with image-copy tooling

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -13,6 +13,7 @@ This directory contains operational runbooks for system administrators managing 
 | [Training Syllabus Import](syllabus-import.md) | Copy a known-good syllabus from one tenant to an empty tenant | Onboarding a new club's curriculum |
 | [Knowledge Test Bank Import](knowledge-test-import.md) | Copy the written-test question bank (questions, templates, presets) from one tenant to another | Onboarding a new club's test bank |
 | [Club Qualifications Import](club-qualifications-import.md) | Copy the club's qualification catalog (types, scope, tooltip) from one tenant to an empty tenant; includes a GCS copy of the icon objects so they render out of the box | Onboarding a new club's qualification catalog |
+| [Badge Import](badges-import.md) | Copy the club's badge catalog (SSA + FAI badges and their legs) from one tenant to an empty tenant; includes a GCS copy of the badge image objects so they render out of the box | Onboarding a new club's badge catalog |
 | [Ansible Playbook Guide](ansible-playbook-guide.md) | Complete reference for all Ansible playbooks | Reference |
 | [Database Operations](database-operations.md) | PostgreSQL backups, restoration, troubleshooting | Database changes, disaster recovery |
 | Security Operations *(coming soon)* | Secret rotation, vulnerability patching | Security incidents, monthly maintenance |

--- a/docs/runbooks/badges-import.md
+++ b/docs/runbooks/badges-import.md
@@ -1,0 +1,227 @@
+# Badge Import Runbook
+
+This runbook explains how to copy the **club's badge catalog** (the list of
+badges a club recognizes — SSA A/B/C, Bronze, and the FAI Silver/Gold/Diamond
+badges with their duration/altitude/distance/goal "legs") out of one tenant
+(the reference `tenant-ssc` cluster, which holds the "good-enough" set) and
+import it into **another** tenant, including the badge images that go with
+each one.
+
+It follows the **IaC-first** philosophy: the seed fixture and the
+import/refresh scripts live **in the repo** so the operation is
+reproducible, reviewable, and does not depend on copying files around by
+hand.
+
+> This mirrors the [Club Qualifications Import](club-qualifications-import.md),
+> [Knowledge Test Bank Import](knowledge-test-import.md), and
+> [Training Syllabus Import](syllabus-import.md) runbooks. The seeds are
+> independent and do not interfere with each other.
+
+## 🎯 Quick Reference
+
+| Operation | Command |
+|-----------|---------|
+| **Refresh the repo seed from a source tenant** | `bash loaddata/badges-demo/refresh_seed_from_tenant.sh` |
+| Refresh from a specific source tenant | `bash loaddata/badges-demo/refresh_seed_from_tenant.sh tenant-ssc` |
+| **Import into an empty tenant (safe, recommended)** | `bash loaddata/badges-demo/import_badges_demo.sh` |
+| Force-load (upsert, **no delete**) | `bash loaddata/badges-demo/import_badges_demo.sh --force` |
+| Skip the image copy (re-upload images later) | `bash loaddata/badges-demo/import_badges_demo.sh --no-images` |
+| Force-copy images over existing objects | `bash loaddata/badges-demo/import_badges_demo.sh --overwrite-images` |
+| Copy images from a non-default source prefix | `bash loaddata/badges-demo/import_badges_demo.sh --source-prefix masa` |
+
+## What "badges" is
+
+The club's badge catalog is modeled by a single model in the `members` app.
+It is **club-owned content** and safe to move between tenants.
+
+| Model | Purpose | Row count in this seed |
+|-------|---------|------------------------|
+| `members.Badge` | Badges the club recognizes (name, image, description, order, optional `parent_badge` for FAI legs) | 15 (7 with images, 8 legs) |
+
+The `parent_badge` field is what makes the FAI badge board work: a badge with
+a parent is a "leg" (e.g. *Silver Duration* is a leg of *FAI Silver Badge*).
+The refresh script verifies that every leg's parent pk is present in the same
+fixture, and the import script re-verifies that after load.
+
+> ⚠️ **Excluded (member-specific):** `members.MemberBadge`.
+> This model records *which member earned which badge*, plus the award date
+> and notes. It references `Member` rows that only exist in the source
+> tenant. Do **not** include it when moving the catalog between clubs — the
+> new tenant's members earn their badges through normal club processes.
+
+## Why we copy images (not strip them)
+
+The `image` field is an `ImageField` with a **prefix-free relative path**
+(e.g. `badge_images/A-Soaring-Badge-Achievement.png`). In production,
+`MEDIA_URL` is constructed from the **rendering tenant's** `CLUB_PREFIX`:
+
+```
+https://storage.googleapis.com/{GS_BUCKET_NAME}/{CLUB_PREFIX}/media/
+```
+
+(`manage2soar/settings.py` — `GS_MEDIA_LOCATION = f"{CLUB_PREFIX}/media"`.)
+
+That means when the new tenant renders `{{ badge.image.url }}`, the browser
+resolves it to `…/{GS_BUCKET_NAME}/{NEW_PREFIX}/media/badge_images/...` —
+**the new tenant's own media area**, not the source tenant's. If we only ran
+`loaddata` and left the DB value as-is, the badge images would **404** for
+the new tenant (their `{NEW_PREFIX}/media/badge_images/` area is empty),
+because the objects only exist under the source prefix in the shared bucket.
+
+So the import script **copies the image objects** from the source tenant's
+media area into the target tenant's media area, using the
+`google.cloud.storage` Python client (already a transitive dependency of
+`django-storages` in the pod image — no `gsutil`/`gcloud` CLI required).
+
+The copy is **no-clobber by default**: if a destination object already exists
+(e.g. the tenant already uploaded their own badge image), it is skipped. Pass
+`--overwrite-images` to force-copy over existing objects.
+
+> This is a deliberate choice over the alternative of stripping the image to
+> `""` (which the knowledge-test seed does for `Question.media`). Badge
+> images are **generic graphics**, not personal data, so there is no privacy
+> concern in copying them — and a new tenant gets working badge art out of
+> the box rather than a broken-image flash.
+
+## Repo layout
+
+```
+loaddata/badges-demo/
+├── refresh_seed_from_tenant.sh        # dump members.Badge from a source tenant
+├── members.Badge.json                 # the seed fixture (15 rows, 7 images, 8 legs)
+└── import_badges_demo.sh              # safe import script (preflight + image copy + load + verify)
+docs/runbooks/badges-import.md         # this file
+```
+
+> **Note:** the repo also contains an older, stale `loaddata/members.Badge.json`
+> (used by the legacy `loaddata/loaddata.sh` onboarding script). That fixture
+> is missing the FAI leg structure (`parent_badge` is null for all rows).
+> `loaddata/badges-demo/members.Badge.json` is the current, production-quality
+> seed and is the one this runbook covers.
+
+## Step 0 — Prerequisites
+
+- `kubectl` authenticated to the cluster (and `gcloud auth login` fresh enough
+  that the GKE auth plugin can mint tokens).
+- The **source** tenant (default `tenant-ssc`) has the badge catalog you want
+  to copy.
+- The **target** tenant pod has the GCS env vars set (`GS_BUCKET_NAME`,
+  `CLUB_PREFIX`) so the image-copy phase can run.
+
+## Step 1 — Refresh the repo seed (only when the source tenant's catalog changes)
+
+From the repo checkout:
+
+```bash
+bash loaddata/badges-demo/refresh_seed_from_tenant.sh            # defaults to tenant-ssc
+bash loaddata/badges-demo/refresh_seed_from_tenant.sh tenant-masa # or another source
+```
+
+Expected output (abridged):
+
+```
+==> Source namespace: tenant-ssc
+==> Source pod: django-app-ssc-...
+==> Dumping from source tenant (plain FK pks, no --natural-foreign)
+    dumpdata members.Badge
+==> No sanitization needed (see header). Summary of image-bearing + leg rows:
+    members.Badge.json: 15 objects (7 with images, 8 legs)
+==> Row counts AFTER refresh (repo)
+    Badge: 15
+```
+
+If the script prints `!! N leg parent pk(s) not in fixture`, stop and
+investigate — the dump is malformed and importing it would produce dangling
+legs.
+
+Then review the diff and commit the refreshed fixture via the normal
+feature-branch + PR flow (NEVER commit to main).
+
+## Step 2 — Import into an empty target tenant
+
+The deployed image may not ship this repo's `loaddata/` tree, so copy the
+seed into the target pod first, then run it from the copied location:
+
+```bash
+NS=tenant-<newclub>
+POD=$(kubectl get pods -n "$NS" -o name | grep -E 'django-app' \
+      | grep -vE 'clearsessions|expire|notify|process|send|cron' | head -1 \
+      | sed -E 's#^pods?/##')
+
+kubectl cp "loaddata/badges-demo" "$NS/$POD:/tmp/bseed" -c django
+kubectl exec -n "$NS" -c django "$POD" -- bash /tmp/bseed/import_badges_demo.sh
+kubectl exec -n "$NS" -c django "$POD" -- rm -rf /tmp/bseed
+```
+
+Expected output (abridged):
+
+```
+==> Preflight: checking that the target tenant has no existing badge catalog
+    Badge: 0
+
+==> Copying badge images from the source tenant's GCS media area
+    into the target tenant's GCS media area (no-clobber by default)
+    Found 7 distinct image path(s) in the fixture.
+    images: copied=7 skipped_existing=0
+
+==> Loading badge catalog fixtures
+    loaddata members.Badge.json
+Installed 15 object(s) from 1 fixture(s)
+
+==> Verifying that every fixture primary key is now present in the target
+    Badge: fixture=15 present=  15  all_present=True  leg_integrity=True
+
+==> Post-load count: Badge: 15
+```
+
+### Options
+
+| Flag | Effect |
+|------|--------|
+| `--force` | Allow import into a tenant that already has badges (upsert by pk, **no delete**). |
+| `--no-images` | Skip the GCS image-copy phase. DB image paths are preserved; the tenant re-uploads images to render them. |
+| `--overwrite-images` | Force-copy images over existing objects in the target area (default is no-clobber). |
+| `--source-prefix PFX` | Source tenant prefix to copy images from (default `ssc`). Independent of the target's `CLUB_PREFIX`. |
+
+## Rollback
+
+`loaddata` upserts by `(model, pk)` and does **not** delete rows it did not
+see, so "rollback" is a matter of deleting the rows the import created:
+
+```bash
+# from the target tenant pod
+python manage.py shell -c '
+from members.models import Badge, MemberBadge
+import json
+pks = [o["pk"] for o in json.load(open("/tmp/bseed/members.Badge.json"))]
+print("deleting", MemberBadge.objects.filter(badge_id__in=pks).delete())
+print("deleting", Badge.objects.filter(pk__in=pks).delete())
+'
+```
+
+If you also copied badge images, delete the objects in GCS:
+
+```
+gsutil rm gs://<GS_BUCKET_NAME>/<NEW_PREFIX>/media/badge_images/*
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `ABORT: This tenant already has a badge catalog (N rows)` | Target already has badges | Confirm intent, re-run with `--force`. |
+| `ERROR: GCS environment is missing (GS_BUCKET_NAME / CLUB_PREFIX)` | Running outside a tenant pod (or env mis-set) | Run inside the pod, or pass `--no-images`. |
+| `ERROR: image copy did not complete successfully` | Source objects missing (wrong `--source-prefix`?) | Check `gsutil ls gs://manage2soar/<src>/media/badge_images/` and retry with the right prefix. |
+| `ERROR: at least one fixture primary key is missing from the target` | `loaddata` failed or was interrupted | Re-run with `--force`; the upsert will repair. |
+| `ERROR: a badge leg points at a parent badge that is missing` | Fixture is corrupt or target DB was tampered with | Re-run the refresh script from the source tenant; re-import with `--force`. |
+| `ERROR: fixture not found: ...` | Ran the script without the fixtures next to it | `kubectl cp` the whole `loaddata/badges-demo` dir first, then run the script from there. |
+| Badges show but images are broken | Image copy was skipped (`--no-images`) or source objects were gone | Re-run with `--overwrite-images`, or upload the images in the admin. |
+
+## Safety reminders
+
+- **NEVER commit to main.** Always feature-branch + PR.
+- **`--force` does not delete** existing badge rows; it upserts by pk.
+- **Image copy is no-clobber by default.** A re-run will never destroy a
+  tenant's customized badge art.
+- The seed excludes `members.MemberBadge` on purpose — new tenants earn
+  badges through normal club processes.

--- a/docs/runbooks/badges-import.md
+++ b/docs/runbooks/badges-import.md
@@ -150,8 +150,12 @@ POD=$(kubectl get pods -n "$NS" -o name | grep -E 'django-app' \
 
 kubectl cp "loaddata/badges-demo" "$NS/$POD:/tmp/bseed" -c django
 kubectl exec -n "$NS" -c django "$POD" -- bash /tmp/bseed/import_badges_demo.sh
-kubectl exec -n "$NS" -c django "$POD" -- rm -rf /tmp/bseed
 ```
+
+> **Keep `/tmp/bseed` for now.** The [Rollback](#rollback) section reads the
+> fixture from `/tmp/bseed/members.Badge.json`. Once you are confident the
+> import is correct and you won't need to roll back, remove it with
+> `kubectl exec -n "$NS" -c django "$POD" -- rm -rf /tmp/bseed`.
 
 Expected output (abridged):
 
@@ -186,17 +190,28 @@ Installed 15 object(s) from 1 fixture(s)
 ## Rollback
 
 `loaddata` upserts by `(model, pk)` and does **not** delete rows it did not
-see, so "rollback" is a matter of deleting the rows the import created:
+see, so "rollback" is a matter of deleting the rows the import created. The
+rollback reads the fixture from `/tmp/bseed` — if you already removed it
+(see Step 2), copy the seed back into the pod first.
 
 ```bash
-# from the target tenant pod
-python manage.py shell -c '
+NS=tenant-<newclub>
+POD=<app-pod>
+
+# 1) Make sure the seed fixture is present in the pod (no-op if already there).
+kubectl cp "loaddata/badges-demo" "$NS/$POD:/tmp/bseed" -c django
+
+# 2) Delete the badge rows (and any member->badge links) the import created.
+kubectl exec -n "$NS" -c django "$POD" -- python manage.py shell -c '
 from members.models import Badge, MemberBadge
 import json
 pks = [o["pk"] for o in json.load(open("/tmp/bseed/members.Badge.json"))]
 print("deleting", MemberBadge.objects.filter(badge_id__in=pks).delete())
 print("deleting", Badge.objects.filter(pk__in=pks).delete())
 '
+
+# 3) Now safe to clean up the copied seed.
+kubectl exec -n "$NS" -c django "$POD" -- rm -rf /tmp/bseed
 ```
 
 If you also copied badge images, delete the objects in GCS:

--- a/loaddata/badges-demo/import_badges_demo.sh
+++ b/loaddata/badges-demo/import_badges_demo.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+#
+# import_badges_demo.sh
+#
+# Imports the portable badge catalog captured from the tenant-ssc cluster
+# (the "good-enough" set of 15 SSA/FAI badges, including the FAI
+# Silver/Gold/Diamond leg structure) into the CURRENT tenant (whichever DB
+# this script's environment points at).
+#
+# The seed is NOT sanitized:
+#   * No Member/User FKs to null.
+#   * `parent_badge` is a self-referential FK (a badge leg -> its parent
+#     badge) whose target pk lives INSIDE this same fixture, so it resolves
+#     cleanly on load in any tenant.
+#   * `image` is a prefix-free GCS relative path (e.g.
+#     `badge_images/A-Soaring-Badge-Achievement.png`). This is a generic
+#     badge graphic, not PII. We preserve it in the DB.
+#
+# The one cross-tenant concern — the image OBJECTS — is handled by an
+# IMAGE-COPY phase that runs BEFORE loaddata. Because `MEDIA_URL` in prod is
+# `https://storage.googleapis.com/{GS_BUCKET_NAME}/{CLUB_PREFIX}/media/`
+# (where `CLUB_PREFIX` is the RENDERING tenant's prefix), a new tenant's own
+# `{NEW_PREFIX}/media/badge_images/` area is empty. If we only ran loaddata,
+# the badge images would 404. So this script copies the image objects from
+# the source tenant's area into the new tenant's area using the
+# `google.cloud.storage` Python client (already a transitive dep of
+# `django-storages` in the pod).
+#
+#   Default behavior: NO-CLOBBER. If a destination object already exists, it
+#   is skipped (so a re-run is safe and never destroys a tenant's customized
+#   badge images). Use --overwrite-images to force-copy over existing objects.
+#
+# Intended use (production / per-tenant):
+#   The deployed image may not ship this repo's loaddata/ tree, so copy the
+#   seed into the pod first, then run it from the copied location:
+#     NS=<tenant-ns>
+#     POD=$(kubectl get pods -n "$NS" -o name | grep -E 'django-app' \
+#           | grep -vE 'clearsessions|expire|notify|process|send|cron' | head -1 \
+#           | sed -E 's#^pods?/##')
+#     kubectl cp "loaddata/badges-demo" "$NS/$POD:/tmp/bseed" -c django
+#     kubectl exec -n "$NS" -c django "$POD" -- bash /tmp/bseed/import_badges_demo.sh
+#   (See docs/runbooks/badges-import.md for the full walkthrough.)
+#
+# Local / dev use (with your Django env already active):
+#   bash loaddata/badges-demo/import_badges_demo.sh
+#
+# Options:
+#   -f, --force               Allow overwriting an existing badge catalog
+#                             (upsert, no delete).
+#   -n, --no-images           Skip the GCS image-copy phase (image DB values
+#                             are preserved; the new tenant re-uploads images
+#                             to render them).
+#   -o, --overwrite-images    Force-copy images over existing objects in the
+#                             target area (default is no-clobber).
+#   -s, --source-prefix PFX   Source tenant prefix to copy images from
+#                             (default: ssc). Separate from the target's
+#                             CLUB_PREFIX which comes from the pod env.
+#   -h, --help                Show this help.
+#
+# Safety notes:
+#   * --force does NOT delete existing rows. loaddata upserts by (model, pk);
+#     rows with the same pk are replaced, other rows are left alone.
+#   * Image copy is NO-CLOBBER by default. Use --overwrite-images to force.
+#
+# Exit codes:
+#   0  success
+#   1  fixture not found
+#   2  bad argument
+#   3  target already has badges and --force was not given
+#   4  could not read the row count from Django
+#   5  verification failed (a fixture pk is missing after loaddata)
+#   6  image copy failed
+#   7  GCS environment not present in the target pod
+
+set -euo pipefail
+
+FORCE=0
+NO_IMAGES=0
+OVERWRITE_IMAGES=0
+SOURCE_PREFIX="ssc"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -f|--force) FORCE=1; shift ;;
+        -n|--no-images) NO_IMAGES=1; shift ;;
+        -o|--overwrite-images) OVERWRITE_IMAGES=1; shift ;;
+        -s|--source-prefix)
+            if [[ -z "${2:-}" ]]; then
+                echo "ERROR: --source-prefix requires a value" >&2
+                exit 2
+            fi
+            SOURCE_PREFIX="$2"; shift 2 ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1 (see --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Resolve the fixture directory relative to this script, so the script works
+# both from the repo root and from inside the container image.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$SCRIPT_DIR"
+export FIXTURE_DIR
+
+FIXTURES=(
+    "members.Badge.json"
+)
+
+for f in "${FIXTURES[@]}"; do
+    if [[ ! -f "$FIXTURE_DIR/$f" ]]; then
+        echo "ERROR: fixture not found: $FIXTURE_DIR/$f" >&2
+        exit 1
+    fi
+done
+
+echo "==> Preflight: checking that the target tenant has no existing badge catalog"
+
+# Django's `manage.py shell -c` prints a line like
+#     "95 objects imported automatically (use -v 2 for details)."
+# to STDOUT before our own print() runs. Filter it out so we only see the
+# count on a single line.
+COUNT="$(
+    python manage.py shell -c '
+from members.models import Badge
+print(Badge.objects.count())
+' 2>/dev/null | grep -EoE '^[0-9]+$' | head -n1 || true
+)"
+
+if [[ -z "$COUNT" ]]; then
+    echo "    ERROR: could not read row count from Django shell (unexpected output)." >&2
+    echo "    Refusing to proceed without a reliable empty-check." >&2
+    exit 4
+fi
+
+echo "    Badge: $COUNT"
+
+if [[ "$COUNT" -ne 0 ]]; then
+    if [[ "$FORCE" -eq 1 ]]; then
+        echo "    !! Existing badge catalog detected, but --force was given. Proceeding (upsert, no delete)."
+    else
+        echo
+        echo "ABORT: This tenant already has a badge catalog ($COUNT rows)."
+        echo "This script is meant for an EMPTY catalog."
+        echo
+        echo "If you are absolutely sure you want to overwrite it, re-run with --force."
+        echo "NOTE: --force upserts by primary key and does NOT delete extra rows."
+        exit 3
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Image copy phase (GCS) — copy badge image objects from the source tenant's
+# media area into the target tenant's media area, so the images resolve for
+# the new tenant (their MEDIA_URL points at their own {CLUB_PREFIX}/media/...).
+# ---------------------------------------------------------------------------
+
+if [[ "$NO_IMAGES" -eq 1 ]]; then
+    echo
+    echo "==> Skipping image copy (--no-images). Image DB values are preserved;"
+    echo "    the new tenant will need to re-upload images for them to render."
+    IMAGE_COPY_STATUS="skipped"
+else
+    echo
+    echo "==> Copying badge images from the source tenant's GCS media area"
+    echo "    into the target tenant's GCS media area (no-clobber by default)"
+
+    # Extract the set of non-empty image relative paths from the fixture.
+    IMAGE_PATHS="$(python3 -c '
+import json, os
+d = os.environ["FIXTURE_DIR"]
+data = json.load(open(f"{d}/members.Badge.json"))
+paths = sorted({o["fields"]["image"] for o in data if o["fields"].get("image")})
+print("\n".join(paths))
+')"
+    IMAGE_COUNT="$(echo "$IMAGE_PATHS" | grep -c . || true)"
+    echo "    Found $IMAGE_COUNT distinct image path(s) in the fixture."
+
+    if [[ "$IMAGE_COUNT" -eq 0 ]]; then
+        echo "    (No images to copy — skipping GCS phase.)"
+        IMAGE_COPY_STATUS="empty"
+    else
+        COPY_OUT="$(
+            BADGE_OVERWRITE_IMAGES="$OVERWRITE_IMAGES" BADGE_IMAGE_PATHS="$IMAGE_PATHS" \
+            BADGE_SOURCE_PREFIX="$SOURCE_PREFIX" \
+            python manage.py shell -c '
+import os
+from google.cloud import storage
+
+overwrite = os.environ.get("BADGE_OVERWRITE_IMAGES") == "1"
+paths = [p.strip() for p in os.environ["BADGE_IMAGE_PATHS"].splitlines() if p.strip()]
+
+bucket_name = os.environ.get("GS_BUCKET_NAME")
+if not bucket_name:
+    print("ERROR: GS_BUCKET_NAME is not set in the environment.")
+    raise SystemExit(1)
+src_prefix = os.environ.get("BADGE_SOURCE_PREFIX", "ssc")
+dst_prefix = os.environ.get("CLUB_PREFIX")
+if not dst_prefix:
+    print("ERROR: CLUB_PREFIX is not set in the environment.")
+    raise SystemExit(1)
+
+client = storage.Client()
+bucket = client.bucket(bucket_name)
+copied = skipped = 0
+for p in paths:
+    src = f"{src_prefix}/media/{p}"
+    dst = f"{dst_prefix}/media/{p}"
+    if bucket.get_blob(dst) is not None and not overwrite:
+        skipped += 1
+        continue
+    # Same shared bucket for source and target; copy_blob expects a Bucket
+    # object (not a string) as the destination bucket.
+    bucket.copy_blob(bucket.blob(src), bucket, dst)
+    copied += 1
+print(f"images: copied={copied} skipped_existing={skipped}")
+' 2>&1
+        )" || true
+
+        echo "$COPY_OUT" | sed 's/^/    /'
+
+        if echo "$COPY_OUT" | grep -qE 'GS_BUCKET_NAME is not set|CLUB_PREFIX is not set'; then
+            echo "    ERROR: GCS environment is missing (GS_BUCKET_NAME / CLUB_PREFIX)." >&2
+            echo "    Run inside the tenant pod, or pass --no-images to skip the image copy." >&2
+            exit 7
+        fi
+        if ! echo "$COPY_OUT" | grep -qE '^images: copied='; then
+            echo "    ERROR: image copy did not complete successfully." >&2
+            echo "    Retry, or pass --no-images to skip the image copy." >&2
+            exit 6
+        fi
+        IMAGE_COPY_STATUS="done"
+    fi
+fi
+
+echo
+echo "==> Loading badge catalog fixtures"
+for f in "${FIXTURES[@]}"; do
+    echo "    loaddata $f"
+    python manage.py loaddata "$FIXTURE_DIR/$f"
+done
+
+echo
+echo "==> Verifying that every fixture primary key is now present in the target"
+
+# `loaddata` upserts by primary key without deleting other rows. For an EMPTY
+# tenant this means post_count == fixture_count; for a NON-EMPTY tenant with
+# overlapping pks the counts will be higher than the fixture (existing rows
+# preserved). The invariant that holds for BOTH cases is: every primary key
+# from the fixture is now present in the target database.
+
+VERIFY="$(
+    python manage.py shell -c '
+import json, os
+d = os.environ["FIXTURE_DIR"]
+from members.models import Badge
+fixture_pks = {o["pk"] for o in json.load(open(os.path.join(d, "members.Badge.json")))}
+present   = set(Badge.objects.values_list("pk", flat=True))
+missing   = fixture_pks - present
+legs_ok   = all(
+    b.parent_badge_id is None or b.parent_badge_id in present
+    for b in Badge.objects.all()
+    if b.pk in fixture_pks
+)
+print(f"Badge: fixture={len(fixture_pks)} present={len(present):>5}  "
+      f"all_present={not missing}  leg_integrity={legs_ok}")
+if missing:
+    print(f"    MISSING pks ({len(missing)}): {sorted(missing)[:10]}")
+    raise SystemExit(1)
+' 2>&1
+)" || true
+
+echo "$VERIFY" | sed 's/^/    /'
+
+# The inner python exits non-zero on any missing pk, but the `|| true` above
+# keeps that status from tripping `set -e` (so the "MISSING pks" diagnostic
+# above is still captured into $VERIFY and printed). The all_present=True
+# check below therefore drives the script's exit code.
+if [[ -z "$VERIFY" ]] || ! echo "$VERIFY" | grep -q "all_present=True"; then
+    echo "    ERROR: at least one fixture primary key is missing from the target." >&2
+    exit 5
+fi
+if ! echo "$VERIFY" | grep -q "leg_integrity=True"; then
+    echo "    ERROR: a badge leg points at a parent badge that is missing." >&2
+    exit 5
+fi
+
+# Post-load counts (informational only).
+POST="$(
+    python manage.py shell -c '
+from members.models import Badge
+print(Badge.objects.count())
+' 2>/dev/null | grep -EoE '^[0-9]+$' | head -n1 || true
+)"
+echo
+echo "==> Post-load count: Badge: ${POST:-(unreadable)}"
+echo
+echo "NOTE: the badge catalog seed is preserved as-is (no sanitization)."
+echo "      Images were ${IMAGE_COPY_STATUS}. If skipped, the new tenant should"
+echo "      re-upload any images they want to use; the DB image paths are intact"
+echo "      either way. FAI legs are linked to their parent badges in this seed."

--- a/loaddata/badges-demo/import_badges_demo.sh
+++ b/loaddata/badges-demo/import_badges_demo.sh
@@ -209,13 +209,27 @@ copied = skipped = 0
 for p in paths:
     src = f"{src_prefix}/media/{p}"
     dst = f"{dst_prefix}/media/{p}"
-    if bucket.get_blob(dst) is not None and not overwrite:
-        skipped += 1
-        continue
-    # Same shared bucket for source and target; copy_blob expects a Bucket
-    # object (not a string) as the destination bucket.
-    bucket.copy_blob(bucket.blob(src), bucket, dst)
-    copied += 1
+    # Same shared bucket for source and target; copy_blob destination
+    # argument must be a Bucket object (not a string).
+    if overwrite:
+        # Overwrite: unconditional copy, replacing any existing destination.
+        bucket.copy_blob(bucket.blob(src), bucket, dst)
+        copied += 1
+    else:
+        # No-clobber, made ATOMIC by a GCS precondition instead of a
+        # check-then-copy (which had a TOCTOU race: the destination could be
+        # created between get_blob() and the copy, and the copy would then
+        # overwrite it). if_generation_match=0 tells GCS to copy ONLY if the
+        # destination does not exist (generation 0); if it does, GCS rejects
+        # with 412 Precondition Failed and nothing is written.
+        try:
+            bucket.copy_blob(bucket.blob(src), bucket, dst, if_generation_match=0)
+            copied += 1
+        except Exception as e:  # noqa: BLE001 - distinguish no-clobber skip vs real failure
+            if getattr(e, "response", None) is not None and e.response.status_code == 412:
+                skipped += 1
+                continue
+            raise
 print(f"images: copied={copied} skipped_existing={skipped}")
 ' 2>&1
         )" || true

--- a/loaddata/badges-demo/members.Badge.json
+++ b/loaddata/badges-demo/members.Badge.json
@@ -1,0 +1,167 @@
+[
+{
+  "model": "members.badge",
+  "pk": 1,
+  "fields": {
+    "name": "A Badge",
+    "image": "badge_images/A-Soaring-Badge-Achievement.png",
+    "description": "<p>Preflight Phase<br>Applicant Demonstrates Knowledge of:</p>\r\n<ul>\r\n<li>Sailplane Nomenclature</li>\r\n<li>Sailplane Handling Procedures</li>\r\n<li>Sailplane Pre-flight Check</li>\r\n<li>Airport Rules and Federal Aviation Regulations</li>\r\n<li>Tow Equipment, Signals, and Procedures</li>\r\n<li>Hook-up of Towline</li>\r\n<li>Launch Signals</li>\r\n<li>Pilot Responsibilities</li>\r\n</ul>\r\n<p>Applicant Possesses:</p>\r\n<ul>\r\n<li>Valid FAA Pilot Certificate</li>\r\n<li>Pilot Logbook or Suitable Permanent Record</li>\r\n</ul>\r\n<p>Presolo Phase</p>\r\n<p>Applicant Has Completed the Following Minimum Flight Training Program:</p>\r\n<ul>\r\n<li>Familiarization Flight</li>\r\n<li>Cockpit Check Procedure</li>\r\n<li>Effects of Controls &ndash; Ground and Flight</li>\r\n<li>Takeoff Procedures &ndash; Normal and Crosswind</li>\r\n<li>Flight During Tow</li>\r\n<li>Straight Gliding Flight</li>\r\n<li>Shallow Turns</li>\r\n<li>Circuit Procedures and Landing Patterns</li>\r\n<li>Landing Procedures &ndash; Normal, Downwind, and Crosswind</li>\r\n<li>Moderate and Steep Turns Up to 720 Degrees in Both Directions</li>\r\n<li>Stall Recognition and Recovery</li>\r\n<li>Conditions of Spin Entry and Recovery</li>\r\n<li>Effective Use of Spoilers/Flaps/Slips</li>\r\n<li>Emergency Procedures</li>\r\n<li>Oral Examination on Federal Aviation Regulations</li>\r\n<li>Solo Flight</li>\r\n</ul>",
+    "order": 1,
+    "parent_badge": null
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 2,
+  "fields": {
+    "name": "B Badge",
+    "image": "badge_images/B-Soaring-Badge-Achievement.png",
+    "description": "<p>Practice Phase<br>Applicant Demonstrates:</p>\r\n<p>Soaring ability by a solo flight of at least 30 minutes duration after release from a 2,000-foot tow (add 1&frac12; minutes per 100 foot tow altitude above 2,000 feet).</p>",
+    "order": 2,
+    "parent_badge": null
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 3,
+  "fields": {
+    "name": "C Badge",
+    "image": "badge_images/C-Soaring-Badge-Achievement-200x200.png",
+    "description": "<p><em>Pre Cross-country Phase</em></p>\r\n<p>Applicant Has Completed the Following Flight Training:</p>\r\n<ul>\r\n<li>\r\n<ul>\r\n<li>Dual Soaring Practice, including instruction in techniques for soaring thermals, ridge soaring, and wave (simulated flight and/or ground instruction may be used when suitable conditions do not exist).</li>\r\n<li>Has Knowledge of:\r\n<ul>\r\n<li>Cross-country Procedures</li>\r\n<li>Sailplane Assembly, Disassembly, and Retrieves</li>\r\n<li>Hazards of Cross-country Flying</li>\r\n</ul>\r\n</li>\r\n<li>Demonstrates Soaring Ability by Solo Flight of at Least 60 Minutes Duration After Release From 2,000 Foot Tow (add 1&frac12; minutes per 100 foot of tow above 2,000 feet).</li>\r\n<li>While Accompanied by an SSA Instructor, Demonstrate the Following:\r\n<ul>\r\n<li>Make a Simulated Off-field Landing From the Approach Without Reference to the Altimeter</li>\r\n<li>Perform an Accuracy Landing From the Approach, Touching Down and Coming to a Complete Stop Within an Area No Greater Than 500 Feet in Length.</li>\r\n</ul>\r\n</li>\r\n</ul>\r\n</li>\r\n</ul>",
+    "order": 3,
+    "parent_badge": null
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 4,
+  "fields": {
+    "name": "Bronze Badge",
+    "image": "badge_images/Bronze-Badge.png",
+    "description": "<p><em>Cross-Country Readiness</em></p>\r\n<p>Applicant Must:</p>\r\n<ul>\r\n<li>Complete the ABC Training Program with the C Badge Awarded.</li>\r\n<li>Log at Least 15 Solo Hours in Gliders. This Time Must Include 30 Solo Flights with at Least 10 Flights Flown in a Single-Place Glider if Possible.</li>\r\n<li>Log at Least 2 Flights,&nbsp;Each&nbsp;Having Duration of Two Hours or More.</li>\r\n<li>Perform at Least 3 Solo Spot Landings in a Glider Witnessed by an SSAI. The Accuracy and Distance Parameters Established Should be Based on Glider Performance Data, Current Winds, Runway Surface, and Density Altitude. As a Guideline, a Maximum Distance of 400 Feet Would be Acceptable for a Schweizer 2-33 Glider.</li>\r\n<li>Log Dual Time in Gliders with an Instructor during which at Least 2 Accuracy Landings are Made without Reference to the Altimeter to Simulate Off-field Landings.</li>\r\n<li>Pass a Closed Book Written Examination Covering Cross-country Techniques and Knowledge. The Minimum Passing Score is 80%. This Examination is Administered Only by an SSAI.</li>\r\n</ul>",
+    "order": 4,
+    "parent_badge": null
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 5,
+  "fields": {
+    "name": "FAI Silver Badge",
+    "image": "badge_images/FAI-Silver-Badge.png",
+    "description": "<p>The FAI Silver Badge involves 3 required elements. Silver Altitude is a 1,000-meter (3,281-foot) altitude gain above an in-flight low point; Silver Duration is a 5-hour flight time after tow release and Silver Distance is A straight distance flight from a start at release to a finish fix located at least 50 km from release and at least 50 km from the fix recorded at the beginning of the take-off roll.</p>",
+    "order": 10,
+    "parent_badge": null
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 6,
+  "fields": {
+    "name": "FAI Gold Badge",
+    "image": "badge_images/FAI-Gold-Badge.png",
+    "description": "<p>The FAI Gold Badge involves 2 required elements. Gold Altitude is a 3,000-meter (9,843-foot) altitude gain above an in-flight low point; Gold Distance is a 300-km (186.42-mile) cross country flight.</p>",
+    "order": 15,
+    "parent_badge": null
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 7,
+  "fields": {
+    "name": "FAI Diamond Badge",
+    "image": "badge_images/FAI-Diamond-Badge--200x199.png",
+    "description": "<p>The FAI Diamond Badge involves 3 required elements. Diamond Altitude is a 5,000-meter (16,404-foot) altitude gain above an in-flight low point; Diamond Goal is a 300-km (186.42-mile) cross country flight using a pre-declared Out and Return or Triangle course; Diamond Distance is a 500-km (310.7-mile) cross country flight.</p>",
+    "order": 20,
+    "parent_badge": null
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 8,
+  "fields": {
+    "name": "Silver Distance",
+    "image": "",
+    "description": "",
+    "order": 7,
+    "parent_badge": 5
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 9,
+  "fields": {
+    "name": "Silver Altitude",
+    "image": "",
+    "description": "",
+    "order": 8,
+    "parent_badge": 5
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 10,
+  "fields": {
+    "name": "Silver Duration",
+    "image": "",
+    "description": "",
+    "order": 9,
+    "parent_badge": 5
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 11,
+  "fields": {
+    "name": "Gold Altitude",
+    "image": "",
+    "description": "",
+    "order": 13,
+    "parent_badge": 6
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 12,
+  "fields": {
+    "name": "Gold Distance",
+    "image": "",
+    "description": "",
+    "order": 14,
+    "parent_badge": 6
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 13,
+  "fields": {
+    "name": "Diamond Altitude",
+    "image": "",
+    "description": "",
+    "order": 17,
+    "parent_badge": 7
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 14,
+  "fields": {
+    "name": "Diamond Distance",
+    "image": "",
+    "description": "",
+    "order": 17,
+    "parent_badge": 7
+  }
+},
+{
+  "model": "members.badge",
+  "pk": 15,
+  "fields": {
+    "name": "Diamond Goal",
+    "image": "",
+    "description": "",
+    "order": 16,
+    "parent_badge": 7
+  }
+}
+]

--- a/loaddata/badges-demo/refresh_seed_from_tenant.sh
+++ b/loaddata/badges-demo/refresh_seed_from_tenant.sh
@@ -92,8 +92,17 @@ for entry in "${MODELS[@]}"; do
     echo "    dumpdata $MODEL"
     kubectl exec -n "$NS" -c django "$POD" -- \
         python manage.py dumpdata "$MODEL" --indent 2 -o "/tmp/badge_$LABEL.json" 2>/dev/null
-    kubectl cp "$NS/$POD:/tmp/badge_$LABEL.json" "$FIXTURE_DIR/members.$LABEL.json" -c django 2>&1 \
-        | grep -viE 'tar: Removing|exiting' || true
+    # Capture kubectl cp's output/exit status WITHOUT letting a non-zero exit
+    # trip `set -euo pipefail` (which would abort here, before we can report
+    # which model failed and that the fixture is stale). `|| true` neutralizes
+    # the status while still preserving stdout/stderr.
+    CP_OUT="$(kubectl cp "$NS/$POD:/tmp/badge_$LABEL.json" "$FIXTURE_DIR/members.$LABEL.json" -c django 2>&1)" || true
+    echo "$CP_OUT" | grep -viE 'tar: Removing|exiting' || true
+    if [[ ! -s "$FIXTURE_DIR/members.$LABEL.json" ]]; then
+        echo "ERROR: kubectl cp for $LABEL did not produce a non-empty fixture" >&2
+        echo "       (the previous fixture, if any, may be stale). See kubectl cp output above." >&2
+        exit 1
+    fi
 done
 kubectl exec -n "$NS" -c django "$POD" -- bash -c 'rm -f /tmp/badge_*.json'
 

--- a/loaddata/badges-demo/refresh_seed_from_tenant.sh
+++ b/loaddata/badges-demo/refresh_seed_from_tenant.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# refresh_seed_from_tenant.sh
+#
+# Refreshes the badge seed fixture in this repo by re-dumping the
+# `members.Badge` catalog from a SOURCE tenant (default: tenant-ssc, which
+# holds the "good-enough" SSA + FAI badge set, including the FAI leg
+# parent/child structure) into loaddata/badges-demo/.
+#
+# Why NO sanitization is needed here (unlike the knowledge-test seed):
+#   * The model has no Member/User FKs, so there are no cross-tenant dangling
+#     references to null out.
+#   * `name` is a generic human label (e.g. "A Badge", "FAI Silver Badge").
+#     `parent_badge` is a self-referential FK (a badge leg pointing at its
+#     parent badge) whose pk lives INSIDE this same fixture, so it resolves
+#     cleanly on load in any tenant.
+#   * `image` is a per-tenant GCS *relative* path (e.g.
+#     `badge_images/A-Soaring-Badge-Achievement.png`) — a generic badge
+#     graphic, not PII. We deliberately PRESERVE the image path in the
+#     fixture. The accompanying import script (import_badges_demo.sh) copies
+#     the image objects from the source tenant's media area into the new
+#     tenant's media area so the badges render out of the box (see that
+#     script's header and docs/runbooks/badges-import.md for details).
+#
+# Models captured (the portable "badge catalog"):
+#   members.Badge
+#
+# Deliberately EXCLUDED (per-member history, not part of a catalog):
+#   members.MemberBadge (references Member; only exists in source). A new
+#   tenant's members earn their badges through normal club processes.
+#
+# What it does:
+#   1. Locates a long-running app pod in the source tenant's namespace.
+#   2. Dumps the model inside that pod (plain FK pks, NOT --natural-foreign).
+#   3. Copies the JSON into loaddata/badges-demo/.
+#   4. Prints before/after row counts and a per-file summary (how many rows
+#      carry an image, and how many are "legs" via parent_badge —
+#      informational, so operators know an image copy is expected at import
+#      time and that the FAI leg structure is intact).
+#   5. Prints a `git diff --stat` hint. It does NOT commit or push.
+#
+# Usage:
+#   bash loaddata/badges-demo/refresh_seed_from_tenant.sh [namespace]
+#     namespace   optional, defaults to tenant-ssc
+#
+# Requirements: kubectl authenticated to the cluster, repo checked out.
+
+set -euo pipefail
+
+NS="${1:-tenant-ssc}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$SCRIPT_DIR"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# (Model label, app.Model for dumpdata, fixture filename)
+MODELS=(
+    "Badge|members.Badge|members.Badge.json"
+)
+
+echo "==> Source namespace: $NS"
+
+POD="$(kubectl get pods -n "$NS" -o name \
+        | grep -E 'django-app' \
+        | grep -vE 'clearsessions|expire|notify|process|send|cron' \
+        | head -1 | sed -E 's#^pods?/##' || true)"
+
+if [[ -z "$POD" ]]; then
+    echo "ERROR: no long-running app pod found in namespace $NS" >&2
+    exit 1
+fi
+echo "==> Source pod: $POD"
+
+echo
+echo "==> Row counts BEFORE refresh (repo)"
+python3 - "$FIXTURE_DIR" <<'PY'
+import json, sys
+d = sys.argv[1]
+for name in ("Badge",):
+    p = f"{d}/members.{name}.json"
+    try:
+        print(f"    {name}: {len(json.load(open(p)))}")
+    except FileNotFoundError:
+        print(f"    {name}: (missing)")
+PY
+
+echo
+echo "==> Dumping from source tenant (plain FK pks, no --natural-foreign)"
+for entry in "${MODELS[@]}"; do
+    LABEL="${entry%%|*}"; rest="${entry#*|}"
+    MODEL="${rest%%|*}"
+    echo "    dumpdata $MODEL"
+    kubectl exec -n "$NS" -c django "$POD" -- \
+        python manage.py dumpdata "$MODEL" --indent 2 -o "/tmp/badge_$LABEL.json" 2>/dev/null
+    kubectl cp "$NS/$POD:/tmp/badge_$LABEL.json" "$FIXTURE_DIR/members.$LABEL.json" -c django 2>&1 \
+        | grep -viE 'tar: Removing|exiting' || true
+done
+kubectl exec -n "$NS" -c django "$POD" -- bash -c 'rm -f /tmp/badge_*.json'
+
+echo
+echo "==> No sanitization needed (see header). Summary of image-bearing + leg rows:"
+python3 - "$FIXTURE_DIR" <<'PY'
+import json, sys
+d = sys.argv[1]
+for fn in ("members.Badge.json",):
+    path = f"{d}/{fn}"
+    data = json.load(open(path))
+    with_img = sum(1 for o in data if o.get("fields", {}).get("image"))
+    legs = sum(1 for o in data if o.get("fields", {}).get("parent_badge"))
+    # Leg parent pks must all resolve to a pk within this fixture.
+    pks = {o["pk"] for o in data}
+    bad_parent = [o["pk"] for o in data
+                  if o.get("fields", {}).get("parent_badge")
+                  and o["fields"]["parent_badge"] not in pks]
+    print(f"    {fn}: {len(data)} objects ({with_img} with images, {legs} legs)")
+    if bad_parent:
+        print(f"    !! {len(bad_parent)} leg parent pk(s) not in fixture: {bad_parent}")
+PY
+
+echo
+echo "==> Row counts AFTER refresh (repo)"
+python3 - "$FIXTURE_DIR" <<'PY'
+import json, sys
+d = sys.argv[1]
+for name in ("Badge",):
+    n = len(json.load(open(f"{d}/members.{name}.json")))
+    print(f"    {name}: {n}")
+PY
+
+echo
+echo "==> Review the diff before committing:"
+echo
+echo "    cd $REPO_ROOT"
+echo "    git status --short loaddata/badges-demo/"
+echo "    git diff --stat loaddata/badges-demo/"
+echo
+echo "Then commit via the normal feature-branch + PR flow (NEVER commit to main)."


### PR DESCRIPTION
## Summary

The fourth portable seed for new-tenant onboarding, completing the set alongside the syllabus (PR #1019), knowledge-test (PR #1022) and club-qualifications (PR #1024) seeds. It exports the **badge catalog** (`members.Badge`) — SSA A/B/C + Bronze and the FAI Silver/Gold/Diamond badges with their duration/altitude/distance/goal **legs** — from a source tenant (default `tenant-ssc`) as a `dumpdata` fixture and imports it into an empty tenant, including a GCS copy of the badge image objects so they render out of the box.

## Why the existing `loaddata/members.Badge.json` wasn't enough

The legacy fixture (used by `loaddata/loaddata.sh`) has the same 15 badge rows but **all `parent_badge` are null**. The FAI leg structure — the parent/child links that make the badge board hide legs once their parent is earned — was missing. A fresh re-dump from `tenant-ssc` captures it (8 legs: Silver ×3 → FAI Silver, Gold ×2 → FAI Gold, Diamond ×3 → FAI Diamond).

## What it does

**Scope** — `members.Badge` only (15 rows: `name`, `image`, `description`, `order`, `parent_badge`). `members.MemberBadge` (per-member award history) is deliberately excluded. No sanitization is needed: no Member/User FKs, `parent_badge` is a self-FK whose target pk lives inside the same fixture, and `image` is a generic badge-graphic path (not PII).

**Why we copy images (not strip them):** `MEDIA_URL = https://storage.googleapis.com/manage2soar/{CLUB_PREFIX}/media/...` uses the *rendering* tenant's `CLUB_PREFIX`, so a bare reference to a source-tenant path would 404 in the target. The import script copies each image object from `gs://manage2soar/{source}/media/badge_images/...` into `gs://manage2soar/{target}/media/badge_images/...` using the `google-cloud-storage` Python client (no `gsutil`/`gcloud` in the pod). No-clobber by default; `--overwrite-images` to replace. Verified: all 7 source image objects exist and are listable.

**Leg integrity check:** the import script verifies after `loaddata` that every leg's `parent_badge_id` resolves to a pk present in the target — a corrupt fixture or interrupted import is caught (exit 5).

## New files

| Path | Purpose |
|------|---------|
| `loaddata/badges-demo/refresh_seed_from_tenant.sh` | Dump `members.Badge` from a source-tenant pod → `kubectl cp` to repo → report image + leg tallies + leg-integrity check |
| `loaddata/badges-demo/members.Badge.json` | Committed 15-row fixture (7 images, 8 legs; regenerable) |
| `loaddata/badges-demo/import_badges_demo.sh` | Safe-by-default importer (preflight → abort unless `--force` → copy images → `loaddata` → pk + leg-integrity verification). Flags: `--force`, `--no-images`, `--overwrite-images`, `--source-prefix PFX` |
| `docs/runbooks/badges-import.md` | Full runbook (quick reference, repo layout, steps, rollback, troubleshooting) |
| `docs/runbooks/README.md` | New index row |

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | success |
| 3 | target already has badges (re-run with `--force`) |
| 5 | verification failed (a fixture pk is missing, or a leg's parent is missing) |
| 6 | image copy failed |
| 7 | GCS env not present in target pod |

## Notes

- Both scripts pass `bash -n`; the fixture is valid JSON (15 rows, 7 images, 8 legs, all leg parents resolve within the fixture).
- Committed on feature branch `feature/badges-seed` per the never-commit-to-main rule.

## Follow-ups (optional)

- Run a Copilot review pass (matching the pattern used on PR #1024).
- Consider migrating the legacy `loaddata/loaddata.sh` to point at the new `loaddata/badges-demo/` seed (or deprecating it) in a follow-up PR — out of scope here.